### PR TITLE
fix: add pull-model to make fireform so Mistral is pulled during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:
 	@echo "make clean        - Remove containers"
 	@echo "make super-clean  - [CAUTION] Use carefully. Cleans up ALL stopped  containers, networks, build cache..."
 
-fireform: build up
+fireform: build up pull-model
 	@echo "Launching interactive shell in the app container..."
 	docker compose exec app /bin/bash
 


### PR DESCRIPTION
**Title:**
```
fix: add pull-model to make fireform target
```

**Body:**
```
## What

Added `pull-model` as a dependency to the `fireform` Makefile target so the Mistral model gets pulled automatically during setup.

## Why

`make fireform` is listed as the primary setup command in `make help`, but it only ran [build](cci:1://file:///Users/abhishekkumar/FireForm/src/llm.py:25:4-44:21) and `up` without pulling the model. Running `python3 src/main.py` after setup would hang and fail because Mistral was not available.

`container-init.sh` already includes `make pull-model` in its flow, so this just brings `make fireform` in line with that.

## Changes

```diff
-fireform: build up
+fireform: build up pull-model
```

## Testing

- Verified the dependency chain: build -> up -> pull-model -> shell
- Confirmed container-init.sh uses the same sequence

Fixes #382
```