### PR TITLE
Fix: prevent crash when appending to non-list JSON field

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -97,11 +97,13 @@ class LLM:
         if ";" in value:
             parsed_value = self.handle_plural_values(value)
 
-        if field in self._json.keys():
-            self._json[field].append(parsed_value)
-        else:
-            self._json[field] = parsed_value
-
+     if field in self._json:
+    if isinstance(self._json[field], list):
+        self._json[field].append(parsed_value)
+    else:
+        self._json[field] = [self._json[field], parsed_value]
+else:
+    self._json[field] = parsed_value
         return
 
     def handle_plural_values(self, plural_value):


### PR DESCRIPTION
### Description
Fixes a bug in `add_response_to_json()` where appending to an existing field crashes if the field is not a list.

### Problem
If a field already contains a string, calling `.append()` results in:
AttributeError: 'str' object has no attribute 'append'

### Solution
Added type checking to convert existing values into a list before appending.

### Related Issue
Closes #334