### PR TITLE
fix: resolve NameError and import pathing in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,8 @@
 import os
-# from backend import Fill  
-from commonforms import prepare_form 
+from typing import Union
+from commonforms import prepare_form
 from pypdf import PdfReader
-from controller import Controller
+from src.controller import Controller
 
 def input_fields(num_fields: int):
     fields = []


### PR DESCRIPTION
## Description
This PR fixes two critical bugs in `src/main.py` that prevented the script from running successfully in a standard environment.

## Changes
1. **Fixed `NameError`:** Added `from typing import Union`. The `Union` type hint was used on line 14 but was never imported, causing the script to crash immediately upon execution.
2. **Fixed Import Pathing:** Changed `from controller import Controller` to `from src.controller import Controller`. This ensures the script can be run from the project root directory (standard practice) without triggering a `ModuleNotFoundError`.

## How to Verify
Before this fix, running `python3 src/main.py` from the root would result in:
- `NameError: name 'Union' is not defined`
- `ModuleNotFoundError: No module named 'controller'`

After this fix, the script successfully imports all dependencies and initializes the `Controller`.
Fixes #388 
