### PR TITLE
Fix field index resetting on each page in multi-page PDF fill

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -147,7 +147,8 @@ class Fill():
         # Read PDF 
         pdf = PdfReader(pdf_form)
 
-        # Loop through pages 
+        # Loop through pages
+        i = 0
         for page in pdf.pages:
             if page.Annots:
                 sorted_annots = sorted(
@@ -155,7 +156,6 @@ class Fill():
                     key=lambda a: (-float(a.Rect[1]), float(a.Rect[0]))
                 )
 
-                i = 0
                 for annot in sorted_annots:
                     if annot.Subtype == '/Widget' and annot.T:
                         field_name = annot.T[1:-1]


### PR DESCRIPTION
 ## What

  In `Fill.fill_form`, the answer index `i` was initialized inside the
  page loop, which caused it to reset to `0` at the start of every page.
  On any form with more than one page, fields from page 2 onward would be
  filled with values already used on page 1, misaligning the entire output.

  Moved `i = 0` to before the page loop so the index advances
  continuously across all pages, matching extracted values to form fields
  in the correct order throughout the document.

  ## Why it matters

  Any multi-page incident report form would produce silently wrong output
  — the kind of error that's hard to catch unless you specifically test
  with a multi-page PDF.

  Fixes #8.
