### PR TITLE
feat(config): add configuration validation and safe URL handling (#74)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,8 @@
 from fastapi import FastAPI
 from api.routes import templates, forms
+from src.config import validate_config
+
+validate_config()
 
 app = FastAPI()
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,38 @@
+# Configuration
+
+FireForm uses **environment variables** for runtime configuration. All values
+are validated at application startup — if a variable is set but invalid the
+application will refuse to start and print a clear error message.
+
+## Environment variables
+
+| Variable | Default | Rules |
+|---|---|---|
+| `OLLAMA_HOST` | `http://localhost:11434` | Must start with `http://` or `https://` |
+| `OLLAMA_API_PATH` | `/api/generate` | Must start with `/` |
+| `OUTPUT_PDF_SUFFIX` | `_filled.pdf` | Must end with `.pdf` |
+
+### Example `.env`
+
+```bash
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_API_PATH=/api/generate
+OUTPUT_PDF_SUFFIX=_filled.pdf
+```
+
+## How validation works
+
+`src/config.py` exposes two public helpers:
+
+- **`validate_config()`** — checks the three variables listed above and raises
+  `ValueError` with a descriptive message when a value is invalid.  This is
+  called once during API startup (in `api/main.py`).
+- **`build_ollama_url()`** — builds the full Ollama endpoint URL using
+  `urllib.parse.urljoin()` so that trailing/leading slashes never produce a
+  double-slash bug (e.g. `http://host//api/generate`).
+
+## Running the validation tests
+
+```bash
+pytest tests/test_config.py -v
+```

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,62 @@
+"""
+Configuration validation and safe URL handling for FireForm.
+
+All environment-based settings are validated at startup via validate_config().
+URLs are built with urllib.parse.urljoin() to avoid double-slash bugs.
+"""
+
+import os
+from urllib.parse import urljoin
+
+
+# ---------------------------------------------------------------------------
+# Default values
+# ---------------------------------------------------------------------------
+_DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+_DEFAULT_OLLAMA_API_PATH = "/api/generate"
+_DEFAULT_OUTPUT_PDF_SUFFIX = "_filled.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_config() -> None:
+    """Validate environment-variable configuration at startup.
+
+    Raises ``ValueError`` with a descriptive message when a setting is
+    invalid.  Call this once during application initialisation.
+    """
+    ollama_host = os.getenv("OLLAMA_HOST", _DEFAULT_OLLAMA_HOST)
+    ollama_api_path = os.getenv("OLLAMA_API_PATH", _DEFAULT_OLLAMA_API_PATH)
+    output_pdf_suffix = os.getenv("OUTPUT_PDF_SUFFIX", _DEFAULT_OUTPUT_PDF_SUFFIX)
+
+    if not ollama_host.startswith(("http://", "https://")):
+        raise ValueError(
+            f"OLLAMA_HOST must start with http:// or https://, got: {ollama_host!r}"
+        )
+
+    if not ollama_api_path.startswith("/"):
+        raise ValueError(
+            f"OLLAMA_API_PATH must start with /, got: {ollama_api_path!r}"
+        )
+
+    if not output_pdf_suffix.endswith(".pdf"):
+        raise ValueError(
+            f"OUTPUT_PDF_SUFFIX must end with .pdf, got: {output_pdf_suffix!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Safe URL builder
+# ---------------------------------------------------------------------------
+
+def build_ollama_url() -> str:
+    """Return the full Ollama API URL built with :func:`urllib.parse.urljoin`.
+
+    This avoids the double-slash bug that occurs with naive string
+    concatenation (e.g. ``http://host//api/generate``).
+    """
+    host = os.getenv("OLLAMA_HOST", _DEFAULT_OLLAMA_HOST)
+    path = os.getenv("OLLAMA_API_PATH", _DEFAULT_OLLAMA_API_PATH)
+    return urljoin(host, path)

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,6 +1,7 @@
 import json
-import os
 import requests
+
+from src.config import build_ollama_url
 
 
 class LLM:
@@ -49,9 +50,7 @@ class LLM:
         for field in self._target_fields.keys():
             prompt = self.build_prompt(field)
             # print(prompt)
-            # ollama_url = "http://localhost:11434/api/generate"
-            ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-            ollama_url = f"{ollama_host}/api/generate"
+            ollama_url = build_ollama_url()
 
             payload = {
                 "model": "mistral",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,103 @@
+"""Tests for src.config – configuration validation and safe URL building."""
+
+import os
+import pytest
+
+from src.config import validate_config, build_ollama_url
+
+
+# ---------------------------------------------------------------------------
+# validate_config – happy path
+# ---------------------------------------------------------------------------
+
+class TestValidateConfigValid:
+    """Default values and well-formed overrides should pass silently."""
+
+    def test_defaults_are_valid(self, monkeypatch):
+        """With no env vars set the defaults must pass validation."""
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        monkeypatch.delenv("OLLAMA_API_PATH", raising=False)
+        monkeypatch.delenv("OUTPUT_PDF_SUFFIX", raising=False)
+        validate_config()  # should not raise
+
+    def test_custom_valid_config(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "https://ollama.example.com")
+        monkeypatch.setenv("OLLAMA_API_PATH", "/v1/generate")
+        monkeypatch.setenv("OUTPUT_PDF_SUFFIX", "_output.pdf")
+        validate_config()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# validate_config – invalid OLLAMA_HOST
+# ---------------------------------------------------------------------------
+
+class TestValidateConfigInvalidHost:
+
+    def test_missing_scheme(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "localhost:11434")
+        with pytest.raises(ValueError, match="OLLAMA_HOST must start with http:// or https://"):
+            validate_config()
+
+    def test_ftp_scheme(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "ftp://localhost:11434")
+        with pytest.raises(ValueError, match="OLLAMA_HOST must start with http:// or https://"):
+            validate_config()
+
+
+# ---------------------------------------------------------------------------
+# validate_config – invalid OLLAMA_API_PATH
+# ---------------------------------------------------------------------------
+
+class TestValidateConfigInvalidApiPath:
+
+    def test_missing_leading_slash(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_PATH", "api/generate")
+        with pytest.raises(ValueError, match="OLLAMA_API_PATH must start with /"):
+            validate_config()
+
+
+# ---------------------------------------------------------------------------
+# validate_config – invalid OUTPUT_PDF_SUFFIX
+# ---------------------------------------------------------------------------
+
+class TestValidateConfigInvalidSuffix:
+
+    def test_wrong_extension(self, monkeypatch):
+        monkeypatch.setenv("OUTPUT_PDF_SUFFIX", "_filled.docx")
+        with pytest.raises(ValueError, match="OUTPUT_PDF_SUFFIX must end with .pdf"):
+            validate_config()
+
+    def test_empty_suffix(self, monkeypatch):
+        monkeypatch.setenv("OUTPUT_PDF_SUFFIX", "")
+        with pytest.raises(ValueError, match="OUTPUT_PDF_SUFFIX must end with .pdf"):
+            validate_config()
+
+
+# ---------------------------------------------------------------------------
+# build_ollama_url – urljoin correctness
+# ---------------------------------------------------------------------------
+
+class TestBuildOllamaUrl:
+
+    def test_default_url(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        monkeypatch.delenv("OLLAMA_API_PATH", raising=False)
+        assert build_ollama_url() == "http://localhost:11434/api/generate"
+
+    def test_trailing_slash_on_host(self, monkeypatch):
+        """The classic double-slash bug must not occur."""
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434/")
+        monkeypatch.setenv("OLLAMA_API_PATH", "/api/generate")
+        url = build_ollama_url()
+        assert url == "http://localhost:11434/api/generate"
+        assert "//" not in url.split("://", 1)[1]  # no double-slash after scheme
+
+    def test_no_trailing_slash_on_host(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+        monkeypatch.setenv("OLLAMA_API_PATH", "/api/generate")
+        assert build_ollama_url() == "http://localhost:11434/api/generate"
+
+    def test_custom_host_and_path(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "https://ai.example.com:8080")
+        monkeypatch.setenv("OLLAMA_API_PATH", "/v2/chat")
+        assert build_ollama_url() == "https://ai.example.com:8080/v2/chat"


### PR DESCRIPTION
## Description

Add startup configuration validation and replace unsafe string-concatenation URL building with `urllib.parse.urljoin()`.

Previously, environment variables (`OLLAMA_HOST`, `OLLAMA_API_PATH`, `OUTPUT_PDF_SUFFIX`) had no validation — typos or malformed values would silently break the app at runtime. The Ollama API URL was built with f-string concatenation, causing double-slash bugs like `http://localhost:11434//api/generate` when the host included a trailing slash.

This PR introduces `src/config.py` with a `validate_config()` function (called at API startup) and a `build_ollama_url()` helper that uses `urljoin()` to safely construct URLs.

Fixes #74

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `pytest tests/test_config.py -v` — 11 new tests covering valid defaults, custom valid config, each invalid-value scenario (`OLLAMA_HOST` missing scheme, `OLLAMA_API_PATH` missing leading `/`, `OUTPUT_PDF_SUFFIX` wrong extension/empty), and the trailing-slash double-slash edge case.
- [x] `pytest tests/ -v` — full suite: 16 passed, 0 failures, no regressions.

**Test Configuration**:
* Python 3.13.6
* pytest 9.0.2
* macOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules