### PR TITLE
feat(api): add GET /templates/{template_id} endpoint with tests

### DIFF
--- a/api/routes/templates.py
+++ b/api/routes/templates.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 from api.deps import get_db
 from api.schemas.templates import TemplateCreate, TemplateResponse
-from api.db.repositories import create_template
+from api.db.repositories import create_template, get_template
 from api.db.models import Template
 from src.controller import Controller
 
@@ -14,3 +14,11 @@ def create(template: TemplateCreate, db: Session = Depends(get_db)):
     template_path = controller.create_template(template.pdf_path)
     tpl = Template(**template.model_dump(exclude={"pdf_path"}), pdf_path=template_path)
     return create_template(db, tpl)
+
+
+@router.get("/{template_id}", response_model=TemplateResponse)
+def get_template_by_id(template_id: int, db: Session = Depends(get_db)):
+    template = get_template(db, template_id)
+    if template is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return template

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -16,3 +16,37 @@ def test_create_template(client):
     response = client.post("/templates/create", json=payload)
 
     assert response.status_code == 200
+
+
+def test_get_template_by_id(client):
+    payload = {
+        "name": "Template 1",
+        "pdf_path": "src/inputs/file.pdf",
+        "fields": {
+            "Employee's name": "string",
+            "Employee's job title": "string",
+            "Employee's department supervisor": "string",
+            "Employee's phone number": "string",
+            "Employee's email": "string",
+            "Signature": "string",
+            "Date": "string",
+        },
+    }
+
+    create_response = client.post("/templates/create", json=payload)
+    template_id = create_response.json()["id"]
+
+    response = client.get(f"/templates/{template_id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == template_id
+    assert data["name"] == payload["name"]
+    assert data["fields"] == payload["fields"]
+
+
+def test_get_template_by_id_not_found(client):
+    response = client.get("/templates/999999")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Template not found"


### PR DESCRIPTION
Closes #160
Added [GET /templates/{template_id}] endpoint to fetch a template by ID.
Returns 404 when template is not found.

Added tests for:
successful fetch by ID
not-found behavior

Validation:
Ran source .venv/bin/activate && PYTHONPATH=. pytest -q
Result: 4 passed