### PR TITLE
fix: register exception handlers and fix handle_plural_values() white spaces

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 from api.routes import templates, forms
+from api.errors.handlers import register_exception_handlers
 
 app = FastAPI()
 
 app.include_router(templates.router)
 app.include_router(forms.router)
+
+register_exception_handlers(app)

--- a/src/llm.py
+++ b/src/llm.py
@@ -104,7 +104,7 @@ class LLM:
 
         return
 
-    def handle_plural_values(self, plural_value):
+    def handle_plural_values(self, plural_value: str) -> list[str]:
         """
         This method handles plural values.
         Takes in strings of the form 'value1; value2; value3; ...; valueN'
@@ -116,16 +116,10 @@ class LLM:
             )
 
         print(
-            f"\t[LOG]: Formating plural values for JSON, [For input {plural_value}]..."
+            f"\t[LOG]: Formatting plural values for JSON, [For input {plural_value}]..."
         )
-        values = plural_value.split(";")
 
-        # Remove trailing leading whitespace
-        for i in range(len(values)):
-            current = i + 1
-            if current < len(values):
-                clean_value = values[current].lstrip()
-                values[current] = clean_value
+        values = [v.strip() for v in plural_value.split(";") if v.strip()]
 
         print(f"\t[LOG]: Resulting formatted list of values: {values}")
 


### PR DESCRIPTION
 Two bug fixes to the LLM data extraction pipeline and API error handling.                                                                                                                                   
  1. src/llm.py: Fix whitespace stripping in handle_plural_values()
The previous loop started at index i+1, leaving values[0] (the first LLM-extracted value) never stripped. It also only applied lstrip(), missing trailing whitespace. Replaced with a list comprehension using str.strip() that correctly cleans all values and filters out empty entries from trailing semicolons. Also adds type hints (str -> list[str]) and fixes a typo in the log message.    
  2. api/main.py: Register custom exception handlers
Register_exception_handlers() was defined in api/errors/handlers.py but never called on app startup, so AppError exceptions (e.g. 404 for missing templates) were unhandled by FastAPI and returned as 500 errors instead of the intended status codes.

Issues:
  Fixes #283
  Fixes #295

  Type of change
  - Bug fix (non-breaking change which fixes an issue)

  How Has This Been Tested?
  - Manually verified handle_plural_values() edge cases: leading whitespace, trailing whitespace, trailing semicolons, normal input
  - Verified AppError with 404 status now returns correct response instead of 500

  Test Configuration:
  - Python: 3.x
  - OS: Windows 11

  Checklist:
  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - My changes generate no new warnings
  - New and existing unit tests pass locally with my changes