### PR TITLE
feat(api): standardize error handling and response schema

### DIFF
--- a/api/errors/base.py
+++ b/api/errors/base.py
@@ -1,4 +1,18 @@
+from typing import Any, Optional
+
+
 class AppError(Exception):
-    def __init__(self, message: str, status_code: int = 400):
+    """Application-level error mapped to a standardized API error response."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 400,
+        code: str = "APP_ERROR",
+        details: Optional[Any] = None,
+    ):
         self.message = message
         self.status_code = status_code
+        self.code = code
+        self.details = details
+        super().__init__(message)

--- a/api/errors/handlers.py
+++ b/api/errors/handlers.py
@@ -1,11 +1,93 @@
-from fastapi import Request
-from fastapi.responses import JSONResponse
-from api.errors.base import AppError
+from __future__ import annotations
 
-def register_exception_handlers(app):
-    @app.exception_handler(AppError)
-    async def app_error_handler(request: Request, exc: AppError):
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={"error": exc.message},
+import logging
+from typing import Any
+
+from fastapi import Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException
+
+from api.errors.base import AppError
+from api.schemas.error import error_body
+
+logger = logging.getLogger(__name__)
+
+_HTTP_STATUS_CODES: dict[int, str] = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_ALLOWED",
+    409: "CONFLICT",
+    422: "UNPROCESSABLE_ENTITY",
+    429: "TOO_MANY_REQUESTS",
+    500: "INTERNAL_SERVER_ERROR",
+    502: "BAD_GATEWAY",
+    503: "SERVICE_UNAVAILABLE",
+}
+
+
+def _normalize_http_detail(detail: Any) -> tuple[str, Any | None]:
+    if detail is None:
+        return "Request failed", None
+    if isinstance(detail, str):
+        return detail, None
+    if isinstance(detail, (list, dict)):
+        return "Request failed", detail
+    return str(detail), None
+
+
+def _code_for_http_status(status: int) -> str:
+    return _HTTP_STATUS_CODES.get(status, "HTTP_ERROR")
+
+
+def register_exception_handlers(app) -> None:
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        payload = error_body(
+            status_code=422,
+            code="VALIDATION_ERROR",
+            message="Request validation failed",
+            details=exc.errors(),
         )
+        return JSONResponse(status_code=422, content=payload)
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(
+        request: Request, exc: HTTPException
+    ) -> JSONResponse:
+        msg, details = _normalize_http_detail(exc.detail)
+        code = _code_for_http_status(exc.status_code)
+        payload = error_body(
+            status_code=exc.status_code,
+            code=code,
+            message=msg,
+            details=details,
+        )
+        return JSONResponse(status_code=exc.status_code, content=payload)
+
+    @app.exception_handler(AppError)
+    async def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
+        payload = error_body(
+            status_code=exc.status_code,
+            code=exc.code,
+            message=exc.message,
+            details=exc.details,
+        )
+        return JSONResponse(status_code=exc.status_code, content=payload)
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(
+        request: Request, exc: Exception
+    ) -> JSONResponse:
+        logger.exception("Unhandled exception: %s", exc)
+        payload = error_body(
+            status_code=500,
+            code="INTERNAL_ERROR",
+            message="An unexpected error occurred",
+            details=None,
+        )
+        return JSONResponse(status_code=500, content=payload)

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
-from api.routes import templates, forms
+
+from api.errors.handlers import register_exception_handlers
+from api.routes import forms, templates
 
 app = FastAPI()
+register_exception_handlers(app)
 
 app.include_router(templates.router)
 app.include_router(forms.router)

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -1,18 +1,42 @@
 from fastapi import APIRouter, Depends
 from sqlmodel import Session
-from api.deps import get_db
-from api.schemas.forms import FormFill, FormFillResponse
-from api.db.repositories import create_form, get_template
+
 from api.db.models import FormSubmission
+from api.db.repositories import create_form, get_template
+from api.deps import get_db
 from api.errors.base import AppError
+from api.schemas.error import ErrorResponse
+from api.schemas.forms import FormFill, FormFillResponse
 from src.controller import Controller
 
 router = APIRouter(prefix="/forms", tags=["forms"])
 
-@router.post("/fill", response_model=FormFillResponse)
+
+@router.post(
+    "/fill",
+    response_model=FormFillResponse,
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "description": "Template not found",
+        },
+        422: {
+            "model": ErrorResponse,
+            "description": "Request validation failed",
+        },
+        500: {
+            "model": ErrorResponse,
+            "description": "Unexpected server error",
+        },
+    },
+)
 def fill_form(form: FormFill, db: Session = Depends(get_db)):
     if not get_template(db, form.template_id):
-        raise AppError("Template not found", status_code=404)
+        raise AppError(
+            "Template not found",
+            status_code=404,
+            code="TEMPLATE_NOT_FOUND",
+        )
 
     fetched_template = get_template(db, form.template_id)
 

--- a/api/routes/templates.py
+++ b/api/routes/templates.py
@@ -1,15 +1,46 @@
+import os
+
 from fastapi import APIRouter, Depends
 from sqlmodel import Session
-from api.deps import get_db
-from api.schemas.templates import TemplateCreate, TemplateResponse
-from api.db.repositories import create_template
+
 from api.db.models import Template
+from api.db.repositories import create_template
+from api.deps import get_db
+from api.errors.base import AppError
+from api.schemas.error import ErrorResponse
+from api.schemas.templates import TemplateCreate, TemplateResponse
 from src.controller import Controller
 
 router = APIRouter(prefix="/templates", tags=["templates"])
 
-@router.post("/create", response_model=TemplateResponse)
+
+@router.post(
+    "/create",
+    response_model=TemplateResponse,
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "description": "Source PDF not found at the given path",
+        },
+        422: {
+            "model": ErrorResponse,
+            "description": "Request validation failed",
+        },
+        500: {
+            "model": ErrorResponse,
+            "description": "Unexpected server error",
+        },
+    },
+)
 def create(template: TemplateCreate, db: Session = Depends(get_db)):
+    if not os.path.isfile(template.pdf_path):
+        raise AppError(
+            "PDF file not found",
+            status_code=404,
+            code="PDF_NOT_FOUND",
+            details={"path": template.pdf_path},
+        )
+
     controller = Controller()
     template_path = controller.create_template(template.pdf_path)
     tpl = Template(**template.model_dump(exclude={"pdf_path"}), pdf_path=template_path)

--- a/api/schemas/common.py
+++ b/api/schemas/common.py
@@ -1,14 +1,8 @@
+from typing import Any
+
 from pydantic import BaseModel
-from typing import Any, Optional
+
 
 class SuccessResponse(BaseModel):
     success: bool = True
     data: Any
-
-class ErrorDetail(BaseModel):
-    code: str
-    message: str
-
-class ErrorResponse(BaseModel):
-    success: bool = False
-    error: ErrorDetail

--- a/api/schemas/error.py
+++ b/api/schemas/error.py
@@ -1,0 +1,35 @@
+"""Standard API error envelope for all JSON error responses."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    """Consistent JSON shape for every API error."""
+
+    status_code: int = Field(..., description="HTTP status code")
+    code: str = Field(..., description="Stable application error identifier")
+    message: str = Field(..., description="Human-readable summary")
+    details: Optional[Union[dict, list]] = Field(
+        None,
+        description="Extra context (e.g. validation errors)",
+    )
+
+
+def error_body(
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    details: Any = None,
+) -> dict:
+    """Serialize to JSON-compatible dict for JSONResponse."""
+    return ErrorResponse(
+        status_code=status_code,
+        code=code,
+        message=message,
+        details=details,
+    ).model_dump()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+tenacity>=8,<9
 pdfrw
 flask
 commonforms

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,9 +1,34 @@
 import json
 import os
 import requests
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+# Ollama HTTP API: transient failures and explicit timeouts
+OLLAMA_REQUEST_TIMEOUT = 10
+OLLAMA_MAX_ATTEMPTS = 5
+_RETRYABLE_HTTP_STATUSES = frozenset({500, 502, 503, 504})
+
+
+def _should_retry_ollama(exc: BaseException) -> bool:
+    if isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+        return True
+    if isinstance(exc, requests.exceptions.HTTPError):
+        resp = getattr(exc, "response", None)
+        if resp is not None and resp.status_code in _RETRYABLE_HTTP_STATUSES:
+            return True
+    return False
 
 
 class LLM:
+    """
+    Drives field-by-field extraction via the Ollama `/api/generate` endpoint.
+
+    Network calls use explicit timeouts, exponential backoff retries (up to
+    OLLAMA_MAX_ATTEMPTS) for connection errors, timeouts, and HTTP 5xx responses
+    (500, 502, 503, 504). Other HTTP errors fail immediately. Parsed values are
+    merged with `add_response_to_json` only after a successful response body parse.
+    """
+
     def __init__(self, transcript_text=None, target_fields=None, json=None):
         if json is None:
             json = {}
@@ -44,12 +69,34 @@ class LLM:
 
         return prompt
 
+    @retry(
+        stop=stop_after_attempt(OLLAMA_MAX_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=4, max=10),
+        retry=retry_if_exception(_should_retry_ollama),
+        reraise=True,
+    )
+    def _post_ollama_generate(self, ollama_url: str, payload: dict) -> requests.Response:
+        response = requests.post(
+            ollama_url,
+            json=payload,
+            timeout=OLLAMA_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        return response
+
     def main_loop(self):
+        """
+        For each target field, call Ollama with retries on transient failures,
+        a bounded request timeout, and strict parsing before updating `_json`.
+
+        On failure, raises ConnectionError for unreachable hosts, RuntimeError for
+        timeouts and HTTP errors (with status in the message), or RuntimeError for
+        invalid JSON or missing `response` content—without calling
+        `add_response_to_json` for that field.
+        """
         # self.type_check_all()
         for field in self._target_fields.keys():
             prompt = self.build_prompt(field)
-            # print(prompt)
-            # ollama_url = "http://localhost:11434/api/generate"
             ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
             ollama_url = f"{ollama_host}/api/generate"
 
@@ -60,20 +107,51 @@ class LLM:
             }
 
             try:
-                response = requests.post(ollama_url, json=payload)
-                response.raise_for_status()
-            except requests.exceptions.ConnectionError:
+                response = self._post_ollama_generate(ollama_url, payload)
+            except requests.exceptions.ConnectionError as e:
                 raise ConnectionError(
-                    f"Could not connect to Ollama at {ollama_url}. "
+                    f"Could not connect to Ollama at {ollama_url} after "
+                    f"{OLLAMA_MAX_ATTEMPTS} attempt(s). "
                     "Please ensure Ollama is running and accessible."
-                )
+                ) from e
+            except requests.exceptions.Timeout as e:
+                raise RuntimeError(
+                    f"Ollama connection timed out after {OLLAMA_REQUEST_TIMEOUT}s "
+                    f"(url: {ollama_url}). The service may be overloaded or hung."
+                ) from e
             except requests.exceptions.HTTPError as e:
-                raise RuntimeError(f"Ollama returned an error: {e}")
+                resp = getattr(e, "response", None)
+                if resp is not None:
+                    code = resp.status_code
+                    reason = (getattr(resp, "reason", None) or "").strip()
+                    reason_part = f" {reason}" if reason else ""
+                    raise RuntimeError(
+                        f"Ollama returned HTTP {code}{reason_part} for {ollama_url}"
+                    ) from e
+                raise RuntimeError(
+                    f"Ollama returned an HTTP error for {ollama_url}: {e}"
+                ) from e
 
-            # parse response
-            json_data = response.json()
+            try:
+                json_data = response.json()
+            except json.JSONDecodeError as e:
+                raise RuntimeError(
+                    f"Ollama returned invalid JSON at {ollama_url}: {e}"
+                ) from e
+
+            if "response" not in json_data:
+                raise RuntimeError(
+                    f"Ollama JSON response missing 'response' key at {ollama_url}. "
+                    f"Keys present: {list(json_data.keys())}"
+                )
+
             parsed_response = json_data["response"]
-            # print(parsed_response)
+            if not isinstance(parsed_response, str):
+                raise RuntimeError(
+                    f"Ollama 'response' field must be a string at {ollama_url}, "
+                    f"got {type(parsed_response).__name__}"
+                )
+
             self.add_response_to_json(field, parsed_response)
 
         print("----------------------------------")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,4 +36,5 @@ def create_test_db():
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    # Return HTTP error bodies (e.g. 500 from global handler) instead of re-raising.
+    return TestClient(app, raise_server_exceptions=False)

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,75 @@
+"""Tests for standardized API error responses and global exception handlers."""
+
+import json
+
+
+def _assert_error_envelope(data: dict) -> None:
+    assert "status_code" in data
+    assert "code" in data
+    assert "message" in data
+    assert "details" in data
+
+
+def test_validation_error_returns_standard_shape(client):
+    response = client.post("/forms/fill", json={})
+    assert response.status_code == 422
+    data = response.json()
+    _assert_error_envelope(data)
+    assert data["code"] == "VALIDATION_ERROR"
+    assert data["status_code"] == 422
+    assert isinstance(data["details"], list)
+
+
+def test_template_not_found_returns_code(client):
+    response = client.post(
+        "/forms/fill",
+        json={"template_id": 999999, "input_text": "hello"},
+    )
+    assert response.status_code == 404
+    data = response.json()
+    _assert_error_envelope(data)
+    assert data["code"] == "TEMPLATE_NOT_FOUND"
+    assert data["message"] == "Template not found"
+    assert data["details"] is None
+
+
+def test_unknown_route_returns_not_found(client):
+    response = client.get("/this-route-does-not-exist")
+    assert response.status_code == 404
+    data = response.json()
+    _assert_error_envelope(data)
+    assert data["code"] == "NOT_FOUND"
+    assert data["status_code"] == 404
+
+
+def test_unhandled_exception_does_not_leak_internals(monkeypatch, client):
+    def boom(*args, **kwargs):
+        raise RuntimeError("secret-internal-token")
+
+    monkeypatch.setattr("api.routes.forms.get_template", boom)
+
+    response = client.post(
+        "/forms/fill",
+        json={"template_id": 1, "input_text": "hello"},
+    )
+    assert response.status_code == 500
+    data = response.json()
+    _assert_error_envelope(data)
+    assert data["code"] == "INTERNAL_ERROR"
+    assert "secret" not in json.dumps(data)
+
+
+def test_pdf_not_found_returns_pdf_not_found(client):
+    response = client.post(
+        "/templates/create",
+        json={
+            "name": "n",
+            "pdf_path": "/nonexistent/path/that/does/not/exist.pdf",
+            "fields": {},
+        },
+    )
+    assert response.status_code == 404
+    data = response.json()
+    assert data["code"] == "PDF_NOT_FOUND"
+    assert data["details"] is not None
+    assert "path" in data["details"]

--- a/tests/test_llm_resilience.py
+++ b/tests/test_llm_resilience.py
@@ -1,0 +1,145 @@
+"""Unit tests for LLM Ollama retry logic, timeouts, and error handling."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from src.llm import LLM, OLLAMA_MAX_ATTEMPTS, OLLAMA_REQUEST_TIMEOUT
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Tenacity uses time.sleep between retries; disable for fast tests."""
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+
+@pytest.fixture(autouse=True)
+def ollama_host_env(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+
+
+def _ok_json_response(body: dict) -> requests.Response:
+    r = requests.Response()
+    r.status_code = 200
+    r.encoding = "utf-8"
+    r._content = json.dumps(body).encode("utf-8")
+    return r
+
+
+def _http_error_response(status: int, reason: str = "") -> requests.Response:
+    r = requests.Response()
+    r.status_code = status
+    r.encoding = "utf-8"
+    r.reason = reason or {400: "Bad Request", 404: "Not Found", 500: "Internal Server Error"}.get(
+        status, "Error"
+    )
+    r._content = b'{"error":"fail"}'
+    return r
+
+
+@patch("src.llm.requests.post")
+def test_retries_connection_error_then_success(mock_post):
+    fails = [requests.exceptions.ConnectionError("refused")] * 2
+    fails.append(_ok_json_response({"response": "extracted"}))
+    mock_post.side_effect = fails
+
+    llm = LLM(transcript_text="hello world", target_fields={"field_a": None})
+    llm.main_loop()
+
+    assert mock_post.call_count == 3
+    assert llm.get_data()["field_a"] == "extracted"
+    for call in mock_post.call_args_list:
+        assert call.kwargs.get("timeout") == OLLAMA_REQUEST_TIMEOUT
+
+
+@patch("src.llm.requests.post")
+def test_timeout_exhausts_retries(mock_post):
+    mock_post.side_effect = requests.exceptions.Timeout()
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with pytest.raises(RuntimeError, match="Ollama connection timed out"):
+        llm.main_loop()
+
+    assert mock_post.call_count == OLLAMA_MAX_ATTEMPTS
+
+
+@patch("src.llm.requests.post")
+def test_http_500_then_200(mock_post):
+    mock_post.side_effect = [
+        _http_error_response(500),
+        _ok_json_response({"response": "ok"}),
+    ]
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+    llm.main_loop()
+
+    assert mock_post.call_count == 2
+    assert llm.get_data()["f"] == "ok"
+
+
+@pytest.mark.parametrize("status", [400, 404])
+@patch("src.llm.requests.post")
+def test_client_http_errors_do_not_retry(mock_post, status):
+    mock_post.return_value = _http_error_response(status)
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with pytest.raises(RuntimeError, match="Ollama returned HTTP"):
+        llm.main_loop()
+
+    assert mock_post.call_count == 1
+
+
+@patch("src.llm.requests.post")
+def test_invalid_json_does_not_call_add_response_to_json(mock_post):
+    r = requests.Response()
+    r.status_code = 200
+    r.encoding = "utf-8"
+    r._content = b"not-json{{{"
+    mock_post.return_value = r
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with patch.object(LLM, "add_response_to_json") as spy:
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            llm.main_loop()
+        spy.assert_not_called()
+
+
+@patch("src.llm.requests.post")
+def test_missing_response_key_does_not_call_add_response_to_json(mock_post):
+    mock_post.return_value = _ok_json_response({"not_response": "x"})
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with patch.object(LLM, "add_response_to_json") as spy:
+        with pytest.raises(RuntimeError, match="missing 'response' key"):
+            llm.main_loop()
+        spy.assert_not_called()
+
+
+@patch("src.llm.requests.post")
+def test_non_string_response_field_raises(mock_post):
+    mock_post.return_value = _ok_json_response({"response": 123})
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with patch.object(LLM, "add_response_to_json") as spy:
+        with pytest.raises(RuntimeError, match="must be a string"):
+            llm.main_loop()
+        spy.assert_not_called()
+
+
+@patch("src.llm.requests.post")
+def test_connection_error_exhausts_retries(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError("refused")
+
+    llm = LLM(transcript_text="hello", target_fields={"f": None})
+
+    with pytest.raises(ConnectionError, match="Could not connect to Ollama"):
+        llm.main_loop()
+
+    assert mock_post.call_count == OLLAMA_MAX_ATTEMPTS


### PR DESCRIPTION
## What and Why

API error responses were inconsistent across the application, with different formats used for validation errors, HTTP exceptions, and custom application errors. Exception handlers were also not consistently registered, leading to unclear and sometimes default FastAPI behaviour.

This made it difficult for clients to rely on a stable response structure and increased the complexity of debugging and integration.

## Fix

Introduced a unified error response format for all API errors:

{
  "status_code": int,
  "code": string,
  "message": string,
  "details": optional
}

Implemented global exception handlers to normalize:

- validation errors (422 → VALIDATION_ERROR)  
- HTTP exceptions (mapped to status codes)  
- application errors (AppError)  
- unexpected exceptions (500 → INTERNAL_ERROR, without exposing internal details)  

Registered handlers in `api/main.py`.

Extended `AppError` to support optional `code` and `details` while maintaining backward compatibility.

Updated routes to use standardised error handling and added explicit OpenAPI error responses.

## Tests

Added `tests/test_api_errors.py` covering:

- validation errors (422)  
- template not found (404)  
- unknown route (404)  
- PDF not found  
- safe 500 responses  

Configured `TestClient` to return error responses instead of raising exceptions.

## Changes

- added `api/schemas/error.py`  
- updated `api/errors/base.py`  
- updated `api/errors/handlers.py`  
- updated `api/main.py`  
- updated routes  
- updated `api/schemas/common.py`  
- added `tests/test_api_errors.py`  
- updated `tests/conftest.py`  

## Impact

- consistent and predictable API error responses  
- improved client integration with machine-readable error codes  
- safer error handling without leaking internal details  
- improved testability and debugging  
