### PR TITLE
fix(filler): keep field index across PDF pages

### DIFF
--- a/src/filler.py
+++ b/src/filler.py
@@ -28,14 +28,16 @@ class Filler:
         # Read PDF
         pdf = PdfReader(pdf_form)
 
+        # Keep one running index across the whole document so multi-page
+        # forms continue mapping values instead of restarting on each page.
+        i = 0
+
         # Loop through pages
         for page in pdf.pages:
             if page.Annots:
                 sorted_annots = sorted(
                     page.Annots, key=lambda a: (-float(a.Rect[1]), float(a.Rect[0]))
                 )
-
-                i = 0
                 for annot in sorted_annots:
                     if annot.Subtype == "/Widget" and annot.T:
                         if i < len(answers_list):

--- a/tests/test_filler.py
+++ b/tests/test_filler.py
@@ -1,0 +1,61 @@
+from src.filler import Filler
+
+
+class DummyT2J:
+    def __init__(self, data):
+        self._data = data
+
+    def get_data(self):
+        return self._data
+
+
+class DummyLLM:
+    def __init__(self, data):
+        self._data = data
+
+    def main_loop(self):
+        return DummyT2J(self._data)
+
+
+class DummyAnnot:
+    def __init__(self, rect, name):
+        self.Rect = rect
+        self.Subtype = "/Widget"
+        self.T = name
+        self.V = None
+        self.AP = "placeholder"
+
+
+class DummyPage:
+    def __init__(self, annots):
+        self.Annots = annots
+
+
+class DummyPdf:
+    def __init__(self, pages):
+        self.pages = pages
+
+
+class CaptureWriter:
+    written = None
+
+    def write(self, output_pdf, pdf):
+        CaptureWriter.written = (output_pdf, pdf)
+
+
+def test_fill_form_keeps_index_across_pages(monkeypatch):
+    # One text widget per page to validate index continuity across pages.
+    page_1 = DummyPage([DummyAnnot([0, 200, 100, 220], "(field_1)")])
+    page_2 = DummyPage([DummyAnnot([0, 200, 100, 220], "(field_2)")])
+    dummy_pdf = DummyPdf([page_1, page_2])
+
+    monkeypatch.setattr("src.filler.PdfReader", lambda _: dummy_pdf)
+    monkeypatch.setattr("src.filler.PdfWriter", lambda: CaptureWriter())
+
+    llm = DummyLLM({"field_1": "alpha", "field_2": "bravo"})
+    output_path = Filler().fill_form("sample.pdf", llm)
+
+    assert output_path.endswith("_filled.pdf")
+    assert page_1.Annots[0].V == "alpha"
+    assert page_2.Annots[0].V == "bravo"
+    assert CaptureWriter.written is not None


### PR DESCRIPTION
## Summary
Fixes issue #8 where multi-page PDF autofill restarted answer mapping on each page.

## Root Cause
In `src/filler.py`, the answer index `i` was initialized inside the per-page loop, so page 2 started from the first answer again.

## Changes
- Moved `i = 0` outside the page loop in `src/filler.py`
- Kept a single running index across all pages
- Added regression test `tests/test_filler.py` to verify values continue correctly across pages

## Validation
- Reproduced old behavior:
  - page1: `alpha`
  - page2: `alpha` (incorrect)
- Verified fixed behavior:
  - page1: `alpha`
  - page2: `bravo` (correct)
  - `PASS = True`
- Compiled updated files successfully:
  - `src/filler.py`
  - `tests/test_filler.py`

## Files Changed
- `src/filler.py`
- `tests/test_filler.py`
