### PR TITLE
fix: make SQL echo configurable via env var instead of hardcoded True

### DIFF
--- a/api/db/database.py
+++ b/api/db/database.py
@@ -1,10 +1,12 @@
+import os
+
 from sqlmodel import create_engine, Session
 
 DATABASE_URL = "sqlite:///./fireform.db"
 
 engine = create_engine(
     DATABASE_URL,
-    echo=True,
+    echo=os.getenv("SQL_DEBUG", "false").lower() == "true",
     connect_args={"check_same_thread": False},
 )
 


### PR DESCRIPTION
## What

Replaced hardcoded `echo=True` in `api/db/database.py` with an env var toggle (`SQL_DEBUG`). SQL echo is now off by default.

## Why

`echo=True` prints every SQL query to stdout on every API request. This was probably left on from debugging but it makes the terminal output really noisy, especially when you're trying to debug something else. It also leaks query details which isn't great.

## Changes

```python
# Before
echo=True,

# After
echo=os.getenv("SQL_DEBUG", "false").lower() == "true",
```

To enable SQL logging when needed, just set the env var:
```bash
SQL_DEBUG=true uvicorn api.main:app --reload
```

## Testing

- Verified SQL output is silent by default (no env var set)
- Verified `SQL_DEBUG=true` enables SQL logging as expected
- No other files depend on this setting

Fixes #372