### PR TITLE
fix: remove unused flask dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 requests
 pdfrw
-flask
 commonforms
 fastapi
 uvicorn


### PR DESCRIPTION
## What

Removed `flask` from `requirements.txt` — it's not imported anywhere in the codebase.

## Why

The API is built entirely on FastAPI + Uvicorn. `flask` appears to be a leftover from the original hackathon version. Having it listed alongside `fastapi` is confusing for new contributors, and it pulls in unnecessary sub-dependencies (Werkzeug, Jinja2, MarkupSafe, etc.) that bloat the Docker image.

## Verification

- Ran `grep -r "flask" --include="*.py" .` from the project root → zero matches
- Confirmed `api/main.py` uses `from fastapi import FastAPI`
- No other file references Flask in any way

Fixes #370