### PR TITLE
  Pin dependency versions and add missing pypdf to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests
-pdfrw
-flask
-commonforms
-
+requests==2.32.5
+pdfrw==0.4
+flask==3.1.3
+commonforms==0.2.1
+pypdf==6.7.1


### PR DESCRIPTION
 ## What

  - Pinned all existing dependencies to exact versions to ensure
    reproducible installs across machines and containers
  - Added `pypdf` which was missing from `requirements.txt` despite
    being required for PDF processing

  ## Why

  Unpinned dependencies resolve to whatever is latest on PyPI at install
  time, which means two developers (or two Docker builds) can get different
  versions and different behaviour.

  Fixes #6. Fixes #18.