### PR TITLE
feat(llm): add retry, timeout, and strict response validation for Ollama calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+tenacity>=8,<9
 pdfrw
 flask
 commonforms

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,9 +1,34 @@
 import json
 import os
 import requests
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+# Ollama HTTP API: transient failures and explicit timeouts
+OLLAMA_REQUEST_TIMEOUT = 10
+OLLAMA_MAX_ATTEMPTS = 5
+_RETRYABLE_HTTP_STATUSES = frozenset({500, 502, 503, 504})
+
+
+def _should_retry_ollama(exc: BaseException) -> bool:
+    if isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+        return True
+    if isinstance(exc, requests.exceptions.HTTPError):
+        resp = getattr(exc, "response", None)
+        if resp is not None and resp.status_code in _RETRYABLE_HTTP_STATUSES:
+            return True
+    return False
 
 
 class LLM:
+    """
+    Drives field-by-field extraction via the Ollama `/api/generate` endpoint.
+
+    Network calls use explicit timeouts, exponential backoff retries (up to
+    OLLAMA_MAX_ATTEMPTS) for connection errors, timeouts, and HTTP 5xx responses
+    (500, 502, 503, 504). Other HTTP errors fail immediately. Parsed values are
+    merged with `add_response_to_json` only after a successful response body parse.
+    """
+
     def __init__(self, transcript_text=None, target_fields=None, json=None):
         if json is None:
             json = {}
@@ -44,12 +69,34 @@ class LLM:
 
         return prompt
 
+    @retry(
+        stop=stop_after_attempt(OLLAMA_MAX_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        retry=retry_if_exception(_should_retry_ollama),
+        reraise=True,
+    )
+    def _post_ollama_generate(self, ollama_url: str, payload: dict) -> requests.Response:
+        response = requests.post(
+            ollama_url,
+            json=payload,
+            timeout=OLLAMA_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        return response
+
     def main_loop(self):
+        """
+        For each target field, call Ollama with retries on transient failures,
+        a bounded request timeout, and strict parsing before updating `_json`.
+
+        On failure, raises ConnectionError for unreachable hosts, RuntimeError for
+        timeouts and HTTP errors (with status in the message), or RuntimeError for
+        invalid JSON or missing `response` content—without calling
+        `add_response_to_json` for that field.
+        """
         # self.type_check_all()
         for field in self._target_fields.keys():
             prompt = self.build_prompt(field)
-            # print(prompt)
-            # ollama_url = "http://localhost:11434/api/generate"
             ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
             ollama_url = f"{ollama_host}/api/generate"
 
@@ -60,20 +107,51 @@ class LLM:
             }
 
             try:
-                response = requests.post(ollama_url, json=payload)
-                response.raise_for_status()
-            except requests.exceptions.ConnectionError:
+                response = self._post_ollama_generate(ollama_url, payload)
+            except requests.exceptions.ConnectionError as e:
                 raise ConnectionError(
-                    f"Could not connect to Ollama at {ollama_url}. "
+                    f"Could not connect to Ollama at {ollama_url} after "
+                    f"{OLLAMA_MAX_ATTEMPTS} attempt(s). "
                     "Please ensure Ollama is running and accessible."
-                )
+                ) from e
+            except requests.exceptions.Timeout as e:
+                raise RuntimeError(
+                    f"Ollama connection timed out after {OLLAMA_REQUEST_TIMEOUT}s "
+                    f"(url: {ollama_url}). The service may be overloaded or hung."
+                ) from e
             except requests.exceptions.HTTPError as e:
-                raise RuntimeError(f"Ollama returned an error: {e}")
+                resp = getattr(e, "response", None)
+                if resp is not None:
+                    code = resp.status_code
+                    reason = (getattr(resp, "reason", None) or "").strip()
+                    reason_part = f" {reason}" if reason else ""
+                    raise RuntimeError(
+                        f"Ollama returned HTTP {code}{reason_part} for {ollama_url}"
+                    ) from e
+                raise RuntimeError(
+                    f"Ollama returned an HTTP error for {ollama_url}: {e}"
+                ) from e
 
-            # parse response
-            json_data = response.json()
+            try:
+                json_data = response.json()
+            except json.JSONDecodeError as e:
+                raise RuntimeError(
+                    f"Ollama returned invalid JSON at {ollama_url}: {e}"
+                ) from e
+
+            if "response" not in json_data:
+                raise RuntimeError(
+                    f"Ollama JSON response missing 'response' key at {ollama_url}. "
+                    f"Keys present: {list(json_data.keys())}"
+                )
+
             parsed_response = json_data["response"]
