### PR TITLE
fix: lazy-load commonforms in FileManipulator

### DIFF
--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -1,7 +1,6 @@
 import os
 from src.filler import Filler
 from src.llm import LLM
-from commonforms import prepare_form
 
 
 class FileManipulator:
@@ -13,6 +12,13 @@ class FileManipulator:
         """
         By using commonforms, we create an editable .pdf template and we store it.
         """
+        try:
+            from commonforms import prepare_form
+        except ImportError:
+            raise RuntimeError(
+                "commonforms is not installed or has missing native dependencies (cv2, numpy, ultralytics). "
+                "Use the Docker image or install full dependencies."
+            ) from None
         template_path = pdf_path[:-4] + "_template.pdf"
         prepare_form(pdf_path, template_path)
         return template_path

--- a/tests/test_lazy_import.py
+++ b/tests/test_lazy_import.py
@@ -1,0 +1,61 @@
+import builtins
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _blocking_import(original_import):
+    def _imp(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "commonforms" or name.startswith("commonforms."):
+            raise ImportError("simulated: commonforms unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    return _imp
+
+
+def _commonforms_module_keys():
+    return [k for k in list(sys.modules) if k == "commonforms" or k.startswith("commonforms.")]
+
+
+def test_import_api_main_without_commonforms():
+    root = Path(__file__).resolve().parents[1]
+    code = r"""
+import builtins
+_real = builtins.__import__
+
+def _imp(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "commonforms" or name.startswith("commonforms."):
+        raise ImportError("simulated: commonforms unavailable")
+    return _real(name, globals, locals, fromlist, level)
+
+builtins.__import__ = _imp
+import api.main
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(root) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
+
+
+def test_create_template_raises_when_commonforms_missing(monkeypatch):
+    original_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", _blocking_import(original_import))
+    cf_keys = _commonforms_module_keys()
+    saved_cf = {k: sys.modules.pop(k) for k in cf_keys if k in sys.modules}
+    try:
+        from src.file_manipulator import FileManipulator
+
+        with pytest.raises(RuntimeError) as exc_info:
+            FileManipulator().create_template("dummy.pdf")
+        assert "commonforms" in str(exc_info.value)
+    finally:
+        sys.modules.update(saved_cf)


### PR DESCRIPTION
## Fix: Lazy-load forms in FileManipulator

### What and Why

While working with the project, I noticed that importing `api.main` was failing in environments where heavy dependencies like `cv2`, `numpy`, or `ultralytics` were not installed.

After checking, the issue was due to this top-level import in `file_manipulator.py '':

```python
from commonforms import prepare_form
```

Since `commonforms 'pulls in' and other native dependencies during import, it caused the app to crash immediately — even if that functionality was never used.

This mainly affects:

* fresh setups
* CI environments
* minimal Docker builds

### Fix

Moved the import inside `create_template()`since that's the only place it's actually needed.

Also added a try/except to catch `ImportError errors and raise a clearer `RuntimeError one with a helpful message.

Now the app can start normally without requiring full CV dependencies unless needed.

### Tests

Added `tests/test_lazy_import.py`:

* checked that `api.main` imports fine even if `commonforms it is blocked
* checked that `create_template()` raises proper error when dependency is missing

### Changes

* updated``
* added `tests/test_lazy_import.py`

### Impact

* avoids unnecessary crashes
* better experience for new contributors
* works better in CI / Docker setups

Solve #345 