### PR TITLE
refactor: move Ollama URL construction out of field iteration loop

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -47,12 +47,13 @@ class textToJSON():
         return prompt
 
     def main_loop(self): #FUTURE -> Refactor this to its own class
+        ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+        ollama_url = f"{ollama_host}/api/generate"
+        
         for field in self.__target_fields:
             prompt = self.build_prompt(field)
             # print(prompt)
             # ollama_url = "http://localhost:11434/api/generate"
-            ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-            ollama_url = f"{ollama_host}/api/generate"
 
             payload = {
                 "model": "mistral",


### PR DESCRIPTION
## **Description**
This PR optimizes the `main_loop` in `src/backend.py` by moving the Ollama URL reconstruction logic outside of the field iteration loop. 

Previously, the code was calling `os.getenv()` and performing string manipulation to build the `ollama_url` for **every single form field**. By moving these definitions to the top of the function, we eliminate redundant processing, making the extracted data pipeline more efficient.

## **Changes**
- Moved `ollama_host` and `ollama_url` calculation outside and before the `for` loop in `main_loop`.
- Improved code readability and performance by removing redundant operations from the "hot" loop.

## **How Has This Been Tested?**
- [x] Verified code syntax and integrity with `python -m py_compile`.
- [x] Manually reviewed logic to ensure the URL is still correctly formed and accessible to all iterations.
#13
## **Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
