### PR TITLE
Fix: add missing pypdf and ollama dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ requests
 pdfrw
 flask
 commonforms
+pypdf
+ollama
 


### PR DESCRIPTION
# Title
fix: add missing pypdf and ollama dependencies to requirements.txt

# Description
This PR adds `pypdf` and `ollama` to the `requirements.txt` file. These dependencies were being imported in `src/main.py` and `src/test/test_model.py` respectively, but were missing from the project's dependency list.

### Changes
- Added `pypdf` to `requirements.txt` (required by `src/main.py`).
- Added `ollama` to `requirements.txt` (required by `src/test/test_model.py`).

### Verification
- [x] Verified that `pypdf` is imported in `src/main.py`.
- [x] Verified that `ollama` is imported in `src/test/test_model.py`.
- [x] Verified `pip install` works with the updated file.
