### PR TITLE
Optimize fill_form by removing redundant get_template calls

### DIFF
--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -11,13 +11,17 @@ router = APIRouter(prefix="/forms", tags=["forms"])
 
 @router.post("/fill", response_model=FormFillResponse)
 def fill_form(form: FormFill, db: Session = Depends(get_db)):
-    if not get_template(db, form.template_id):
-        raise AppError("Template not found", status_code=404)
-
     fetched_template = get_template(db, form.template_id)
 
+    if not fetched_template:
+        raise AppError("Template not found", status_code=404)
+
     controller = Controller()
-    path = controller.fill_form(user_input=form.input_text, fields=fetched_template.fields, pdf_form_path=fetched_template.pdf_path)
+    path = controller.fill_form(
+        user_input=form.input_text,
+        fields=fetched_template.fields,
+        pdf_form_path=fetched_template.pdf_path
+    )
 
     submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
     return create_form(db, submission)


### PR DESCRIPTION
This PR addresses inefficiency in the `fill_form` endpoint by removing redundant database calls.
Closes #374 
## Summary

Optimized the `fill_form` endpoint by removing redundant calls to `get_template()`.

## Problem

The current implementation calls `get_template()` twice:

* Once to check if the template exists
* Again to fetch the template data

```python
if not get_template(db, form.template_id):
    raise AppError("Template not found", status_code=404)

fetched_template = get_template(db, form.template_id)
```

This results in unnecessary database queries and reduced efficiency.

## Solution

Refactored the code to call `get_template()` only once and reuse the result:

```python
fetched_template = get_template(db, form.template_id)

if not fetched_template:
    raise AppError("Template not found", status_code=404)
```

## Benefits

* Eliminates redundant database calls
* Improves performance
* Enhances code readability and maintainability

## Additional Notes

This optimization reduces database load and improves endpoint efficiency, especially under repeated usage.
This change does not alter functionality but improves the efficiency of the endpoint by avoiding duplicate queries.

I’d be happy to extend this optimization to similar patterns across the codebase if needed.