-            # print(parsed_response)
+            if not isinstance(parsed_response, str):
+                raise RuntimeError(
+                    f"Ollama 'response' field must be a string at {ollama_url}, "
+                    f"got {type(parsed_response).__name__}"
+                )
+
             self.add_response_to_json(field, parsed_response)
 
         print("----------------------------------")

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -1,0 +1,145 @@
+"""Unit tests for LLM Ollama retry logic, timeouts, and error handling."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from src.llm import LLM, OLLAMA_MAX_ATTEMPTS, OLLAMA_REQUEST_TIMEOUT
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Tenacity uses time.sleep between retries; disable for fast tests."""
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+
+@pytest.fixture(autouse=True)
+def ollama_host_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+
+
+def _ok_json_response(body: dict) -> requests.Response:
+    r = requests.Response()
+    r.status_code = 200
+    r.encoding = "utf-8"
+    r._content = json.dumps(body).encode("utf-8")
+    return r
+
+
+def _http_error_response(status: int, reason: str = "") -> requests.Response:
+    r = requests.Response()
+    r.status_code = status
+    r.encoding = "utf-8"
+    r.reason = reason or {400: "Bad Request", 404: "Not Found", 500: "Internal Server Error"}.get(
+        status, "Error"
+    )
+    r._content = b'{"error":"fail"}'
+    return r
+
+
+@patch("src.llm.requests.post")
+def test_retries_connection_error_then_success(mock_post):
+    fails = [requests.exceptions.ConnectionError("refused")] * 2
+    fails.append(_ok_json_response({"response": "extracted"}))
+    mock_post.side_effect = fails
+
+    llm = LLM(transcript_text="hello world", target_fields={"field_a": None})
+    llm.main_loop()
+
+    assert mock_post.call_count == 3
+    assert llm.get_data()["field_a"] == "extracted"
+    for call in mock_post.call_args_list:
+        assert call.kwargs.get("timeout") == OLLAMA_REQUEST_TIMEOUT
+
+
+@patch("src.llm.requests.post")
+def test_timeout_exhausts_retries(mock_post):
+    mock_post.side_effect = requests.exceptions.Timeout()
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with pytest.raises(RuntimeError, match="Ollama connection timed out"):
+        llm.main_loop()
+
+    assert mock_post.call_count == OLLAMA_MAX_ATTEMPTS
+
+
+@patch("src.llm.requests.post")
+def test_http_500_then_200(mock_post):
+    mock_post.side_effect = [
+        _http_error_response(500),
+        _ok_json_response({"response": "ok"}),
+    ]
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+    llm.main_loop()
+
+    assert mock_post.call_count == 2
+    assert llm.get_data()["f"] == "ok"
+
+
+@pytest.mark.parametrize("status", [400, 404])
+@patch("src.llm.requests.post")
+def test_client_http_errors_do_not_retry(mock_post, status):
+    mock_post.return_value = _http_error_response(status)
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with pytest.raises(RuntimeError, match="Ollama returned HTTP"):
+        llm.main_loop()
+
+    assert mock_post.call_count == 1
+
+
+@patch("src.llm.requests.post")
+def test_invalid_json_does_not_call_add_response_to_json(mock_post):
+    r = requests.Response()
+    r.status_code = 200
+    r.encoding = "utf-8"
+    r._content = b"not-json{{{"
+    mock_post.return_value = r
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with patch.object(LLM, "add_response_to_json") as spy:
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            llm.main_loop()
+        spy.assert_not_called()
+
+
+@patch("src.llm.requests.post")
+def test_missing_response_key_does_not_call_add_response_to_json(mock_post):
+    mock_post.return_value = _ok_json_response({"not_response": "x"})
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with patch.object(LLM, "add_response_to_json") as spy:
+        with pytest.raises(RuntimeError, match="missing 'response' key"):
+            llm.main_loop()
+        spy.assert_not_called()
+
+
+@patch("src.llm.requests.post")
+def test_non_string_response_field_raises(mock_post):
+    mock_post.return_value = _ok_json_response({"response": 123})
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with patch.object(LLM, "add_response_to_json") as spy:
+        with pytest.raises(RuntimeError, match="must be a string"):
+            llm.main_loop()
+        spy.assert_not_called()
+
+
+@patch("src.llm.requests.post")
+def test_connection_error_exhausts_retries(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError("refused")
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with pytest.raises(ConnectionError, match="Could not connect to Ollama"):
+        llm.main_loop()
+
+    assert mock_post.call_count == OLLAMA_MAX_ATTEMPTS


### PR DESCRIPTION
## What and Why

LLM calls could fail or hang without recovery. There was no retry for transient failures and no timeout, so requests could block indefinitely. Errors were generic and responses were not strictly validated.

This affects:
- unstable network cases  
- Ollama not ready  
- CI or local runs  

## Fix

Added retry with exponential backoff (max 5 attempts).

Added timeout (10s).

Retry only on:
- ConnectionError  
- Timeout  
- HTTP 5xx  

No retry on 4xx.

Improved error messages for timeout, HTTP errors, and invalid responses.

Validated response before use and ensured `add_response_to_json` runs only after successful parsing.

![LLM retry flow](https://github.com/user-attachments/assets/31589acc-cda5-48b0-95d7-5a446e9f9d91)

## Tests

Added `tests/test_llm_resilience.py`:
- mock requests.post  
- retry then success  
- timeout case  
- 5xx retry  
- 4xx no retry  
- invalid JSON  
- missing/invalid response  
- connection failure  

## Changes

- updated `src/llm.py`  
- added `tests/test_llm_resilience.py`  
- added `tenacity`  

## Checklist

- [x] Tests added  
- [x] No breaking changes  
- [x] Error handling improved  

## Impact

- prevents hanging requests  
- improves reliability  
- clearer errors  
- safer handling  

