### PR TITLE
fix: register AppError handler, PDF validation, duplicate field crash, Pydantic V2, tests init, Dockerfile PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Set Python path so imports work correctly
-ENV PYTHONPATH=/app/src
+ENV PYTHONPATH=/app
 
 # Keep container running for interactive use
 CMD ["tail", "-f", "/dev/null"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 from api.routes import templates, forms
+from api.errors.handlers import register_exception_handlers
 
 app = FastAPI()
+
+register_exception_handlers(app)
 
 app.include_router(templates.router)
 app.include_router(forms.router)

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -17,7 +17,10 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
     fetched_template = get_template(db, form.template_id)
 
     controller = Controller()
-    path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)
+    try:
+        path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)
+    except FileNotFoundError:
+        raise AppError("Template PDF file not found on disk", status_code=404)
 
     submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
     return create_form(db, submission)

--- a/api/schemas/forms.py
+++ b/api/schemas/forms.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class FormFill(BaseModel):
     template_id: int
@@ -6,10 +6,9 @@ class FormFill(BaseModel):
 
 
 class FormFillResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     template_id: int
     input_text: str
     output_pdf_path: str
-
-    class Config:
-        from_attributes = True

--- a/api/schemas/templates.py
+++ b/api/schemas/templates.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class TemplateCreate(BaseModel):
     name: str
@@ -6,10 +6,9 @@ class TemplateCreate(BaseModel):
     fields: dict
 
 class TemplateResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
     pdf_path: str
     fields: dict
-
-    class Config:
-        from_attributes = True

--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -26,8 +26,7 @@ class FileManipulator:
         print(f"[2] PDF template path: {pdf_form_path}")
 
         if not os.path.exists(pdf_form_path):
-            print(f"Error: PDF template not found at {pdf_form_path}")
-            return None  # Or raise an exception
+            raise FileNotFoundError(f"PDF template not found at {pdf_form_path}")
 
         print("[3] Starting extraction and PDF filling process...")
         try:

--- a/src/filler.py
+++ b/src/filler.py
@@ -1,3 +1,4 @@
+import os
 from pdfrw import PdfReader, PdfWriter
 from src.llm import LLM
 from datetime import datetime
@@ -12,12 +13,8 @@ class Filler:
         Fill a PDF form with values from user_input using LLM.
         Fields are filled in the visual order (top-to-bottom, left-to-right).
         """
-        output_pdf = (
-            pdf_form[:-4]
-            + "_"
-            + datetime.now().strftime("%Y%m%d_%H%M%S")
-            + "_filled.pdf"
-        )
+        base, _ = os.path.splitext(pdf_form)
+        output_pdf = base + "_" + datetime.now().strftime("%Y%m%d_%H%M%S") + "_filled.pdf"
 
         # Generate dictionary of answers from your original function
         t2j = llm.main_loop()
@@ -29,13 +26,13 @@ class Filler:
         pdf = PdfReader(pdf_form)
 
         # Loop through pages
+        i = 0
         for page in pdf.pages:
             if page.Annots:
                 sorted_annots = sorted(
                     page.Annots, key=lambda a: (-float(a.Rect[1]), float(a.Rect[0]))
                 )
 
-                i = 0
                 for annot in sorted_annots:
                     if annot.Subtype == "/Widget" and annot.T:
                         if i < len(answers_list):

--- a/src/llm.py
+++ b/src/llm.py
@@ -60,12 +60,17 @@ class LLM:
             }
 
             try:
-                response = requests.post(ollama_url, json=payload)
+                response = requests.post(ollama_url, json=payload, timeout=60)
                 response.raise_for_status()
             except requests.exceptions.ConnectionError:
                 raise ConnectionError(
                     f"Could not connect to Ollama at {ollama_url}. "
                     "Please ensure Ollama is running and accessible."
+                )
+            except requests.exceptions.Timeout:
+                raise TimeoutError(
+                    f"Ollama request timed out after 60 seconds at {ollama_url}. "
+                    "The model may be overloaded or unavailable."
                 )
             except requests.exceptions.HTTPError as e:
                 raise RuntimeError(f"Ollama returned an error: {e}")

--- a/src/llm.py
+++ b/src/llm.py
@@ -102,8 +102,11 @@ class LLM:
         if ";" in value:
             parsed_value = self.handle_plural_values(value)
 
-        if field in self._json.keys():
-            self._json[field].append(parsed_value)
+        if field in self._json:
+            existing = self._json[field]
+            if not isinstance(existing, list):
+                existing = [existing]
+            self._json[field] = existing + [parsed_value]
         else:
             self._json[field] = parsed_value
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import os
-# from backend import Fill  
-from commonforms import prepare_form 
+from typing import Union
+# from backend import Fill
+from commonforms import prepare_form
 from pypdf import PdfReader
 from controller import Controller
 


### PR DESCRIPTION
Closes fireform-core#311, fireform-core#295, fireform-core#293, fireform-core#251, fireform-core#235, fireform-core#182, fireform-core#137, fireform-core#129, fireform-core#116, fireform-core#118

Description:
This PR fixes several bugs that were causing incorrect behavior across the API, data layer, and Docker environment. The fixes address unhandled exceptions returning 500 errors, silent data corruption in the database, a crash in the LLM response handler, Pydantic V2 deprecation warnings, missing test infrastructure, and a broken Docker PYTHONPATH.

Why is this needed?
Multiple routes were returning generic 500 errors instead of meaningful JSON error responses. The database was silently storing corrupt records when PDF generation failed. The LLM field handler would crash on duplicate fields. The Docker container's PYTHONPATH excluded the api package entirely, breaking all imports in a deployed environment.

Key Changes:
- AppError Handler Registration: register_exception_handlers(app) is now called in api/main.py before routers are included, so all AppError exceptions return proper JSON responses with the correct HTTP status codes instead of 500s.
- PDF File Validation: file_manipulator.py now raises FileNotFoundError instead of silently returning None when a PDF template doesn't exist on disk. The forms route catches this and raises an AppError(404), preventing corrupt FormSubmission records from being written to the database.
- Duplicate Field Crash Fix: add_response_to_json() in llm.py now safely converts a scalar value to a list before appending when the same field is processed more than once.
- Pydantic V2 Compatibility: Replaced the deprecated class Config: from_attributes = True pattern with model_config = ConfigDict(from_attributes=True) in FormFillResponse and TemplateResponse.
- Test Package Init: Added missing tests/init.py so pytest can discover and run tests correctly.
- Dockerfile PYTHONPATH: Fixed PYTHONPATH=/app/src → PYTHONPATH=/app so that api.* imports resolve correctly inside the container.


Type of Change
- 
Bug fix (non-breaking change which fixes an issue)


How Has This Been Tested?
- AppError handler: Send a POST to /forms/fill with a non-existent template_id. Expect 404 JSON response instead of 500.
- 
Stale template / missing PDF: Send a POST to /forms/fill with a valid template_id pointing to a deleted PDF file. Expect 404 JSON response and no new FormSubmission record in the database.
- 
Duplicate field crash: Process a transcript where the LLM returns a value for the same field more than once. No crash, values are collected into a list.


Pydantic warnings: Start the API server and confirm no PydanticDeprecatedSince20 warnings appear in the logs.

Tests: Run pytest tests/ from the project root. Tests are discovered and run without import errors.

Docker: Build and run the Docker container. Api.* imports resolve and the server starts correctly.

Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- My changes generate no new warnings
- New and existing unit tests pass locally with my changes