### PR TITLE
feat(api): add GET /templates endpoint with pagination

### DIFF
--- a/api/db/repositories.py
+++ b/api/db/repositories.py
@@ -11,6 +11,10 @@ def create_template(session: Session, template: Template) -> Template:
 def get_template(session: Session, template_id: int) -> Template | None:
     return session.get(Template, template_id)
 
+def list_templates(session: Session, limit: int = 20, offset: int = 0) -> list[Template]:
+    statement = select(Template).order_by(Template.id).offset(offset).limit(limit)
+    return session.exec(statement).all()
+
 # Forms
 def create_form(session: Session, form: FormSubmission) -> FormSubmission:
     session.add(form)

--- a/api/routes/templates.py
+++ b/api/routes/templates.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 from api.deps import get_db
 from api.schemas.templates import TemplateCreate, TemplateResponse
-from api.db.repositories import create_template
+from api.db.repositories import create_template, list_templates
 from api.db.models import Template
 from src.controller import Controller
 
@@ -14,3 +14,12 @@ def create(template: TemplateCreate, db: Session = Depends(get_db)):
     template_path = controller.create_template(template.pdf_path)
     tpl = Template(**template.model_dump(exclude={"pdf_path"}), pdf_path=template_path)
     return create_template(db, tpl)
+
+
+@router.get("", response_model=list[TemplateResponse])
+def list_all_templates(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+):
+    return list_templates(db, limit=limit, offset=offset)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,6 @@
-def test_create_template(client):
-    payload = {
-        "name": "Template 1",
+def _template_payload(name: str):
+    return {
+        "name": name,
         "pdf_path": "src/inputs/file.pdf",
         "fields": {
             "Employee's name": "string",
@@ -13,6 +13,53 @@ def test_create_template(client):
         },
     }
 
+
+def test_list_templates_empty(client):
+    response = client.get("/templates")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_create_template(client):
+    payload = _template_payload("Template 1")
+
     response = client.post("/templates/create", json=payload)
 
     assert response.status_code == 200
+
+
+def test_list_templates_populated(client):
+    client.post("/templates/create", json=_template_payload("Template A"))
+    client.post("/templates/create", json=_template_payload("Template B"))
+
+    response = client.get("/templates")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 2
+    names = [item["name"] for item in data]
+    assert "Template A" in names
+    assert "Template B" in names
+
+
+def test_list_templates_pagination(client):
+    response_before = client.get("/templates")
+    existing = response_before.json()
+
+    client.post("/templates/create", json=_template_payload("Template Paginated 1"))
+    client.post("/templates/create", json=_template_payload("Template Paginated 2"))
+
+    first_page = client.get(f"/templates?limit=1&offset={len(existing)}")
+    second_page = client.get(f"/templates?limit=1&offset={len(existing) + 1}")
+
+    assert first_page.status_code == 200
+    assert second_page.status_code == 200
+
+    first_data = first_page.json()
+    second_data = second_page.json()
+
+    assert len(first_data) == 1
+    assert len(second_data) == 1
+    assert first_data[0]["id"] != second_data[0]["id"]


### PR DESCRIPTION
Adds template listing endpoint for API consumers.
Supports [limit] and [offset] pagination.
Adds tests for empty/populated/paginated results.
Keeps behavior backward-compatible with the existing create endpoint.


closes #162 