### PR TITLE
chore: replaced print statements with structured logging

### DIFF
--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -2,7 +2,9 @@ import os
 from src.filler import Filler
 from src.llm import LLM
 from commonforms import prepare_form
+import logging
 
+logger = logging.getLogger(__name__)
 
 class FileManipulator:
     def __init__(self):
@@ -22,26 +24,26 @@ class FileManipulator:
         It receives the raw data, runs the PDF filling logic,
         and returns the path to the newly created file.
         """
-        print("[1] Received request from frontend.")
-        print(f"[2] PDF template path: {pdf_form_path}")
+        logger.info("[1] Received request from frontend.")
+        logger.info(f"[2] PDF template path: {pdf_form_path}")
 
         if not os.path.exists(pdf_form_path):
-            print(f"Error: PDF template not found at {pdf_form_path}")
+            logger.error(f"Error: PDF template not found at {pdf_form_path}")
             return None  # Or raise an exception
 
-        print("[3] Starting extraction and PDF filling process...")
+        logger.info("[3] Starting extraction and PDF filling process...")
         try:
             self.llm._target_fields = fields
             self.llm._transcript_text = user_input
             output_name = self.filler.fill_form(pdf_form=pdf_form_path, llm=self.llm)
 
-            print("\n----------------------------------")
-            print("✅ Process Complete.")
-            print(f"Output saved to: {output_name}")
+            logger.info("\n----------------------------------")
+            logger.info("✅ Process Complete.")
+            logger.info(f"Output saved to: {output_name}")
 
             return output_name
 
         except Exception as e:
-            print(f"An error occurred during PDF generation: {e}")
+            logger.error(f"An error occurred during PDF generation: {e}", exc_info=True)
             # Re-raise the exception so the frontend can handle it
             raise e

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,7 +1,9 @@
 import json
 import os
 import requests
+import logging
 
+logger = logging.getLogger(__name__)
 
 class LLM:
     def __init__(self, transcript_text=None, target_fields=None, json=None):
@@ -76,10 +78,10 @@ class LLM:
             # print(parsed_response)
             self.add_response_to_json(field, parsed_response)
 
-        print("----------------------------------")
-        print("\t[LOG] Resulting JSON created from the input text:")
-        print(json.dumps(self._json, indent=2))
-        print("--------- extracted data ---------")
+        logger.info("----------------------------------")
+        logger.info("\t[LOG] Resulting JSON created from the input text:")
+        logger.info(json.dumps(self._json, indent=2))
+        logger.info("--------- extracted data ---------")
 
         return self
 
@@ -115,7 +117,7 @@ class LLM:
                 f"Value is not plural, doesn't have ; separator, Value: {plural_value}"
             )
 
-        print(
+        logger.info(
             f"\t[LOG]: Formating plural values for JSON, [For input {plural_value}]..."
         )
         values = plural_value.split(";")
@@ -127,7 +129,7 @@ class LLM:
                 clean_value = values[current].lstrip()
                 values[current] = clean_value
 
-        print(f"\t[LOG]: Resulting formatted list of values: {values}")
+        logger.info(f"\t[LOG]: Resulting formatted list of values: {values}")
 
         return values
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,10 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+import logging
 
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 def input_fields(num_fields: int):
     fields = []
     for i in range(num_fields):
@@ -18,17 +21,17 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
     and returns the path to the newly created file.
     """
     
-    print("[1] Received request from frontend.")
-    print(f"[2] PDF template path: {pdf_form_path}")
+    logger.info("[1] Received request from frontend.")
+    logger.info(f"[2] PDF template path: {pdf_form_path}")
     
     # Normalize Path/PathLike to a plain string for downstream code
     pdf_form_path = os.fspath(pdf_form_path)
     
     if not os.path.exists(pdf_form_path):
-        print(f"Error: PDF template not found at {pdf_form_path}")
+        logger.error(f"Error: PDF template not found at {pdf_form_path}")
         return None # Or raise an exception
 
-    print("[3] Starting extraction and PDF filling process...")
+    logger.info("[3] Starting extraction and PDF filling process...")
     try:
         output_name = Fill.fill_form(
             user_input=user_input,
@@ -36,14 +39,14 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
             pdf_form=pdf_form_path
         )
         
-        print("\n----------------------------------")
-        print(f"✅ Process Complete.")
-        print(f"Output saved to: {output_name}")
+        logger.info("\n----------------------------------")
+        logger.info(f"✅ Process Complete.")
+        logger.info(f"Output saved to: {output_name}")
         
         return output_name
         
     except Exception as e:
-        print(f"An error occurred during PDF generation: {e}")
+        logger.error(f"An error occurred during PDF generation: {e}", exc_info=True)
         # Re-raise the exception so the frontend can handle it
         raise e
 


### PR DESCRIPTION
### What
Improves server observability by replacing generic `print()` statements throughout the core backend with Python's standard `logging` module, utilizing professional `INFO` and `ERROR` log level formatting.

### Changes
* [src/main.py](cci:7://file:///e:/all%20projects/new%20project/FireForm/src/main.py:0:0-0:0): Initialized standard logging configuration with timestamp, level, and message formats (`%(asctime)s - %(levelname)s - %(message)s`). Replaced print statements with `logger.info()` and `logger.error(exc_info=True)` to trace the main PDF execution loop.
* [src/file_manipulator.py](cci:7://file:///e:/all%20projects/new%20project/FireForm/src/file_manipulator.py:0:0-0:0): Swapped all terminal prints with cleanly scoped `logger.info()` and explicit error logs during template processing.
* [src/llm.py](cci:7://file:///e:/all%20projects/new%20project/FireForm/src/llm.py:0:0-0:0): Replaced unstructured raw response prints with `logger.info()` to clearly format and log plural values and JSON structure compilation.

### Why
Writing terminal `print()` statements is an anti-pattern for server environments (FastAPI/Docker). When deploying FireForm as an API or running it as a background service container, standard prints are untrackable and lack crucial metadata. By upgrading to structured Python logging, developers and system administrators can properly track operations timestamps, severity warnings, and exact error traces without bloating the console output unproductively.

### Checklist
- [x] Removed all standard `print` statements in core pipeline
- [x] Application successfully emits timestamped informational logs
- [x] Feature works inside Docker container
