### PR TITLE
feat: add PDF field extraction utility for template inspection

### DIFF
--- a/src/utils/extract_pdf_fields.py
+++ b/src/utils/extract_pdf_fields.py
@@ -1,0 +1,31 @@
+from pypdf import PdfReader
+import sys
+import os
+
+
+def extract_fields(pdf_path):
+    if not os.path.exists(pdf_path):
+        print(f"File not found: {pdf_path}")
+        return
+    try: 
+        reader = PdfReader(pdf_path)
+    except Exception as e:
+        print(f"Error reading PDF: {e}")
+        return
+    
+    fields = reader.get_fields()
+
+    if not fields:
+        print("No form fields found.")
+        return
+
+    print("PDF Form Fields:\n")
+    for field in fields.keys():
+        print(field)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python extract_pdf_fields.py <pdf_path>")
+        sys.exit(1)
+
+    extract_fields(sys.argv[1])

--- a/src/utils/extract_pdf_fields.py
+++ b/src/utils/extract_pdf_fields.py
@@ -5,27 +5,29 @@ import os
 
 def extract_fields(pdf_path):
     if not os.path.exists(pdf_path):
-        print(f"File not found: {pdf_path}")
-        return
+        print(f"File not found: {pdf_path}", file=sys.stderr)
+        return 1
     try: 
         reader = PdfReader(pdf_path)
     except Exception as e:
-        print(f"Error reading PDF: {e}")
-        return
+        print(f"Error reading PDF: {e}", file=sys.stderr)
+        return 1
     
     fields = reader.get_fields()
 
     if not fields:
-        print("No form fields found.")
-        return
+        print("No form fields found.", file=sys.stderr)
+        return 1
 
     print("PDF Form Fields:\n")
     for field in fields.keys():
         print(field)
 
+    return 0
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python extract_pdf_fields.py <pdf_path>")
+        print("Usage: python extract_pdf_fields.py <pdf_path>", file=sys.stderr)
         sys.exit(1)
 
-    extract_fields(sys.argv[1])
+    sys.exit(extract_fields(sys.argv[1]))


### PR DESCRIPTION
This PR introduces a small utility to extract and list PDF form field names from templates.

This implements the proposal in #48  and supports ongoing template mapping work discussed in #42   .

Usage:
python src/utils/extract_pdf_fields.py <pdf_path>
closes #48 
No changes were made to the existing filling pipeline.