### PR TITLE
Add forms route tests and register AppError handler

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI
+from api.errors.handlers import register_exception_handlers
 from api.routes import templates, forms
 
 app = FastAPI()
+register_exception_handlers(app)
 
 app.include_router(templates.router)
 app.include_router(forms.router)

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -11,10 +11,9 @@ router = APIRouter(prefix="/forms", tags=["forms"])
 
 @router.post("/fill", response_model=FormFillResponse)
 def fill_form(form: FormFill, db: Session = Depends(get_db)):
-    if not get_template(db, form.template_id):
-        raise AppError("Template not found", status_code=404)
-
     fetched_template = get_template(db, form.template_id)
+    if not fetched_template:
+        raise AppError("Template not found", status_code=404)
 
     controller = Controller()
     path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,25 +1,59 @@
-def test_submit_form(client):
-    pass
-    # First create a template
-    # form_payload = {
-    #     "template_id": 3,
-    #     "input_text": "Hi. The employee's name is John Doe. His job title is managing director. His department supervisor is Jane Doe. His phone number is 123456. His email is jdoe@ucsc.edu. The signature is <Mamañema>, and the date is 01/02/2005",
-    # }
+from src.controller import Controller
 
-    # template_res = client.post("/templates/", json=template_payload)
-    # template_id = template_res.json()["id"]
 
-    # # Submit a form
-    # form_payload = {
-    #     "template_id": template_id,
-    #     "data": {"rating": 5, "comment": "Great service"},
-    # }
+def test_submit_form(client, monkeypatch):
+    template_payload = {
+        "name": "Template 1",
+        "pdf_path": "src/inputs/file.pdf",
+        "fields": {
+            "Employee's name": "string",
+            "Employee's job title": "string",
+            "Employee's department supervisor": "string",
+            "Employee's phone number": "string",
+            "Employee's email": "string",
+            "Signature": "string",
+            "Date": "string",
+        },
+    }
 
-    # response = client.post("/forms/", json=form_payload)
+    def fake_create_template(self, pdf_path):
+        assert pdf_path == template_payload["pdf_path"]
+        return "src/inputs/file_template.pdf"
 
-    # assert response.status_code == 200
+    monkeypatch.setattr(Controller, "create_template", fake_create_template)
 
-    # data = response.json()
-    # assert data["id"] is not None
-    # assert data["template_id"] == template_id
-    # assert data["data"] == form_payload["data"]
+    template_res = client.post("/templates/create", json=template_payload)
+    assert template_res.status_code == 200
+    template_id = template_res.json()["id"]
+
+    form_payload = {
+        "template_id": template_id,
+        "input_text": "Hi. The employee's name is John Doe.",
+    }
+
+    def fake_fill_form(self, user_input, fields, pdf_form_path):
+        assert user_input == form_payload["input_text"]
+        assert fields == template_payload["fields"]
+        assert pdf_form_path == "src/inputs/file_template.pdf"
+        return "src/outputs/file_filled.pdf"
+
+    monkeypatch.setattr(Controller, "fill_form", fake_fill_form)
+
+    response = client.post("/forms/fill", json=form_payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] is not None
+    assert data["template_id"] == template_id
+    assert data["input_text"] == form_payload["input_text"]
+    assert data["output_pdf_path"] == "src/outputs/file_filled.pdf"
+
+
+def test_submit_form_returns_404_for_missing_template(client):
+    response = client.post(
+        "/forms/fill",
+        json={"template_id": 999999, "input_text": "Missing template test"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "Template not found"}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,4 +1,13 @@
-def test_create_template(client):
+from src.controller import Controller
+
+
+def test_create_template(client, monkeypatch):
+    def fake_create_template(self, pdf_path):
+        assert pdf_path == "src/inputs/file.pdf"
+        return "src/inputs/file_template.pdf"
+
+    monkeypatch.setattr(Controller, "create_template", fake_create_template)
+
     payload = {
         "name": "Template 1",
         "pdf_path": "src/inputs/file.pdf",
@@ -16,3 +25,8 @@ def test_create_template(client):
     response = client.post("/templates/create", json=payload)
 
     assert response.status_code == 200
+    data = response.json()
+    assert data["id"] is not None
+    assert data["name"] == payload["name"]
+    assert data["fields"] == payload["fields"]
+    assert data["pdf_path"] == "src/inputs/file_template.pdf"


### PR DESCRIPTION
## Summary

This PR improves route-level reliability around form submission.

### Changes
- register the custom `AppError` handler in `api/main.py`
- fetch the template only once in `/forms/fill`
- add route tests for:
  - successful `/forms/fill`
  - missing-template `/forms/fill` returning `404`
- strengthen `/templates/create` assertions

## Why

The forms route already raises `AppError` for missing templates, but the app was not registering the exception handler, so the intended API behavior was incomplete.

The existing `tests/test_forms.py` file was also still a stub, so the main submission path had no meaningful coverage.

## Testing

Added API tests using `monkeypatch` to isolate route behavior from:
- PDF processing
- Ollama/LLM calls
- file generation side effects

## Notes

I could not execute the test suite in the current local environment because no installed Python interpreter was available to `py`. The tests are written to run with the repository's normal Python or Docker setup.
