### PR TITLE
feat: added JSON schema validation for AI output

### DIFF
--- a/src/filler.py
+++ b/src/filler.py
@@ -23,6 +23,32 @@ class Filler:
         t2j = llm.main_loop()
         textbox_answers = t2j.get_data()  # This is a dictionary
 
+        from jsonschema import validate, ValidationError
+        import logging
+        logger = logging.getLogger(__name__)
+
+        incident_schema = {
+            "type": "object",
+            "properties": {
+                "incident_type": {"type": "string"},
+                "location": {"type": "string"},
+                "date": {"type": "string"},
+                "casualties": {"type": "integer"}
+            },
+            "required": ["incident_type", "location"]
+        }
+
+        def validate_output(data):
+            try:
+                validate(instance=data, schema=incident_schema)
+                return True
+            except ValidationError as e:
+                logger.error(f"Invalid AI output: {e.message}")
+                return False
+
+        if not validate_output(textbox_answers):
+            return {"error": "AI output validation failed"}
+
         answers_list = list(textbox_answers.values())
 
         # Read PDF


### PR DESCRIPTION
📌 PR Title feat: added JSON schema validation for AI output

📄 PR Description

What
Brings strict format constraints to the AI extraction layer by implementing a JSON Schema guard — preventing unpredictably malformed LLM outputs from crashing the downstream PDF generation pipeline.

Changes

src/filler.py
: Implemented a strict incident_schema dictionary that validates the presence of required data fields (e.g. incident_type, location) extracted by the LLM.

src/filler.py
: Added a validate_output() function that gracefully intercepts and logs schema errors (ValidationError) instead of allowing the application to break when passing null fields to PdfWriter.
Why
As outlined in the README ("real-world emergency response environments"), unhandled exceptions from incomplete model outputs disrupt operational pipelines. When deploying local generative models, hallucinated schemas or missing JSON keys are inevitable. This PR brings necessary production guardrails to ensure that malformed AI outputs are caught predictably rather than instantly crashing the application.

### Checklist
- [x] Feature works in Docker container
- [x] Correctly identifies malformed AI outputs without crashing
- [x] Unit tests pass locally
