### PR TITLE
fix: resolve AttributeError when appending to existing field

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -98,7 +98,11 @@ class LLM:
             parsed_value = self.handle_plural_values(value)
 
         if field in self._json.keys():
-            self._json[field].append(parsed_value)
+            current_value = self._json[field]
+            if isinstance(current_value, list):
+                self._json[field].append(parsed_value)
+            else:
+                self._json[field] = [current_value, parsed_value]
         else:
             self._json[field] = parsed_value
 


### PR DESCRIPTION
### **SUMMARY**
Fixed `AttributeError: 'str' object has no attribute 'append'` in `src/llm.py`.

### **ISSUE**
The original code incorrectly assumed existing fields were always lists, whereas the first extracted value is a string.

### **SOLUTION**
This PR implements a type check using `isinstance` to handle the dynamic conversion from a single string to a list.

**Fixes #325**