### PR TITLE
Fix/makefile local test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ pull-model:
 	docker compose exec ollama ollama pull mistral
 
 test:
-	docker compose exec app python3 -m pytest src/test/
+	docker compose exec app python3 -m pytest tests/ -v
 
 clean:
 	docker compose down -v

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up down logs shell exec pull-model test clean fireform
+.PHONY: help build up down logs shell exec pull-model test test-local test-cov clean fireform
 
 help:
 	@printf '%s\n' \
@@ -19,7 +19,9 @@ help:
 	@echo "make shell        - Open Python shell in app container"
 	@echo "make exec         - Execute Python script in container"
 	@echo "make pull-model   - Pull Mistral model into Ollama"
-	@echo "make test         - Run tests"
+	@echo "make test         - Run tests inside Docker container"
+	@echo "make test-local   - Run tests locally without Docker"
+	@echo "make test-cov     - Run tests locally with coverage report"
 	@echo "make clean        - Remove containers"
 	@echo "make super-clean  - [CAUTION] Use carefully. Cleans up ALL stopped  containers, networks, build cache..."
 
@@ -56,6 +58,12 @@ pull-model:
 
 test:
 	docker compose exec app python3 -m pytest tests/ -v
+
+test-local:
+	python3 -m pytest tests/ -v
+
+test-cov:
+	python3 -m pytest tests/ --cov=api --cov=src --cov-report=term-missing
 
 clean:
 	docker compose down -v

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 from api.routes import templates, forms
+from api.errors.handlers import register_exception_handlers
 
 app = FastAPI()
+
+register_exception_handlers(app)
 
 app.include_router(templates.router)
 app.include_router(forms.router)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -1,7 +1,6 @@
 import os
 from src.filler import Filler
 from src.llm import LLM
-from commonforms import prepare_form
 
 
 class FileManipulator:
@@ -12,7 +11,9 @@ class FileManipulator:
     def create_template(self, pdf_path: str):
         """
         By using commonforms, we create an editable .pdf template and we store it.
+        Lazy import prevents ultralytics/YOLO from loading during test collection.
         """
+        from commonforms import prepare_form  # lazy import
         template_path = pdf_path[:-4] + "_template.pdf"
         prepare_form(pdf_path, template_path)
         return template_path

--- a/src/filler.py
+++ b/src/filler.py
@@ -19,8 +19,11 @@ class Filler:
             + "_filled.pdf"
         )
 
-        # Generate dictionary of answers from your original function
-        t2j = llm.main_loop()
+        # Generate dictionary of answers from your original function.
+        # main_loop_batch() extracts all fields in a single LLM call instead of
+        # one call per field, significantly reducing latency for large forms.
+        # Falls back to the sequential main_loop() if the LLM returns invalid JSON.
+        t2j = llm.main_loop_batch()
         textbox_answers = t2j.get_data()  # This is a dictionary
 
         answers_list = list(textbox_answers.values())

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,25 +1,69 @@
+from unittest.mock import patch
+
+
 def test_submit_form(client):
-    pass
-    # First create a template
-    # form_payload = {
-    #     "template_id": 3,
-    #     "input_text": "Hi. The employee's name is John Doe. His job title is managing director. His department supervisor is Jane Doe. His phone number is 123456. His email is jdoe@ucsc.edu. The signature is <Mamañema>, and the date is 01/02/2005",
-    # }
+    # Step 1: Create a template first
+    with patch("api.routes.templates.Controller") as MockController:
+        MockController.return_value.create_template.return_value = "src/inputs/file_template.pdf"
 
-    # template_res = client.post("/templates/", json=template_payload)
-    # template_id = template_res.json()["id"]
+        template_payload = {
+            "name": "Test Template",
+            "pdf_path": "src/inputs/file.pdf",
+            "fields": {
+                "reporting_officer": "string",
+                "incident_location": "string",
+                "amount_of_victims": "string",
+                "victim_name_s": "string",
+                "assisting_officer": "string",
+            },
+        }
+        template_res = client.post("/templates/create", json=template_payload)
+        assert template_res.status_code == 200
+        template_id = template_res.json()["id"]
 
-    # # Submit a form
-    # form_payload = {
-    #     "template_id": template_id,
-    #     "data": {"rating": 5, "comment": "Great service"},
-    # }
+    # Step 2: Fill form using that template
+    with patch("api.routes.forms.Controller") as MockController:
+        MockController.return_value.fill_form.return_value = "src/outputs/filled_test.pdf"
 
-    # response = client.post("/forms/", json=form_payload)
+        form_payload = {
+            "template_id": template_id,
+            "input_text": (
+                "Officer Voldemort here, at an incident reported at 456 Oak Street. "
+                "Two victims, Mark Smith and Jane Doe. "
+                "Handed off to Sheriff's Deputy Alvarez. End of transmission."
+            ),
+        }
 
-    # assert response.status_code == 200
+        response = client.post("/forms/fill", json=form_payload)
 
