### PR TITLE
Fix runtime errors in main.py (Union import, Fill reference, target_f…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import os
-# from backend import Fill  
+from typing import Union
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
@@ -11,7 +11,7 @@ def input_fields(num_fields: int):
         fields.append(field)
     return fields
 
-def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Union[str, os.PathLike]):
+def run_pdf_fill_process(user_input: str, definitions: Union[dict, list], pdf_form_path: Union[str, os.PathLike]):
     """
     This function is called by the frontend server.
     It receives the raw data, runs the PDF filling logic,
@@ -30,10 +30,11 @@ def run_pdf_fill_process(user_input: str, definitions: list, pdf_form_path: Unio
 
     print("[3] Starting extraction and PDF filling process...")
     try:
-        output_name = Fill.fill_form(
+        controller = Controller()
+        output_name = controller.fill_form(
             user_input=user_input,
-            definitions=definitions,
-            pdf_form=pdf_form_path
+            fields=definitions,
+            pdf_form_path=pdf_form_path
         )
         
         print("\n----------------------------------")


### PR DESCRIPTION
## Summary
This PR fixes several runtime errors in `src/main.py` that prevent the application from running correctly.

## Issues Fixed

### 1. Missing `Union` Import
`Union[str, os.PathLike]` was used in a type hint but `Union` was not imported from `typing`, causing a `NameError` during module import.

### 2. Invalid `Fill` Reference
The function `run_pdf_fill_process` called `Fill.fill_form(...)` while the `Fill` import was commented out.  
This resulted in a runtime `NameError`.

The implementation was updated to use the existing `Controller` class:

```python
controller = Controller()
controller.fill_form(...)
```
Fixes #218 