### PR TITLE
Fix: Prevent crash in add_response_to_json when appending to non-list fields

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -97,8 +97,12 @@ class LLM:
         if ";" in value:
             parsed_value = self.handle_plural_values(value)
 
-        if field in self._json.keys():
-            self._json[field].append(parsed_value)
+        if field in self._json:
+            if isinstance(self._json[field], list):
+                self._json[field].append(parsed_value)
+            else:
+        # Convert existing value to list
+                self._json[field] = [self._json[field], parsed_value]
         else:
             self._json[field] = parsed_value
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+from typing import Union
 
 def input_fields(num_fields: int):
     fields = []


### PR DESCRIPTION
This PR fixes a crash in add_response_to_json where the code assumes all existing fields are lists.
If a field already exists as a non-list type (e.g., string or int), calling .append() causes a runtime error.
This fix checks the type of the existing field:
- If it's a list → append normally
- If not → convert it into a list and then append

This ensures robust handling of mixed data types and prevents runtime crashes.