### PR TITLE
fix: correct json.DecodeError to json.JSONDecodeError in JsonManager

### DIFF
--- a/src/json_manager.py
+++ b/src/json_manager.py
@@ -11,7 +11,7 @@ class JsonManager():
         except FileNotFoundError:
             print(f"Warning: File not found at {path_to_file}. Returning empty list.")
             data = []
-        except json.DecodeError:
+        except json.JSONDecodeError:
             raise IOError(f"JSON file at {path_to_file} is corrupted.")
         
         return data


### PR DESCRIPTION
## Description

It fixes a critical bug in `JsonManager.load_json()` where the code tries to catch `json.DecodeError`, which doesn't exist in Python's json module. The correct exception is `json.JSONDecodeError`.

## Problem
Solves #237

## Solution

Changed line 13 in `src/json_manager.py`:
- `except json.DecodeError:` → `except json.JSONDecodeError:`

## Testing
Created and ran `test_json_manager_fix.py` - all 4 tests passes!