### PR TITLE
fix: resolve multi-page PDF index reset

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -147,6 +147,9 @@ class Fill():
         # Read PDF 
         pdf = PdfReader(pdf_form)
 
+        #Initialize index BEFORE the page loop
+        i=0
+
         # Loop through pages 
         for page in pdf.pages:
             if page.Annots:
@@ -155,7 +158,6 @@ class Fill():
                     key=lambda a: (-float(a.Rect[1]), float(a.Rect[0]))
                 )
 
-                i = 0
                 for annot in sorted_annots:
                     if annot.Subtype == '/Widget' and annot.T:
                         field_name = annot.T[1:-1]


### PR DESCRIPTION
This PR fixes issue #8 by moving the index initialization outside the page loop in src/backend.py. This ensures that field values are mapped sequentially across all pages instead of resetting on each new page.
<img width="649" height="491" alt="Screenshot 2026-02-21 132942" src="https://github.com/user-attachments/assets/1598f602-e721-41ef-9331-abfb2ce98b60" />

