### PR TITLE
fix: logic error in handle_plural_values skipping first item

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -113,10 +113,7 @@ class textToJSON():
         
         # Remove trailing leading whitespace
         for i in range(len(values)):
-            current = i+1 
-            if current < len(values):
-                clean_value = values[current].lstrip()
-                values[current] = clean_value
+            values[i] = values[i].lstrip()
 
         print(f"\t[LOG]: Resulting formatted list of values: {values}")
         


### PR DESCRIPTION
# Title : fix: logic error in handle_plural_values skipping first item

# Description
This PR resolves an off-by-one logic error inside the `handle_plural_values` function in `src/backend.py`. 

**Resolves: #27**

### Problem
When processing plural/multipart form values (separated by semicolons), the code attempted to remove leading whitespace. However, because it offset the loop index by setting `current = i+1` before accessing the array, it completely skipped removing the whitespace from the first item (`values[0]`).

### Changes
- Cleaned up the `for` loop in `handle_plural_values` (`src/backend.py`), removing the `current = i+1` offset causing the bug.

### Verification
- [x] Verified code syntax with `python -m py_compile src/backend.py`.
- [x] Confirmed the loop now properly processes the 0th element in the list.
