### PR TITLE
feat(config): centralize configuration with env var support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# FireForm configuration
+# Copy this file to .env and adjust values as needed.
+
+# Ollama / LLM
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=mistral
+OLLAMA_API_PATH=/api/generate
+
+# PDF output
+OUTPUT_PDF_SUFFIX=_filled.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ src/__pycache__
 .idea
 venv
 .venv
+.env

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ The result is hours of time saved per shift, per firefighter.
 
 Open-Source (DPG): Built 100% with open-source tools to be a true Digital Public Good, freely available for any department to adopt and modify.
 
+## Configuration
+
+FireForm can be configured via environment variables. You can also create a `.env` file in the project root (see `.env.example`).
+
+| Variable | Default | Description |
+|---|---|---|
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
+| `OLLAMA_MODEL` | `mistral` | LLM model to use |
+| `OLLAMA_API_PATH` | `/api/generate` | Ollama API endpoint path |
+| `OUTPUT_PDF_SUFFIX` | `_filled.pdf` | Suffix appended to filled PDFs |
+
 ## 🤝 Code of Conduct
 
 We are committed to providing a friendly, safe, and welcoming environment for all. Please see our [Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app/src
       - OLLAMA_HOST=http://ollama:11434
+      - OLLAMA_MODEL=mistral
     networks:
       - fireform-network
     stdin_open: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ requests
 pdfrw
 flask
 commonforms
+python-dotenv
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -1,9 +1,9 @@
 import json
-import os
 import requests
 from json_manager import JsonManager
 from input_manager import InputManager
 from pdfrw import PdfReader, PdfWriter
+import config
 
 
 
@@ -50,12 +50,10 @@ class textToJSON():
         for field in self.__target_fields:
             prompt = self.build_prompt(field)
             # print(prompt)
-            # ollama_url = "http://localhost:11434/api/generate"
-            ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-            ollama_url = f"{ollama_host}/api/generate"
+            ollama_url = f"{config.OLLAMA_HOST}{config.OLLAMA_API_PATH}"
 
             payload = {
-                "model": "mistral",
+                "model": config.OLLAMA_MODEL,
                 "prompt": prompt,
                 "stream": False # don't really know why --> look into this later.
             }
@@ -136,7 +134,7 @@ class Fill():
         Fields are filled in the visual order (top-to-bottom, left-to-right).
         """
 
-        output_pdf = pdf_form[:-4] + "_filled.pdf"
+        output_pdf = pdf_form[:-4] + config.OUTPUT_PDF_SUFFIX
 
         # Generate dictionary of answers from your original function 
         t2j = textToJSON(user_input, definitions)

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,27 @@
+"""
+Centralized configuration for FireForm.
+
+All tuneable values live here.  Every setting can be overridden with an
+environment variable; a ``.env`` file in the project root is loaded
+automatically when present (via python-dotenv).
+"""
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+# ── Paths ────────────────────────────────────────────────────────────
+BASE_DIR: Path = Path(__file__).resolve().parent  # …/src/
+
+DEFAULT_INPUT_PDF: Path = BASE_DIR / "inputs" / "file.pdf"
+DEFAULT_PREPARED_PDF: Path = BASE_DIR / "temp_outfile.pdf"
+
+OUTPUT_PDF_SUFFIX: str = os.getenv("OUTPUT_PDF_SUFFIX", "_filled.pdf")
+
+# ── Ollama / LLM ────────────────────────────────────────────────────
+OLLAMA_HOST: str = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+OLLAMA_MODEL: str = os.getenv("OLLAMA_MODEL", "mistral")
+OLLAMA_API_PATH: str = os.getenv("OLLAMA_API_PATH", "/api/generate")

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,9 @@
 import os
-from backend import Fill  
-from commonforms import prepare_form 
+from backend import Fill
+from commonforms import prepare_form
 from pypdf import PdfReader
-from pathlib import Path
 from typing import Union
+import config
 
 def input_fields(num_fields: int):
     fields = []
@@ -50,9 +50,8 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
 
 
 if __name__ == "__main__":
-    BASE_DIR = Path(__file__).resolve().parent
-    file = BASE_DIR / "inputs" / "file.pdf"
-    prepared_pdf = BASE_DIR / "temp_outfile.pdf"
+    file = config.DEFAULT_INPUT_PDF
+    prepared_pdf = config.DEFAULT_PREPARED_PDF
     
     #file = "/Users/vincentharkins/Desktop/FireForm/src/inputs/file.pdf"
     user_input = "Hi. The employee's name is John Doe. His job title is managing director. His department supervisor is Jane Doe. His phone number is 123456. His email is jdoe@ucsc.edu. The signature is <Mamañema>, and the date is 01/02/2005"

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
         )
         
         print("\n----------------------------------")
-        print("Process Complete.")
+        print(f"✅ Process Complete.")
         print(f"Output saved to: {output_name}")
         
         return output_name

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
         )
         
         print("\n----------------------------------")
-        print(f"✅ Process Complete.")
+        print("Process Complete.")
         print(f"Output saved to: {output_name}")
         
         return output_name

--- a/src/test/test_config.py
+++ b/src/test/test_config.py
@@ -58,6 +58,14 @@ class TestEnvOverrides:
         cfg = _reload_config({"OLLAMA_MODEL": "llama3"})
         assert cfg.OLLAMA_MODEL == "llama3"
 
+    def test_ollama_api_path_override(self):
+        cfg = _reload_config({"OLLAMA_API_PATH": "/v2/generate"})
+        assert cfg.OLLAMA_API_PATH == "/v2/generate"
+
+    def test_output_pdf_suffix_override(self):
+        cfg = _reload_config({"OUTPUT_PDF_SUFFIX": "_output.pdf"})
+        assert cfg.OUTPUT_PDF_SUFFIX == "_output.pdf"
+
     def test_ollama_host_trailing_slash_stripped(self):
         cfg = _reload_config({"OLLAMA_HOST": "http://my-server:9999/"})
         assert cfg.OLLAMA_HOST == "http://my-server:9999"

--- a/src/test/test_config.py
+++ b/src/test/test_config.py
@@ -1,0 +1,86 @@
+"""Unit tests for the centralised config module."""
+
+import importlib
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _reload_config(env_overrides: dict | None = None):
+    """Reload ``config`` with optional env-var overrides."""
+    env_overrides = env_overrides or {}
+    old_values = {}
+    for key, value in env_overrides.items():
+        old_values[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    try:
+        import config
+        importlib.reload(config)
+        return config
+    finally:
+        for key, old in old_values.items():
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+
+# ── Default values ───────────────────────────────────────────────────
+
+class TestDefaults:
+    def test_ollama_host_default(self):
+        cfg = _reload_config()
+        assert cfg.OLLAMA_HOST == "http://localhost:11434"
+
+    def test_ollama_model_default(self):
+        cfg = _reload_config()
+        assert cfg.OLLAMA_MODEL == "mistral"
+
+    def test_ollama_api_path_default(self):
+        cfg = _reload_config()
+        assert cfg.OLLAMA_API_PATH == "/api/generate"
+
+    def test_output_pdf_suffix_default(self):
+        cfg = _reload_config()
+        assert cfg.OUTPUT_PDF_SUFFIX == "_filled.pdf"
+
+
+# ── Env-var overrides ────────────────────────────────────────────────
+
+class TestEnvOverrides:
+    def test_ollama_host_override(self):
+        cfg = _reload_config({"OLLAMA_HOST": "http://my-server:9999"})
+        assert cfg.OLLAMA_HOST == "http://my-server:9999"
+
+    def test_ollama_model_override(self):
+        cfg = _reload_config({"OLLAMA_MODEL": "llama3"})
+        assert cfg.OLLAMA_MODEL == "llama3"
+
+    def test_ollama_host_trailing_slash_stripped(self):
+        cfg = _reload_config({"OLLAMA_HOST": "http://my-server:9999/"})
+        assert cfg.OLLAMA_HOST == "http://my-server:9999"
+
+
+# ── Path values ──────────────────────────────────────────────────────
+
+class TestPaths:
+    def test_base_dir_is_src(self):
+        cfg = _reload_config()
+        assert cfg.BASE_DIR.name == "src"
+        assert cfg.BASE_DIR.is_dir()
+
+    def test_default_input_pdf_path(self):
+        cfg = _reload_config()
+        assert cfg.DEFAULT_INPUT_PDF == cfg.BASE_DIR / "inputs" / "file.pdf"
+
+    def test_default_prepared_pdf_path(self):
+        cfg = _reload_config()
+        assert cfg.DEFAULT_PREPARED_PDF == cfg.BASE_DIR / "temp_outfile.pdf"
+
+    def test_paths_are_path_objects(self):
+        cfg = _reload_config()
+        assert isinstance(cfg.BASE_DIR, Path)
+        assert isinstance(cfg.DEFAULT_INPUT_PDF, Path)
+        assert isinstance(cfg.DEFAULT_PREPARED_PDF, Path)

--- a/src/test/test_model.py
+++ b/src/test/test_model.py
@@ -1,8 +1,9 @@
 # test_ollama.py
 import ollama
+import config
 
 try:
-    response = ollama.chat(model='mistral', messages=[
+    response = ollama.chat(model=config.OLLAMA_MODEL, messages=[
         {'role': 'user', 'content': 'Say hello in Spanish'}
     ])
     print("Success! Response:", response['message']['content'])


### PR DESCRIPTION
## Summary

Closes #56

Centralizes all hardcoded configuration values (Ollama URL, model name, API path, file paths) into a single `src/config.py` module with environment variable overrides and sensible defaults.

### Changes

- **`src/config.py`** -- single source of truth for all tuneable settings, using `python-dotenv` to optionally load from a `.env` file
- **`src/backend.py`** -- replaced hardcoded Ollama URL, model (`"mistral"`), API path, and PDF suffix with config references
- **`src/main.py`** -- replaced hardcoded default PDF paths with config references
- **`docker-compose.yml`** -- added `OLLAMA_MODEL` env var to app service
- **`.env.example`** -- documents every available env var with its default
- **`README.md`** -- added Configuration section with env var table
- **`src/test/test_config.py`** -- 11 unit tests covering defaults, env overrides, trailing-slash stripping, path types

No logic changes -- only structural improvements for portability and maintainability.

## Environment Variables

| Variable | Default | Description |
|---|---|---|
| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
| `OLLAMA_MODEL` | `mistral` | LLM model to use |
| `OLLAMA_API_PATH` | `/api/generate` | Ollama API endpoint path |
| `OUTPUT_PDF_SUFFIX` | `_filled.pdf` | Suffix appended to filled PDFs |

## Test Plan

- [x] `PYTHONPATH=src python -m pytest src/test/test_config.py -v` -- 11/11 tests pass
- [x] Grep verification: no hardcoded Ollama URLs or `"mistral"` remain in `backend.py` or `main.py`
- [x] `docker-compose.yml` passes `OLLAMA_MODEL` to app container