### PR TITLE
Test: Guard Fill invocation contract in main orchestration

### DIFF
--- a/src/test/test_main_invocation.py
+++ b/src/test/test_main_invocation.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_main_uses_static_fill_call():
+    """Guard against reintroducing constructor/call mismatch for Fill."""
+    main_path = Path(__file__).resolve().parents[1] / "main.py"
+    content = main_path.read_text(encoding="utf-8")
+
+    assert "Fill.fill_form(" in content
+    assert "Fill(user_input=user_input).fill_form(" not in content


### PR DESCRIPTION
## Summary
Adds a regression test to prevent reintroducing the `Fill` invocation mismatch in the PDF fill orchestration flow. Fix #226 

This issue can cause runtime failure if `src/main.py` calls:
Fill(user_input=user_input).fill_form(...)

### What Changed
- Added src/test/test_main_invocation.py
- Asserts src/main.py contains Fill.fill_form(
- Asserts broken pattern Fill(user_input=user_input).fill_form( is not present

### Why
The constructor/signature mismatch is a high-impact reliability risk that can crash the main report generation path with TypeError.
Even though the current code is already correct, this test ensures the bug does not regress in future edits.

### Validation
- Ran:
 -m pytest test_main_invocation.py -q

- Result:
1 passed

### Scope
Test-only change
No runtime behavior changes

