### PR TITLE
#179- sanitize path outputs of template created and filled

### DIFF
--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -11,11 +11,19 @@ class FileManipulator:
 
     def create_template(self, pdf_path: str):
         """
-        By using commonforms, we create an editable .pdf template and we store it.
+        By using commonforms, we create an editable .pdf template securely in the OS temp directory.
         """
-        template_path = pdf_path[:-4] + "_template.pdf"
-        prepare_form(pdf_path, template_path)
-        return template_path
+        import tempfile
+        from pathlib import Path
+        
+        safe_original_name = Path(pdf_path).stem # Extracts just "file" from "../../../file.pdf"
+        
+        # mkstemp creates a highly secure, collision-proof temporary file
+        fd, temp_path = tempfile.mkstemp(suffix="_template.pdf", prefix=f"{safe_original_name}_")
+        os.close(fd) # Close the file descriptor so commonforms can write to it
+        
+        prepare_form(pdf_path, temp_path)
+        return temp_path
 
     def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
         """

--- a/src/filler.py
+++ b/src/filler.py
@@ -9,15 +9,20 @@ class Filler:
 
     def fill_form(self, pdf_form: str, llm: LLM):
         """
-        Fill a PDF form with values from user_input using LLM.
-        Fields are filled in the visual order (top-to-bottom, left-to-right).
+        Fill a PDF form with values from user_input using LLM safely.
         """
-        output_pdf = (
-            pdf_form[:-4]
-            + "_"
-            + datetime.now().strftime("%Y%m%d_%H%M%S")
-            + "_filled.pdf"
-        )
+        from pathlib import Path
+        
+        # 1. Sanitize the path to block traversal attacks
+        safe_name = Path(pdf_form).stem 
+        
+        # 2. Ensure a secure output directory exists
+        output_dir = Path("outputs")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        
+        # 3. Safely construct the final path
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_pdf = str(output_dir / f"{safe_name}_{timestamp}_filled.pdf")
 
         # Generate dictionary of answers from your original function
         t2j = llm.main_loop()

--- a/src/llm.py
+++ b/src/llm.py
@@ -46,7 +46,7 @@ class LLM:
 
     def main_loop(self):
         # self.type_check_all()
-        for field in self._target_fields.keys():
+        for field in self._target_fields:
             prompt = self.build_prompt(field)
             # print(prompt)
             # ollama_url = "http://localhost:11434/api/generate"

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+from typing import Union
 
 def input_fields(num_fields: int):
     fields = []
@@ -68,7 +69,7 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
 if __name__ == "__main__":
     file = "./src/inputs/file.pdf"
     user_input = "Hi. The employee's name is John Doe. His job title is managing director. His department supervisor is Jane Doe. His phone number is 123456. His email is jdoe@ucsc.edu. The signature is <Mamañema>, and the date is 01/02/2005"
-    fields = ["Employee's name", "Employee's job title", "Employee's department supervisor", "Employee's phone number", "Employee's email", "Signature", "Date"]
+    descriptive_fields = ["Employee's name", "Employee's job title", "Employee's department supervisor", "Employee's phone number", "Employee's email", "Signature", "Date"]
     prepared_pdf = "temp_outfile.pdf"
     prepare_form(file, prepared_pdf)
     
@@ -80,4 +81,4 @@ if __name__ == "__main__":
         num_fields = 0
         
     controller = Controller()
-    controller.fill_form(user_input, fields, file)
+    controller.fill_form(user_input, descriptive_fields, file)


### PR DESCRIPTION
Closes #179 

## 🚀 Description
Fixes path traversal vulnerabilities and secures temporary file storage. Replaced insecure string slicing with `pathlib` for safe filename extraction, and implemented `tempfile` to securely manage intermediate templates outside the project root.

## 🛠️ Changes Proposed
- **`src/file_manipulator.py`**: Switched to `tempfile.mkstemp()` to securely generate `_template.pdf` in the OS temp directory.
- **`src/filler.py`**: Replaced `[:-4]` with `pathlib.Path().stem` and added auto-routing for final PDFs into an isolated `outputs/` directory.

## ✅ PR Checklist
- [x] Path traversal vulnerability mitigated.
- [x] `outputs/` directory dynamically created if missing.
- [x] Temporary template files are no longer stored in the project root.