### PR TITLE
security: restrict Ollama port exposure to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ollama/ollama:latest
     container_name: fireform-ollama
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ollama_data:/root/.ollama
     networks:


### PR DESCRIPTION
# Title
security: restrict Ollama port exposure to localhost

# Description
This PR restricts the Ollama service port mapping in `docker-compose.yml` to the localhost interface (`127.0.0.1`). 
##Fixes  #15 
### Problem
Previously, the port `11434` was mapped as `"11434:11434"`, which bound it to `0.0.0.0`. This exposed the Ollama instance to the entire local network, posing a security risk as anyone on the network could potentially interact with the LLM API.

### Solution
By changing the mapping to `"127.0.0.1:11434:11434"`, we ensure that the port is only accessible from the host machine. Inter-container communication (i.e., between the `app` container and the `ollama` container) continues to work as expected via the internal Docker bridge network (`fireform-network`).

## Changes
- Updated `docker-compose.yml` to restrict port `11434` to `127.0.0.1`.

## How Has This Been Tested?
- [x] Verified the `docker-compose.yml` syntax.
- [x] Confirmed that internal networking between containers remains functional.
- [x] Verified that external network access to the port is now blocked.
