### PR TITLE
Fix JSON decode exception handling in JsonManager

### DIFF
--- a/src/json_manager.py
+++ b/src/json_manager.py
@@ -11,7 +11,7 @@ class JsonManager():
         except FileNotFoundError:
             print(f"Warning: File not found at {path_to_file}. Returning empty list.")
             data = []
-        except json.DecodeError:
+        except json.JSONDecodeError:
             raise IOError(f"JSON file at {path_to_file} is corrupted.")
         
         return data

--- a/src/test/test_json_manager.py
+++ b/src/test/test_json_manager.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from json_manager import JsonManager
+
+
+def test_load_json_raises_ioerror_for_corrupted_json(tmp_path: Path):
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("{bad json", encoding="utf-8")
+
+    with pytest.raises(IOError, match="is corrupted"):
+        JsonManager().load_json(str(bad_json))
+
+
+def test_load_json_returns_data_for_valid_json(tmp_path: Path):
+    payload = {"name": "fireform", "ok": True}
+    good_json = tmp_path / "good.json"
+    good_json.write_text(json.dumps(payload), encoding="utf-8")
+
+    data = JsonManager().load_json(str(good_json))
+    assert data == payload


### PR DESCRIPTION
### Description
This PR fixes a **JSON parsing bug in JsonManager.load_json** where malformed JSON files were not handled correctly due to catching an invalid exception type. The code previously used **json.DecodeError**, which caused an **AttributeError** path instead of the intended corruption handling flow. This has been corrected to **json.JSONDecodeError**, and load_json now consistently raises IOError for corrupted JSON as intended.

In addition, this PR adds focused unit tests for JsonManager.load_json:
- verifies corrupted JSON raises IOError
- verifies valid JSON is parsed and returned correctly. 

## Motivation/context:
- Improves reliability of JSON-loading behavior.
- Prevents misleading runtime exceptions for malformed JSON input.
- Adds regression coverage so this bug does not recur.

Dependencies:
- No new runtime dependencies.
- Test execution requires pytest in local environment.

Fixes #104 

### Type of change
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Ran targeted unit tests for JsonManager behavior on malformed and valid JSON. 
- Manually reproduced malformed JSON handling to confirm corrected exception behavior.
- Test A: python -m pytest -q src/test/test_json_manager.py
- Test B: manual malformed JSON repro script invoking JsonManager().load_json(...) and confirming IOError.

## Test Configuration:
- Firmware version: N/A
- Hardware: Windows laptop (local dev machine)
- SDK: N/A
- Python: local Python 3.x environment

### Checklist:
- [x]   My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [ ]  Any dependent changes have been merged and published in downstream modules