### PR TITLE
fix: filename generation with pathlib.stem instead of hardcoded [:-4]

### DIFF
--- a/src/filler.py
+++ b/src/filler.py
@@ -1,6 +1,7 @@
 from pdfrw import PdfReader, PdfWriter
 from src.llm import LLM
 from datetime import datetime
+from pathlib import Path
 
 
 class Filler:
@@ -12,12 +13,9 @@ class Filler:
         Fill a PDF form with values from user_input using LLM.
         Fields are filled in the visual order (top-to-bottom, left-to-right).
         """
-        output_pdf = (
-            pdf_form[:-4]
-            + "_"
-            + datetime.now().strftime("%Y%m%d_%H%M%S")
-            + "_filled.pdf"
-        )
+        # Use pathlib to properly handle any file extension
+        base_name = Path(pdf_form).stem
+        output_pdf = f"{base_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}_filled.pdf"
 
         # Generate dictionary of answers from your original function
         t2j = llm.main_loop()


### PR DESCRIPTION
Fixes #247

Changed the filename generation in `src/filler.py` to use `Path().stem` instead of slicing off the last 4 characters with `[:-4]`.

The old approach broke with files like `document.pdf.backup` or `contract_2024` (no extension). Now it properly handles any filename pattern and prevents name collisions.

Works correctly now whether you're processing ```.pdf```, ```.pdf.backup```, or files without extensions.