### PR TITLE
FIX: Make ollama smoke test optional during pytest collection

### DIFF
--- a/src/test/test_model.py
+++ b/src/test/test_model.py
@@ -1,10 +1,12 @@
-# test_ollama.py
-import ollama
+import pytest
 
-try:
-    response = ollama.chat(model='mistral', messages=[
-        {'role': 'user', 'content': 'Say hello in Spanish'}
-    ])
-    print("Success! Response:", response['message']['content'])
-except Exception as e:
-    print("Error:", e)
+
+def test_ollama_chat_smoke():
+    ollama = pytest.importorskip("ollama")
+    response = ollama.chat(
+        model="mistral",
+        messages=[{"role": "user", "content": "Say hello in Spanish"}],
+    )
+    assert "message" in response
+    assert "content" in response["message"]
+    assert response["message"]["content"]


### PR DESCRIPTION
### Description
This PR fixes test collection failures in clean environments where the optional ollama Python package is not installed.

Previously, src/test/test_model.py imported ollama at module import time, which caused pytest collection to fail with ModuleNotFoundError and prevented the rest of the suite from running. The test has been updated to use pytest-compatible optional dependency handling so environments without ollama skip this integration smoke test instead of failing collection.

Fixes #163 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
-Ran:
python -m pytest -q src/test/test_model.py

-Result:
1 skipped in 0.11s when ollama is not installed, confirming collection no longer errors and behavior is now optional.

## Test Configuration:
- Firmware version: N/A
- Hardware: Windows local machine
- SDK: N/A
- Python: 3.13+

### Checklist:
 

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code 
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [ ]  Any dependent changes have been merged and published in downstream modules