### PR TITLE
fix: Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pydantic
 sqlmodel
 pytest
 httpx
-numpy<2
+numpy>=2.0.0
 ollama

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+from typing import Union
 
 def input_fields(num_fields: int):
     fields = []


### PR DESCRIPTION
- Update numpy constraint to >=2.0.0 for Python 3.13 support
- Add missing Union import in main.py