### PR TITLE
feat: added configurable llm backend with multi-model support

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -1,9 +1,10 @@
+from typing import Optional
 from sqlmodel import SQLModel, Field
 from sqlalchemy import Column, JSON
 from datetime import datetime
 
 class Template(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
     name: str
     fields: dict = Field(sa_column=Column(JSON))
     pdf_path: str
@@ -11,7 +12,7 @@ class Template(SQLModel, table=True):
 
 
 class FormSubmission(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
     template_id: int
     input_text: str
     output_pdf_path: str

--- a/api/db/repositories.py
+++ b/api/db/repositories.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from sqlmodel import Session, select
 from api.db.models import Template, FormSubmission
 
@@ -8,7 +9,7 @@ def create_template(session: Session, template: Template) -> Template:
     session.refresh(template)
     return template
 
-def get_template(session: Session, template_id: int) -> Template | None:
+def get_template(session: Session, template_id: int) -> Optional[Template]:
     return session.get(Template, template_id)
 
 # Forms

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -17,7 +17,7 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
     fetched_template = get_template(db, form.template_id)
 
     controller = Controller()
-    path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)
+    path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path, model=form.model)
 
     submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
     return create_form(db, submission)

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -19,7 +19,7 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
     controller = Controller()
     path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path, model=form.model)
 
-    submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
+    submission = FormSubmission(**form.model_dump(exclude={"model"}), output_pdf_path=path)
     return create_form(db, submission)
 
 

--- a/api/schemas/forms.py
+++ b/api/schemas/forms.py
@@ -1,8 +1,10 @@
 from pydantic import BaseModel
+from typing import Optional
 
 class FormFill(BaseModel):
     template_id: int
     input_text: str
+    model: Optional[str] = None  # e.g. "mistral", "llama3", "phi3" — defaults to LLM_MODEL env var
 
 
 class FormFillResponse(BaseModel):

--- a/src/controller.py
+++ b/src/controller.py
@@ -4,8 +4,8 @@ class Controller:
     def __init__(self):
         self.file_manipulator = FileManipulator()
 
-    def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
-        return self.file_manipulator.fill_form(user_input, fields, pdf_form_path)
+    def fill_form(self, user_input: str, fields: list, pdf_form_path: str, model: str = None):
+        return self.file_manipulator.fill_form(user_input, fields, pdf_form_path, model=model)
     
     def create_template(self, pdf_path: str):
         return self.file_manipulator.create_template(pdf_path)

--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -1,7 +1,6 @@
 import os
 from src.filler import Filler
 from src.llm import LLM
-from commonforms import prepare_form
 
 
 class FileManipulator:
@@ -13,6 +12,7 @@ class FileManipulator:
         """
         By using commonforms, we create an editable .pdf template and we store it.
         """
+        from commonforms import prepare_form  # lazy import — only needed at runtime in Docker
         template_path = pdf_path[:-4] + "_template.pdf"
         prepare_form(pdf_path, template_path)
         return template_path

--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -17,7 +17,7 @@ class FileManipulator:
         prepare_form(pdf_path, template_path)
         return template_path
 
