### PR TITLE
Fix: Import Union from typing to fix runtime error

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+from typing import Union
 
 def input_fields(num_fields: int):
     fields = []


### PR DESCRIPTION
This PR fixes a runtime error caused by a missing import of `Union` from the `typing` module in `src/main.py`.

Without this import, the application fails when executing the `run_pdf_fill_process` function due to unresolved type hints.

This change ensures proper type resolution and prevents execution failure.