### PR TITLE
fix(backend): replace mutable default argument in textToJSON.__init__

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -8,7 +8,9 @@ from pdfrw import PdfReader, PdfWriter
 
 
 class textToJSON():
-    def __init__(self, transcript_text, target_fields, json={}):
+    def __init__(self, transcript_text, target_fields, json=None):
+        if json is None:
+            json = {}
         self.__transcript_text = transcript_text # str
         self.__target_fields = target_fields # List, contains the template field.
         self.__json = json # dictionary


### PR DESCRIPTION
## What
Fixes #29 

## Problem
`textToJSON.__init__` in [src/backend.py](cci:7://file:///C:/Users/rajan/Desktop/GSOC/UN/FireForm/src/backend.py:0:0-0:0) uses `json={}` as a default argument. 

In Python, default arguments are evaluated **once** at function definition time — not at each call. This means every [textToJSON](cci:2://file:///C:/Users/rajan/Desktop/GSOC/UN/FireForm/src/backend.py:9:0-128:26) instance that doesn't explicitly pass [json](cci:7://file:///C:/Users/rajan/Desktop/GSOC/UN/FireForm/src/test/test_output_1.json:0:0-0:0) shares the **same dictionary object** in memory. Data extracted from one incident report silently leaks into the next.

## Fix
Replace with the standard `None` sentinel pattern:

- Before: `def __init__(self, transcript_text, target_fields, json={})`
- After: `def __init__(self, transcript_text, target_fields, json=None)` with a `if json is None: json = {}` guard

## Proof of Bug

Report 1: `{'officer_name': 'John Doe'}`
Report 2: `{'officer_name': 'John Doe', 'victim_name': 'Jane'}` ← LEAKED!
Same object? `True` ← both instances point to the same dict

**After fix:**
Report 1: `{'officer_name': 'John Doe'}`
Report 2: `{'victim_name': 'Jane'}` ← Isolated ✅
Same object? `False`

## References
- [Python docs — default argument values](https://docs.python.org/3/reference/compound_stmts.html#function-definitions)
- [Common Python Gotchas — Mutable Default Arguments](https://docs.python-guide.org/writing/gotchas/)