### PR TITLE
Feat/cli fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 pdfrw
 flask
-commonforms
+pydantic>=2.0
 

--- a/src/backend.py
+++ b/src/backend.py
@@ -1,21 +1,30 @@
 import json
 import os
 import requests
+from pydantic import create_model, Field, ValidationError
+from typing import Optional
+
+# Keep existing imports just in case, though we primarily use pydantic/requests now
 from json_manager import JsonManager
 from input_manager import InputManager
 from pdfrw import PdfReader, PdfWriter
 
 
-
 class textToJSON():
-    def __init__(self, transcript_text, target_fields, json={}):
+    def __init__(self, transcript_text, target_fields, json_data=None):
+        # Fixed BUG: Mutable default argument issue (Issue #29)
+        if json_data is None:
+            json_data = {}
+            
         self.__transcript_text = transcript_text # str
         self.__target_fields = target_fields # List, contains the template field.
-        self.__json = json # dictionary
+        self.__json = json_data # dictionary
+        
         self.type_check_all()
-        self.main_loop()
+        # Run the new single-shot Pydantic extraction
+        self.extract_data_with_pydantic()
 
-    
+
     def type_check_all(self):
         if type(self.__transcript_text) != str:
             raise TypeError(f"ERROR in textToJSON() ->\
@@ -24,127 +33,168 @@ class textToJSON():
             raise TypeError(f"ERROR in textToJSON() ->\
                 Target fields must be a list. Input:\n\ttarget_fields: {self.__target_fields}")
 
-   
-    def build_prompt(self, current_field):
-        """ 
-            This method is in charge of the prompt engineering. It creates a specific prompt for each target field. 
-            @params: current_field -> represents the current element of the json that is being prompted.
+
+    def extract_data_with_pydantic(self):
         """
-        prompt = f""" 
+        Dynamically generates a Pydantic schema, asks the LLM to fill all fields 
+        in a single request, and strictly validates the output.
+        """
+        print(f"\t[LOG] Generating Pydantic Schema for {len(self.__target_fields)} fields...")
+
+        # 1. Map fields safely. PDF fields often have spaces (e.g., "Date of Incident").
+        safe_fields = {}
+        self.__field_mapping = {}
+
+        for i, original_field in enumerate(self.__target_fields):
+            safe_name = f"field_{i}"
+            self.__field_mapping[safe_name] = original_field
+            safe_fields[safe_name] = (
+                Optional[str], 
+                Field(default="-1", description=f"Extract value for: '{original_field}'")
+            )
+
+        # 2. Dynamically create the Pydantic Model
+        DynamicIncidentModel = create_model('DynamicIncidentModel', **safe_fields)
+        schema_json = json.dumps(DynamicIncidentModel.model_json_schema(), indent=2)
+
+        # 3. Build a single, comprehensive prompt
+        prompt = f"""
             SYSTEM PROMPT:
-            You are an AI assistant designed to help fillout json files with information extracted from transcribed voice recordings. 
-            You will receive the transcription, and the name of the JSON field whose value you have to identify in the context. Return 
-            only a single string containing the identified value for the JSON field. 
-            If the field name is plural, and you identify more than one possible value in the text, return both separated by a ";".
-            If you don't identify the value in the provided text, return "-1".
-            ---
-            DATA:
-            Target JSON field to find in text: {current_field}
+            You are an AI assistant designed to extract information from transcribed voice recordings and fill out JSON files.
             
-            TEXT: {self.__transcript_text}
-            """
+            RULES:
+            1. Output ONLY a valid JSON object matching the exact schema provided. Do not include conversational text.
+            2. If you don't find a value for a specific field in the text, you MUST return "-1".
+            3. If a field name is plural and you identify multiple values, return them as a single string separated by a ";" (e.g., "value1; value2").
+            
+            SCHEMA (Use these exact keys):
+            {schema_json}
 
-        return prompt
+            TRANSCRIPT: 
+            {self.__transcript_text}
+        """
 
-    def main_loop(self): #FUTURE -> Refactor this to its own class
-        for field in self.__target_fields:
-            prompt = self.build_prompt(field)
-            # print(prompt)
-            # ollama_url = "http://localhost:11434/api/generate"
-            ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-            ollama_url = f"{ollama_host}/api/generate"
+        # 4. Call Ollama once (Single-shot extraction)
+        print("\t[LOG] Sending single-shot extraction request to Ollama...")
+        ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+        ollama_url = f"{ollama_host}/api/generate"
 
-            payload = {
-                "model": "mistral",
-                "prompt": prompt,
-                "stream": False # don't really know why --> look into this later.
-            }
+        payload = {
+            "model": "mistral",
+            "prompt": prompt,
+            "format": "json", # Forces Ollama into strict JSON mode
+            "stream": False 
+        }
 
+        try:
             response = requests.post(ollama_url, json=payload)
-
-            # parse response
-            json_data = response.json()
-            parsed_response = json_data['response']
-            # print(parsed_response)
-            self.add_response_to_json(field, parsed_response)
+            response.raise_for_status()
             
-        print("----------------------------------")
-        print("\t[LOG] Resulting JSON created from the input text:")
-        print(json.dumps(self.__json, indent=2))
-        print("--------- extracted data ---------")
+            raw_response = response.json()['response']
+            
+            # 5. Validate output strictly against our Pydantic schema
+            validated_data = DynamicIncidentModel.model_validate_json(raw_response)
+            extracted_dict = validated_data.model_dump()
 
-        return None
+            # 6. Map safe fields back to original PDF fields
+            for safe_key, parsed_value in extracted_dict.items():
+                original_field_name = self.__field_mapping[safe_key]
+                self.add_response_to_json(original_field_name, parsed_value)
+
+            print("----------------------------------")
+            print("\t[LOG] Resulting JSON created and validated via Pydantic:")
+            print(json.dumps(self.__json, indent=2))
+            print("--------- extracted data ---------")
+
+        except ValidationError as e:
+            print(f"\t[ERROR] AI returned invalid schema data. Pydantic Error:\n{e}")
+        except Exception as e:
+            print(f"\t[ERROR] An error occurred during extraction:\n{e}")
+
 
     def add_response_to_json(self, field, value):
-        """ 
-            this method adds the following value under the specified field, 
-            or under a new field if the field doesn't exist, to the json dict 
-        """
+        # Legacy helper maintained to ensure lists are handled correctly
+        if not isinstance(value, str):
+            value = str(value)
+            
         value = value.strip().replace('"', '')
         parsed_value = None
-        plural = False
- 
+
         if value != "-1":
             parsed_value = value       
         
         if ";" in value:
             parsed_value = self.handle_plural_values(value)
-            plural = True
-
 
         if field in self.__json.keys():
+            if not isinstance(self.__json[field], list):
+                self.__json[field] = [self.__json[field]]
             self.__json[field].append(parsed_value)
         else: 
             self.__json[field] = parsed_value
-                
-        return
 
     def handle_plural_values(self, plural_value):
-        """ 
-            This method handles plural values.
-            Takes in strings of the form 'value1; value2; value3; ...; valueN' 
-            returns a list with the respective values -> [value1, value2, value3, ..., valueN]
-        """
-        if ";" not in plural_value:
-            raise ValueError(f"Value is not plural, doesn't have ; separator, Value: {plural_value}")
-        
-        print(f"\t[LOG]: Formating plural values for JSON, [For input {plural_value}]...")
+        print(f"\t[LOG]: Formatting plural values for JSON, [For input {plural_value}]...")
         values = plural_value.split(";")
-        
-        # Remove trailing leading whitespace
-        for i in range(len(values)):
-            current = i+1 
-            if current < len(values):
-                clean_value = values[current].lstrip()
-                values[current] = clean_value
-
+        values = [v.strip() for v in values if v.strip()]
         print(f"\t[LOG]: Resulting formatted list of values: {values}")
-        
         return values
         
-
     def get_data(self):
-        return self.__json
+        ordered_data = {}
+        for field in self.__target_fields:
+            ordered_data[field] = self.__json.get(field, "-1")
+        return ordered_data
+
 
 class Fill():
     def __init__(self):
         pass
     
+    @staticmethod
     def fill_form(user_input: str, definitions: list, pdf_form: str):
         """
-        Fill a PDF form with values from user_input using testToJSON.
+        Fill a PDF form with values from user_input using textToJSON.
         Fields are filled in the visual order (top-to-bottom, left-to-right).
         """
 
         output_pdf = pdf_form[:-4] + "_filled.pdf"
 
-        # Generate dictionary of answers from your original function 
+        # 1. Generate dictionary of answers from the AI
         t2j = textToJSON(user_input, definitions)
         textbox_answers = t2j.get_data()  # This is a dictionary
 
+        # ---------------------------------------------------------
+        # 2. NEW: CLI FALLBACK (Human-in-the-Loop)
+        # ---------------------------------------------------------
+        print("\n\t[SYSTEM] Verifying extracted data completeness...")
+        
+        missing_fields = False
+        for field_name, extracted_value in textbox_answers.items():
+            if extracted_value == "-1":
+                if not missing_fields:
+                    print("\n\t⚠️ MISSING DATA DETECTED ")
+                    print("\tThe AI could not find all required fields in the transcript.")
+                    missing_fields = True
+                
+                # Prompt the user interactively in the terminal
+                user_correction = input(f"\t Please enter the value for '{field_name}' (or press Enter to leave blank): ")
+                
+                # Update the dictionary with human input
+                if user_correction.strip() != "":
+                    textbox_answers[field_name] = user_correction.strip()
+                else:
+                    textbox_answers[field_name] = ""
+                    
+        if not missing_fields:
+            print("\t All fields successfully extracted!")
+        else:
+            print("\n\t Manual data entry complete.")
+        # ---------------------------------------------------------
+
         answers_list = list(textbox_answers.values())
 
-        # Read PDF 
+        # 3. Read and Fill PDF 
         pdf = PdfReader(pdf_form)
 
         # Loop through pages 
@@ -158,7 +208,7 @@ class Fill():
                 i = 0
                 for annot in sorted_annots:
                     if annot.Subtype == '/Widget' and annot.T:
-                        field_name = annot.T[1:-1]
+                        # field_name = annot.T[1:-1]
                         
                         if i < len(answers_list):
                             annot.V = f'{answers_list[i]}'


### PR DESCRIPTION
### 🔗 Linked Issues
- Resolves #72 

### 📝 Description
This PR introduces an interactive **Human-in-the-Loop (HITL)** fallback mechanism to `src/backend.py`. 

While the new Pydantic pipeline safely catches missing data by defaulting to `"-1"`, this PR ensures those errors don't reach the final PDF. Instead, the application now detects these missing fields and prompts the user via the CLI to provide them manually.

### 🛠️ Key Changes
- Modified `Fill.fill_form()` in `src/backend.py`.
- Added a validation loop that scans extracted JSON for `"-1"` values.
- Implemented `input()` prompts to allow real-time data correction by the first responder.
- Added logic to handle blank skips (converting `"-1"` to `""` if the user chooses to skip).

### Testing Performed
- [x] Verified locally using a transcript missing 'Address' and 'Time'.
- [x] Confirmed the CLI pauses execution and waits for user input.
- [x] Confirmed the manual input successfully overwrites the `"-1"` in the final data dictionary.

### 📸 Test Output
```text
[SYSTEM] Verifying extracted data completeness...

 MISSING DATA DETECTED 
The AI could not find all required fields in the transcript.
 Please enter the value for 'Address' (or press Enter to leave blank): New Delhi, India
 Please enter the value for 'Time' (or press Enter to leave blank): 22:56

Manual data entry complete.