### PR TITLE
fix: add missing Union import in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import os
+from typing import Union
 # from backend import Fill  
 from commonforms import prepare_form 
 from pypdf import PdfReader


### PR DESCRIPTION
Fixes #187

## Problem
`Union` is used as a type hint in run_pdf_fill_process() but was 
never imported, causing an immediate NameError on startup:

NameError: name 'Union' is not defined

## Changes
Added to src/main.py:
- `from typing import Union`

## How to verify
1. `docker compose up -d`
2. `docker exec -it fireform-app bash`
3. `python src/main.py`
4. App should run past line 14 without any NameError.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Self-reviewed my changes
- [x] No new warnings introduced
- [x] Tested locally and verified fix works