### PR TITLE
FIX BUG: Docker container is missing system libraries required for OpenCV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 FROM python:3.11-slim
 
 WORKDIR /app
@@ -6,6 +5,8 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy and install Python dependencies

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ __Contributors:__
 - Vincent Harkins (@vharkins1)
 - Marc Vergés (@marcvergees) 
 - Jan Sans
+
+.

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import os
+from typing import Union
 # from backend import Fill  
 from commonforms import prepare_form 
 from pypdf import PdfReader


### PR DESCRIPTION
Add the missing system packages to apt-get install in the Dockerfile:
RUN apt-get update && apt-get install -y \
 curl \
 libgl1 \
 libglib2.0-0 \
 && rm -rf [[/var/lib/apt/lists/*]]
[[BUG]: Docker container is missing system libraries required for OpenCV #275](https://github.com/fireform-core/FireForm/issues/275)
