### PR TITLE
Fix - Prevent Orphaned DB Record

### DIFF
--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -1,8 +1,9 @@
+import os
 from fastapi import APIRouter, Depends
 from sqlmodel import Session
 from api.deps import get_db
 from api.schemas.forms import FormFill, FormFillResponse
-from api.db.repositories import create_form, get_template
+from api.db.repositories import get_template
 from api.db.models import FormSubmission
 from api.errors.base import AppError
 from src.controller import Controller
@@ -15,11 +16,36 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
         raise AppError("Template not found", status_code=404)
 
     fetched_template = get_template(db, form.template_id)
-
-    controller = Controller()
-    path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)
-
-    submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
-    return create_form(db, submission)
+    
+    try:
+        controller = Controller()
+        path = controller.fill_form(
+            user_input=form.input_text,
+            fields=fetched_template.fields,
+            pdf_form_path=fetched_template.pdf_path
+        )
+        
+        # Validate PDF file was created successfully
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"PDF generation failed: file not found at {path}")
+        
+        file_size = os.path.getsize(path)
+        if file_size == 0:
+            raise ValueError(f"PDF generation created empty file at {path}")
+        
+        # Create database record only after validation
+        submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
+        db.add(submission)
+        db.commit()
+        db.refresh(submission)
+        
+        return submission
+        
+    except (FileNotFoundError, ValueError) as e:
+        db.rollback()
+        raise AppError(f"PDF generation failed: {str(e)}", status_code=500)
+    except Exception as e:
+        db.rollback()
+        raise
 
 


### PR DESCRIPTION
## What I Found
I was testing form submissions and found something weird - the database kept saving records even when PDFs didn't actually get created. So you'd have a database entry saying "here's your PDF at /path/to/file.pdf" but the file doesn't exist.

Did some digging and the issue was in the fill_form endpoint. It calls controller.fill_form() to make the PDF, then immediately saves to database without checking if the file actually got created.
## What I Changed
My fix adds validation before the database commit - just checks if the file exists and isn't empty. If something went wrong with PDF generation, it rolls back the transaction instead of leaving bad data.
## Testing
Wrote some tests to make sure this doesn't break normal usage and actually prevents the orphaned records. The existing test suite still passes too.

Tries to fix: #251 
