### PR TITLE
fix: Add missing libgl dependency resolving cv2 crash and expose API port (Fixes #223)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy and install Python dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: fireform-app
+    ports:
+      - "8000:8000"
     depends_on:
       ollama:
         condition: service_healthy


### PR DESCRIPTION
##  What does this PR do?
Fixes the out-of-the-box local development experience. The `python:3.11-slim` base image strips out several C libraries, leading to an immediate `ImportError: libGL.so.1` crash when starting the FastAPI server because `commonforms` relies on OpenCV. 

Additionally, port 8000 was not exposed in the docker compose file, preventing the host machine from hitting the API.

## Changes Made
- **`Dockerfile`:** Added `libgl1` and `libglib2.0-0` to the `apt-get` system dependencies.
- **`docker-compose.yml`:** Added `ports: - "8000:8000"` to the `app` service so developers can interact with the API endpoints locally.

## Testing Performed
- Ran `make build` successfully.
- Ran `make up`, successfully launched `uvicorn` inside the container without the OpenCV crash, and successfully routed a `POST` request from the host machine to `http://localhost:8000/templates/create`.
Fixes #224 