### PR TITLE
  Fix AttributeError in add_response_to_json and missing @staticmethod on Fill.fill_form

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -92,9 +92,13 @@ class textToJSON():
             plural = True
 
 
-        if field in self.__json.keys():
-            self.__json[field].append(parsed_value)
-        else: 
+        if field in self.__json:
+            existing = self.__json[field]
+            if isinstance(existing, list):
+                existing.append(parsed_value)
+            else:
+                self.__json[field] = [existing, parsed_value]
+        else:
             self.__json[field] = parsed_value
                 
         return
@@ -130,6 +134,7 @@ class Fill():
     def __init__(self):
         pass
     
+    @staticmethod
     def fill_form(user_input: str, definitions: list, pdf_form: str):
         """
         Fill a PDF form with values from user_input using testToJSON.


### PR DESCRIPTION
 ## What

  Two bugs fixed in `src/backend.py`:

  **1. AttributeError when a field is encountered more than once (fixes #26)**

  `add_response_to_json` assumed every existing field value was already a
  list, so calling `.append()` on a string raised `AttributeError`. The fix
  checks the type first: if the value is a list, append to it; if it's a
  string, promote it to a two-element list.

  **2. Missing `@staticmethod` on `Fill.fill_form` (partially addresses #31)**

  `fill_form` takes no `self` or `cls` parameter, but was not decorated as
  a static method. Calling it on an instance would silently pass the instance
  as `user_input`, causing incorrect behaviour. Added `@staticmethod`.

  ## Testing

  Verified manually against the existing code path in `main.py`.


Also added the missing @staticmethod decorator to Fill.fill_form. The method does not use self or cls, so calling it on an instance would have passed the instance as the first positional argument, silently mismatching the user_input parameter.

Fixes #26. Partially addresses #31 (decorator misuse).