### PR TITLE
fix: resolve AttributeError in JSON appending and add unit tests

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -93,10 +93,14 @@ class textToJSON():
 
 
         if field in self.__json.keys():
-            self.__json[field].append(parsed_value)
+            # If it's already a list, we add it. Otherwise, we convert it into a list.
+            if isinstance(self.__json[field], list):
+                self.__json[field].append(parsed_value)
+            else:
+                self.__json[field] = [self.__json[field], parsed_value]
         else: 
-            self.__json[field] = parsed_value
-                
+            # We always initialize it as a list to avoid errors on the next turn.
+            self.__json[field] = [parsed_value]
         return
 
     def handle_plural_values(self, plural_value):

--- a/src/test/test_backend_fix.py
+++ b/src/test/test_backend_fix.py
@@ -1,0 +1,86 @@
+import unittest
+import sys
+import os
+
+# --- PATH CONFIGURATION ---
+# This ensures that the script can find 'backend.py' in the parent directory
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+try:
+    from backend import textToJSON
+except ImportError:
+    print("Error: Could not find backend.py. Ensure the file is in the src/ folder.")
+    sys.exit(1)
+
+class TestBackendFix(unittest.TestCase):
+    """
+    Test suite to verify the stability of JSON field handling in FireForm.
+    Specifically targets the AttributeError when adding multiple responses to a single field.
+    """
+
+    def setUp(self):
+        """
+        Initial setup before each test.
+        Initializes the textToJSON class with a sample transcript.
+        Note: This triggers the local LLM (Ollama), which may take some time.
+        """
+        self.definitions = ["Date", "Location", "Incident_Type"]
+        self.transcript = "The incident happened on Monday in Agadir."
+        
+        print("\n" + "-"*34)
+        print("Starting LLM initialization...")
+        self.t2j = textToJSON(self.transcript, self.definitions)
+        print("Initialization complete.")
+        print("-"*34)
+
+    def test_json_append_logic(self):
+        """
+        Verifies that add_response_to_json correctly converts string fields 
+        into lists when a duplicate key is added, preventing an AttributeError.
+        """
+        field = "Date"
+        
+        # Get data state BEFORE manual insertion
+        data_before = self.t2j.get_data()
+        initial_val = data_before.get(field)
+        
+        # Determine how many items are already in the field (extracted by LLM)
+        if initial_val is None or initial_val == [None]:
+            initial_count = 0
+        elif isinstance(initial_val, list):
+            initial_count = len(initial_val)
+        else:
+            initial_count = 1
+            
+        print(f"[LOG] Initial items in '{field}': {initial_count}")
+
+        # Manually add a new response (This is where the bug used to happen)
+        new_response = "2026-03-01"
+        try:
+            print(f"[LOG] Attempting to append: '{new_response}'")
+            self.t2j.add_response_to_json(field, new_response)
+        except AttributeError as e:
+            self.fail(f"CRITICAL FAILURE: add_response_to_json() raised AttributeError: {e}")
+
+        # Get data state AFTER manual insertion
+        data_after = self.t2j.get_data()
+        
+        # --- VERIFICATIONS ---
+        
+        # 1. Check if the field is now a list
+        self.assertIsInstance(data_after[field], list, f"Field '{field}' should be a list.")
+        
+        # 2. Check if the count increased correctly
+        final_count = len(data_after[field])
+        self.assertEqual(final_count, initial_count + 1, 
+                         f"Expected {initial_count + 1} items, but found {final_count}.")
+        
+        # 3. Check if our manual response is actually stored
+        self.assertIn(new_response, data_after[field], f"The new response '{new_response}' was not found in the JSON.")
+
+        print("[LOG] Test passed: No AttributeError, and list count is correct.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
---
name: 🛠️ Bug Fix
about: Resolve the AttributeError when appending data to JSON fields.
title: "fix: resolve JSON AttributeError and improve duplicate field handling"
labels: bug
assignees: 'yassinezadod'

---

## 📝 Description
This PR resolves a critical `AttributeError` that occurs when the LLM attempts to append data to existing string fields within the JSON structure. It ensures that fields are correctly initialized as lists and maintained as such when multiple responses are received for the same key.

## 💡 Rationale
Currently, if the LLM returns multiple values for a field like "Date", the system tries to call `.append()` on a string, causing a crash. This prevents the final PDF from being generated correctly in scenarios with duplicate field extractions.

## 🛠️ Proposed Solution
- [x] Logic change in `src/backend.py`: Modified `add_response_to_json` to initialize fields as lists and handle appending safely.
- [x] Fix in `src/json_manager.py`: Corrected the reference to `json.JSONDecodeError` to prevent secondary crashes.
- [x] New unit test: Added `src/test/test_backend_fix.py` to validate the fix using a real local LLM cycle.

## ✅ Acceptance Criteria
- [x] Feature works in local environment with Ollama/Mistral.
- [x] Unit test `test_backend_fix.py` passes with "OK".
- [x] JSON output validates correctly even with duplicate field names.

## 📌 Additional Context
Verified locally on Windows. The fix was tested against a real transcript where the LLM extracted multiple date-related entities, confirming that the list conversion logic is stable.

Related Issues:
Fixes #26
Fixes #41
Fixes #97