### PR TITLE
#135- fix Union import error

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+from typing import Union
 
 def input_fields(num_fields: int):
     fields = []


### PR DESCRIPTION
Closes #135 

Running the application via the `make exec` command crashes immediately upon startup with a `NameError: name 'Union' is not defined`. This occurs because `Union` is used for type hinting the `pdf_form_path` parameter in the `run_pdf_fill_process` function signature in `src/main.py`, but the module is never imported.

## Fix added to main.py: 
Add the missing import statement from the standard typing library at the top of src/main.py:

``` bash
from typing import Union