-    def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
+    def fill_form(self, user_input: str, fields: list, pdf_form_path: str, model: str = None):
         """
         It receives the raw data, runs the PDF filling logic,
         and returns the path to the newly created file.
@@ -27,12 +27,14 @@ class FileManipulator:
 
         if not os.path.exists(pdf_form_path):
             print(f"Error: PDF template not found at {pdf_form_path}")
-            return None  # Or raise an exception
+            return None
 
         print("[3] Starting extraction and PDF filling process...")
         try:
             self.llm._target_fields = fields
             self.llm._transcript_text = user_input
+            if model:
+                self.llm._model = model
             output_name = self.filler.fill_form(pdf_form=pdf_form_path, llm=self.llm)
 
             print("\n----------------------------------")

--- a/src/llm.py
+++ b/src/llm.py
@@ -49,6 +49,7 @@ class LLM:
 
     def main_loop(self):
         # self.type_check_all()
+        print(f"\t[LOG] Using model: {self._model}")
         for field in self._target_fields.keys():
             prompt = self.build_prompt(field)
             # print(prompt)

--- a/src/llm.py
+++ b/src/llm.py
@@ -2,14 +2,17 @@ import json
 import os
 import requests
 
+DEFAULT_MODEL = os.getenv("LLM_MODEL", "mistral")
+
 
 class LLM:
-    def __init__(self, transcript_text=None, target_fields=None, json=None):
+    def __init__(self, transcript_text=None, target_fields=None, json=None, model: str = None):
         if json is None:
             json = {}
         self._transcript_text = transcript_text  # str
         self._target_fields = target_fields  # List, contains the template field.
         self._json = json  # dictionary
+        self._model = model or DEFAULT_MODEL  # configurable LLM model
 
     def type_check_all(self):
         if type(self._transcript_text) is not str:
@@ -54,9 +57,9 @@ class LLM:
             ollama_url = f"{ollama_host}/api/generate"
 
             payload = {
-                "model": "mistral",
+                "model": self._model,
                 "prompt": prompt,
-                "stream": False,  # don't really know why --> look into this later.
+                "stream": False,
             }
 
             try:


### PR DESCRIPTION
## Summary
Closes #256  — adds configurable LLM backend so users can switch between models (Mistral, LLaMA3, Phi3, Gemma, etc.) without touching source code.

## Changes
- `src/llm.py` — added `model` param to `LLM.__init__()`, reads `LLM_MODEL` env var as default
- `src/file_manipulator.py` — `fill_form()` accepts and forwards `model` param
- `src/controller.py` — `fill_form()` accepts and forwards `model` param
- `api/schemas/forms.py` — added optional `model` field to `FormFill` request schema
- `api/routes/forms.py` — passes `model` from request through to controller

## How to test
1. Start Ollama with a non-Mistral model: `ollama pull llama3`
2. Send a POST to `/forms/fill` with `"model": "llama3"` in the body
3. Verify the correct model is used in Ollama logs
4. Alternatively set `LLM_MODEL=llama3` env var and omit `model` from the request

```bash
curl -X POST http://localhost:8000/forms/fill \
  -H "Content-Type: application/json" \
  -d '{"template_id": 1, "input_text": "John Doe, 01/02/2005", "model": "llama3"}'
```

## Checklist
- [x] `LLM` class accepts `model` parameter
- [x] Falls back to `LLM_MODEL` env var, then `mistral`
- [x] `model` is optional in the API — existing requests without it still work
- [x] `model` is excluded from `FormSubmission` DB dump (no schema migration needed)
- [x] No breaking changes to existing behaviour
- [x] Tested with at least 2 different Ollama models (manual step)

## Test verification

Tested locally with uvicorn + SQLite. Both requests confirmed via `[LOG] Using model:` in server output.

Request 1 — default model (no `model` field):
```bash
curl -X POST http://localhost:8000/forms/fill \
  -H "Content-Type: application/json" \
  -d '{"template_id": 1, "input_text": "The employee name is John Doe, date is 01/02/2005"}'
# Server log: [LOG] Using model: mistral
# Response: {"id":1,"template_id":1,"input_text":"...","output_pdf_path":"src/inputs/file_..._filled.pdf"}
```

Request 2 — explicit `llama3`:
```bash
curl -X POST http://localhost:8000/forms/fill \
  -H "Content-Type: application/json" \
  -d '{"template_id": 1, "input_text": "The employee name is John Doe, date is 01/02/2005", "model": "llama3"}'
# Server log: [LOG] Using model: llama3
# Response: {"id":2,"template_id":1,"input_text":"...","output_pdf_path":"src/inputs/file_..._filled.pdf"}
```

