### PR TITLE
Fixing error handling message when PDF generation fails

### DIFF
--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -19,6 +19,9 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
     controller = Controller()
     path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)
 
+    if not path:
+        raise AppError("PDF generation failed", status_code=400)
+
     submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
     return create_form(db, submission)
 


### PR DESCRIPTION
Closes #251
Before the  API returns a 500 Internal Server Error when PDF generation fails because output_pdf_path becomes None.
This changed and adds validation after controller.fill_form() and raises a proper 400 error instead, improving API reliability and in result of good user understanding.