### PR TITLE
feat(api): add GET /forms/{submission_id} endpoint with tests

### DIFF
--- a/api/db/repositories.py
+++ b/api/db/repositories.py
@@ -17,3 +17,7 @@ def create_form(session: Session, form: FormSubmission) -> FormSubmission:
     session.commit()
     session.refresh(form)
     return form
+
+
+def get_form_submission(session: Session, submission_id: int) -> FormSubmission | None:
+    return session.get(FormSubmission, submission_id)

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 from api.deps import get_db
 from api.schemas.forms import FormFill, FormFillResponse
-from api.db.repositories import create_form, get_template
+from api.db.repositories import create_form, get_template, get_form_submission
 from api.db.models import FormSubmission
 from api.errors.base import AppError
 from src.controller import Controller
@@ -21,5 +21,13 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
 
     submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
     return create_form(db, submission)
+
+
+@router.get("/{submission_id}", response_model=FormFillResponse)
+def get_form_submission_by_id(submission_id: int, db: Session = Depends(get_db)):
+    submission = get_form_submission(db, submission_id)
+    if submission is None:
+        raise HTTPException(status_code=404, detail="Form submission not found")
+    return submission
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,25 +1,46 @@
-def test_submit_form(client):
-    pass
-    # First create a template
-    # form_payload = {
-    #     "template_id": 3,
-    #     "input_text": "Hi. The employee's name is John Doe. His job title is managing director. His department supervisor is Jane Doe. His phone number is 123456. His email is jdoe@ucsc.edu. The signature is <Mamañema>, and the date is 01/02/2005",
-    # }
+from src.controller import Controller
 
-    # template_res = client.post("/templates/", json=template_payload)
-    # template_id = template_res.json()["id"]
 
-    # # Submit a form
-    # form_payload = {
-    #     "template_id": template_id,
-    #     "data": {"rating": 5, "comment": "Great service"},
-    # }
+def _template_payload(name: str):
+    return {
+        "name": name,
+        "pdf_path": "src/inputs/file.pdf",
+        "fields": {
+            "Employee's name": "string",
+            "Employee's job title": "string",
+            "Employee's department supervisor": "string",
+            "Employee's phone number": "string",
+            "Employee's email": "string",
+            "Signature": "string",
+            "Date": "string",
+        },
+    }
 
-    # response = client.post("/forms/", json=form_payload)
 
-    # assert response.status_code == 200
+def test_get_form_submission_by_id(client, monkeypatch):
+    monkeypatch.setattr(Controller, "fill_form", lambda self, user_input, fields, pdf_form_path: "filled_test.pdf")
 
-    # data = response.json()
-    # assert data["id"] is not None
-    # assert data["template_id"] == template_id
-    # assert data["data"] == form_payload["data"]
+    template_response = client.post("/templates/create", json=_template_payload("Form Template"))
+    template_id = template_response.json()["id"]
+
+    fill_response = client.post(
+        "/forms/fill",
+        json={"template_id": template_id, "input_text": "test transcript"},
+    )
+    submission_id = fill_response.json()["id"]
+
+    response = client.get(f"/forms/{submission_id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == submission_id
+    assert data["template_id"] == template_id
+    assert data["input_text"] == "test transcript"
+    assert data["output_pdf_path"] == "filled_test.pdf"
+
+
+def test_get_form_submission_by_id_not_found(client):
+    response = client.get("/forms/999999")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Form submission not found"


### PR DESCRIPTION
This PR adds a new read endpoint to retrieve an existing form submission by ID, completes the missing retrieval path for form records, and adds focused tests to validate success and error behavior.

##What Changed -

1.) API Route

Added a new endpoint in api/routes/forms.py:
GET /forms/{submission_id}
Returns 200 with the submission payload when found
Returns 404 with a clear message when not found

2.) Repository Layer

Added a repository helper in api/db/repositories.py:
              get_form_submission(session, submission_id)
              direct primary-key lookup for efficient retrieval

3.) Tests

Replaced placeholder form tests with real endpoint tests in tests/test_forms.py:
       test_get_form_submission_by_id
       test_get_form_submission_by_id_not_found
Test design avoids external LLM/Ollama dependency by monkeypatching controller fill behavior, so tests remain fast and deterministic.

## Behaviour Before vs After -

Before

Submissions could be created via POST /forms/fill
No API endpoint existed to fetch a submission later by ID

After

Submissions can now be retrieved via GET /forms/{submission_id}
Clients can reliably fetch generated output metadata (including output_pdf_path)
Missing records return a consistent 404 response


##API Contract

GET /forms/{submission_id}
200 OK: returns FormFillResponse payload
404 Not Found: returns error detail "Form submission not found"


##Why This Change Matters

Completes a core CRUD read path for form submissions
Enables frontend/history/detail views to load a submission directly
Improves operational usability for follow-up access to generated form outputs
Keeps architecture aligned with existing repository + route separation

##Impact Assessment

Backward compatibility: Fully backward-compatible (additive endpoint only)
Risk level: Low
Performance impact: Minimal; single-row lookup by primary key
External dependency impact: None

##Validation Performed

Ran local test suite:
                                  source .venv/bin/activate && PYTHONPATH=. pytest -q
Result: 3 passed

##Files Included in This PR
api/routes/forms.py
api/db/repositories.py
tests/test_forms.py


##Out of Scope
No changes to fill pipeline logic
No schema model restructuring
No Docker/runtime config changes



closed #165 