### PR TITLE
Fix: return empty dict instead of list in load_json on FileNotFoundError

### DIFF
--- a/src/json_manager.py
+++ b/src/json_manager.py
@@ -9,8 +9,8 @@ class JsonManager():
             with open(path_to_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except FileNotFoundError:
-            print(f"Warning: File not found at {path_to_file}. Returning empty list.")
-            data = []
+            print(f"Warning: File not found at {path_to_file}. Returning empty dictionary.")
+            data = {}
         except json.DecodeError:
             raise IOError(f"JSON file at {path_to_file} is corrupted.")
         


### PR DESCRIPTION
# Pull Request: [FIX] Return empty dictionary instead of list on FileNotFoundError in load_json

### 📝 Description
This PR fixes a critical type inconsistency in the `JsonManager.load_json` function. 

Previously, when a requested JSON file was not found, the function returned an empty list `[]`. However, the core application logic (e.g., `textToJSON` in `backend.py`) expects this data to be a dictionary. This mismatch caused the application to crash with `AttributeError` or `KeyError` when attempting to access dictionary methods on the returned list.

## Fixes #36 

### 🚀 Key Changes
- **Modified `src/json_manager.py`**: Updated the `FileNotFoundError` exception handler to return an empty dictionary `{}` instead of a list.
- **Improved Logging**: Updated the warning message to accurately state that an empty dictionary is being returned for better debugging clarity.

### 🧪 Verification Results
- **Type Check**: Confirmed that `load_json` now returns `<class 'dict'>` when a file is missing.
- **Log Validation**: Verified that the console output correctly reflects the change: `Warning: File not found at .... Returning empty dictionary.`
- **Stability**: Ensured that dictionary-dependent logic (like `.keys()` calls) no longer crashes when config files are absent.

### ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested the fix locally
