### PR TITLE
fix: docker crash on startup caused by missing OpenCV system libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy and install Python dependencies


### PR DESCRIPTION
Fixes #184 

## Problem
`python:3.11-slim` doesn't include libGL which cv2 requires, causing an 
immediate crash on startup:

ImportError: libGL.so.1: cannot open shared object file: No such file or directory

## Changes
Added to Dockerfile apt-get install:
- `libgl1` — provides libGL.so.1 required by cv2
- `libglib2.0-0` — glib dependencies also needed by cv2

## How to verify
1. `docker compose build --no-cache`
2. `docker compose up -d`
3. `docker exec -it fireform-app bash`
4. `python src/main.py` — should run past the import stage

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] Tested locally and verified fix works