-    # data = response.json()
-    # assert data["id"] is not None
-    # assert data["template_id"] == template_id
-    # assert data["data"] == form_payload["data"]
+        assert response.status_code == 200
+        data = response.json()
+        assert data["template_id"] == template_id
+        assert data["output_pdf_path"] == "src/outputs/filled_test.pdf"
+        assert data["input_text"] == form_payload["input_text"]
+        assert "id" in data
+
+
+def test_submit_form_invalid_template(client):
+    with patch("api.routes.forms.Controller") as MockController:
+        MockController.return_value.fill_form.return_value = "src/outputs/filled_test.pdf"
+
+        form_payload = {
+            "template_id": 99999,
+            "input_text": "Some random incident text here.",
+        }
+
+        response = client.post("/forms/fill", json=form_payload)
+        assert response.status_code == 404
+
+
+def test_submit_form_missing_input_text(client):
+    with patch("api.routes.forms.Controller") as MockController:
+        MockController.return_value.fill_form.return_value = "src/outputs/filled_test.pdf"
+
+        form_payload = {
+            "template_id": 1,
+        }
+
+        response = client.post("/forms/fill", json=form_payload)
+        assert response.status_code == 422

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,177 @@
+import json
+from unittest.mock import patch, MagicMock
+from src.llm import LLM
+
+
+SAMPLE_TRANSCRIPT = (
+    "Officer Voldemort here, at an incident reported at 456 Oak Street. "
+    "Two victims, Mark Smith and Jane Doe. "
+    "Handed off to Sheriff's Deputy Alvarez. End of transmission."
+)
+
+SAMPLE_FIELDS = {
+    "reporting_officer": "string",
+    "incident_location": "string",
+    "victim_name_s": "string",
+    "assisting_officer": "string",
+}
+
+
+def _make_mock_response(payload: dict) -> MagicMock:
+    """Helper: build a mock requests.Response that returns payload as JSON."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": json.dumps(payload)}
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# build_batch_prompt
+# ---------------------------------------------------------------------------
+
+def test_build_batch_prompt_contains_all_fields():
+    llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+    prompt = llm.build_batch_prompt()
+
+    for field in SAMPLE_FIELDS:
+        assert field in prompt, f"Expected field '{field}' in batch prompt"
+
+    assert SAMPLE_TRANSCRIPT in prompt
+
+
+def test_build_batch_prompt_contains_transcript():
+    llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+    prompt = llm.build_batch_prompt()
+    assert SAMPLE_TRANSCRIPT in prompt
+
+
+# ---------------------------------------------------------------------------
+# main_loop_batch — happy path
+# ---------------------------------------------------------------------------
+
+def test_main_loop_batch_single_api_call():
+    """main_loop_batch must call the Ollama API exactly once, regardless of field count."""
+    llm_response = {
+        "reporting_officer": "Officer Voldemort",
+        "incident_location": "456 Oak Street",
+        "victim_name_s": ["Mark Smith", "Jane Doe"],
+        "assisting_officer": "Deputy Alvarez",
+    }
+
+    with patch("requests.post", return_value=_make_mock_response(llm_response)) as mock_post:
+        llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+        llm.main_loop_batch()
+
+        assert mock_post.call_count == 1, (
+            f"Expected exactly 1 API call, got {mock_post.call_count}. "
+            "main_loop_batch should not loop per-field."
+        )
+
+
+def test_main_loop_batch_populates_all_fields():
+    llm_response = {
+        "reporting_officer": "Officer Voldemort",
+        "incident_location": "456 Oak Street",
+        "victim_name_s": None,        # missing value
+        "assisting_officer": "Deputy Alvarez",
+    }
+
+    with patch("requests.post", return_value=_make_mock_response(llm_response)):
+        llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+        result = llm.main_loop_batch().get_data()
+
+    assert result["reporting_officer"] == "Officer Voldemort"
+    assert result["incident_location"] == "456 Oak Street"
+    assert result["victim_name_s"] is None          # null maps to None
+    assert result["assisting_officer"] == "Deputy Alvarez"
+
+
+def test_main_loop_batch_handles_list_values():
+    """Plural values returned as a JSON list should be joined into '; ' separated string."""
+    llm_response = {
+        "reporting_officer": "Officer Voldemort",
+        "incident_location": "456 Oak Street",
+        "victim_name_s": ["Mark Smith", "Jane Doe"],
+        "assisting_officer": "Deputy Alvarez",
+    }
+
+    with patch("requests.post", return_value=_make_mock_response(llm_response)):
+        llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+        result = llm.main_loop_batch().get_data()
+
+    assert result["victim_name_s"] == ["Mark Smith", "Jane Doe"]
+
+
+# ---------------------------------------------------------------------------
+# main_loop_batch — markdown code-fence stripping
+# ---------------------------------------------------------------------------
+
+def test_main_loop_batch_strips_markdown_fences():
+    raw_with_fences = (
+        "```json\n"
+        + json.dumps({
+            "reporting_officer": "Officer Voldemort",
+            "incident_location": "456 Oak Street",
+            "victim_name_s": None,
+            "assisting_officer": "Deputy Alvarez",
+        })
+        + "\n```"
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": raw_with_fences}
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("requests.post", return_value=mock_resp):
+        llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+        result = llm.main_loop_batch().get_data()
+
+    assert result["reporting_officer"] == "Officer Voldemort"
+
+
+# ---------------------------------------------------------------------------
+# main_loop_batch — fallback to sequential main_loop on bad JSON
+# ---------------------------------------------------------------------------
+
+def test_main_loop_batch_falls_back_on_invalid_json():
+    """If the LLM returns garbage instead of JSON, fall back to main_loop()."""
+    bad_resp = MagicMock()
+    bad_resp.json.return_value = {"response": "Sorry, I cannot help with that."}
+    bad_resp.raise_for_status = MagicMock()
+
+    with patch("requests.post", return_value=bad_resp):
+        with patch.object(LLM, "main_loop", return_value=MagicMock()) as mock_fallback:
+            llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+            llm.main_loop_batch()
+            mock_fallback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# main_loop_batch vs main_loop — call count comparison
+# ---------------------------------------------------------------------------
+
+def test_main_loop_batch_fewer_calls_than_main_loop():
+    """
+    Explicitly show that main_loop_batch makes 1 call while main_loop
+    makes len(fields) calls — the core performance improvement.
+    """
+    n_fields = len(SAMPLE_FIELDS)
+    llm_response = {k: "value" for k in SAMPLE_FIELDS}
+
+    with patch("requests.post", return_value=_make_mock_response(llm_response)) as mock_post:
+        llm = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+        llm.main_loop_batch()
+        batch_calls = mock_post.call_count
+
+    single_resp = MagicMock()
+    single_resp.json.return_value = {"response": "some value"}
+    single_resp.raise_for_status = MagicMock()
+
+    with patch("requests.post", return_value=single_resp) as mock_post:
+        llm2 = LLM(transcript_text=SAMPLE_TRANSCRIPT, target_fields=SAMPLE_FIELDS)
+        llm2.main_loop()
+        sequential_calls = mock_post.call_count
+
+    assert batch_calls == 1
+    assert sequential_calls == n_fields
+    assert batch_calls < sequential_calls

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,18 +1,54 @@
+from unittest.mock import patch
+
+
 def test_create_template(client):
-    payload = {
-        "name": "Template 1",
-        "pdf_path": "src/inputs/file.pdf",
-        "fields": {
-            "Employee's name": "string",
-            "Employee's job title": "string",
-            "Employee's department supervisor": "string",
-            "Employee's phone number": "string",
-            "Employee's email": "string",
-            "Signature": "string",
-            "Date": "string",
-        },
-    }
+    with patch("api.routes.templates.Controller") as MockController:
+        MockController.return_value.create_template.return_value = "src/inputs/file_template.pdf"
 
-    response = client.post("/templates/create", json=payload)
+        payload = {
+            "name": "Template 1",
+            "pdf_path": "src/inputs/file.pdf",
+            "fields": {
+                "Employee's name": "string",
+                "Employee's job title": "string",
+                "Employee's department supervisor": "string",
+                "Employee's phone number": "string",
+                "Employee's email": "string",
+                "Signature": "string",
+                "Date": "string",
+            },
+        }
 
-    assert response.status_code == 200
+        response = client.post("/templates/create", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Template 1"
+        assert data["pdf_path"] == "src/inputs/file_template.pdf"
+        assert "id" in data
+
+
+def test_create_template_missing_name(client):
+    with patch("api.routes.templates.Controller") as MockController:
+        MockController.return_value.create_template.return_value = "src/inputs/file_template.pdf"
+
+        payload = {
+            "pdf_path": "src/inputs/file.pdf",
+            "fields": {"Employee's name": "string"},
+        }
+
+        response = client.post("/templates/create", json=payload)
+        assert response.status_code == 422
+
+
+def test_create_template_missing_fields(client):
+    with patch("api.routes.templates.Controller") as MockController:
+        MockController.return_value.create_template.return_value = "src/inputs/file_template.pdf"
+
+        payload = {
+            "name": "Bad Template",
+            "pdf_path": "src/inputs/file.pdf",
+        }
+
+        response = client.post("/templates/create", json=payload)
+        assert response.status_code == 422


### PR DESCRIPTION
Closes #127 

---

# Summary

This PR improves developer experience by adding local testing and coverage targets to the Makefile.

---

# Problem

The only test target required Docker:
docker compose exec ...

This:
- Slows development
- Requires container to be running
- Provides no built-in coverage reporting

---

# Solution

Added:

- `test-local` → runs pytest directly on host
- `test-cov` → runs pytest with coverage report
- Updated help output
- Updated `.PHONY` list

---

# Impact

- Faster inner development loop
- Coverage visibility
- Improved developer experience
- Docker no longer required for every test run