### PR TITLE
Add foreign key from FormSubmission.template_id to Template.id

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -12,7 +12,7 @@ class Template(SQLModel, table=True):
 
 class FormSubmission(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
-    template_id: int
+    template_id: int = Field(foreign_key="template.id")
     input_text: str
     output_pdf_path: str
     created_at: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
 Summary
Adds a database-level foreign key so `FormSubmission.template_id` must reference an existing `Template.id`, enforcing referential integrity and preventing orphan submissions.

 Changes
(`api/db/models.py`)  : Declared `FormSubmission.template_id` with `Field(foreign_key="template.id")` instead of a plain `int`.

Motivation
Previously, `template_id` had no FK constraint. The database could accept submissions pointing to non-existent or deleted templates. This PR ensures every submission references a valid template.

Testing
New databases created via `python -m api.db.init_db` include the constraint.
Inserting a `FormSubmission` with an invalid `template_id` is rejected by the DB.

Notes
Existing databases: Unchanged unless re-initialized. To apply the FK on an existing DB, you would need to recreate the schema or run a migration (e.g. new DB + export/import, or a migration script).
No API or request/response changes; behavior is backward compatible for valid data.

Fixes #194 