### PR TITLE
fix: point make test to tests/ instead of src/test/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ pull-model:
 	docker compose exec ollama ollama pull mistral
 
 test:
-	docker compose exec app python3 -m pytest src/test/
+	docker compose exec app python3 -m pytest tests/
 
 clean:
 	docker compose down -v


### PR DESCRIPTION
## What

Changed the `make test` target in the Makefile from `src/test/` to `tests/`.

## Why

`make test` was running `pytest src/test/`, which only contains `test_model.py` — a manual smoke test script with no assertions. The actual test suite (`conftest.py`, `test_forms.py`, `test_templates.py`) lives in the root `tests/` directory and was being silently skipped.

## Changes

```diff
 test:
-	docker compose exec app python3 -m pytest src/test/
+	docker compose exec app python3 -m pytest tests/
```

## Testing

- Verified `tests/` contains the real pytest suite with fixtures and API test cases
- Verified `src/test/test_model.py` has no pytest assertions (just print + try/except)

Fixes #380