### PR TITLE
fix: strip whitespace from all plural values in handle_plural_values

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -118,14 +118,8 @@ class LLM:
         print(
             f"\t[LOG]: Formating plural values for JSON, [For input {plural_value}]..."
         )
-        values = plural_value.split(";")
-
-        # Remove trailing leading whitespace
-        for i in range(len(values)):
-            current = i + 1
-            if current < len(values):
-                clean_value = values[current].lstrip()
-                values[current] = clean_value
+        # Split and strip whitespace from all values
+        values = [v.strip() for v in plural_value.split(";")]
 
         print(f"\t[LOG]: Resulting formatted list of values: {values}")
 


### PR DESCRIPTION
### Summary
Refactored the `handle_plural_values()` method to simplify plural value parsing and whitespace handling.

### Problem
The previous implementation used a manual loop to remove leading whitespace after splitting the string:

```python
values = plural_value.split(";")

for i in range(len(values)):
    current = i + 1
    if current < len(values):
        clean_value = values[current].lstrip()
        values[current] = clean_value
```
Fixes #283