### PR TITLE
feat(#131): checkpointed pipeline + fix import path issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 
 FROM python:3.11-slim
 
+RUN apt-get update && apt-get install -y \
+    libgl1 \
+    libglib2.0-0
+
 WORKDIR /app
 
 # Install system dependencies
@@ -16,7 +20,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Set Python path so imports work correctly
-ENV PYTHONPATH=/app/src
+ENV PYTHONPATH=/app:/app/src
 
 # Keep container running for interactive use
 CMD ["tail", "-f", "/dev/null"]

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ pull-model:
 	docker compose exec ollama ollama pull mistral
 
 test:
-	docker compose exec app python3 -m pytest src/test/
+	docker compose exec app python3 -m pytest tests/
 
 clean:
 	docker compose down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - .:/app
     environment:
       - PYTHONUNBUFFERED=1
-      - PYTHONPATH=/app/src
+      - PYTHONPATH=/app:/app/src
       - OLLAMA_HOST=http://ollama:11434
     networks:
       - fireform-network

--- a/docs/session_resuming.md
+++ b/docs/session_resuming.md
@@ -1,0 +1,105 @@
+# Session Resuming & Checkpointing
+
+## Overview
+
+In this pull request, FireForm's LLM extraction pipeline supports **stateful resumption**. If an extraction run is interrupted (container crash, Ollama timeout, manual `Ctrl+C`),  progress is saved after every successfully extracted field. The next run with the same transcript and target fields picks up where it left off.
+
+## How It Works
+
+### 1. Session ID
+
+At the start of `main_loop()`, a unique `session_id` is computed as an MD5
+hash of both the transcript text and the sorted field names. 
+
+Hashing both inputs means the same transcript run against two different form
+templates produces two separate checkpoints. 
+
+### 2. State File Location
+
+Progress is stored at:
+```
+$FIREFORM_STATE_DIR/.fireform_state_<session_id>.json
+```
+
+`FIREFORM_STATE_DIR` defaults to `/tmp/fireform_states`, which is always
+writable inside Docker containers. Override it with:
+```bash
+export FIREFORM_STATE_DIR=/var/fireform/checkpoints
+```
+
+### 3. Atomic Writes
+
+The pipeline writes to a `.tmp` file first then renames it. A crash mid-write won't
+corrupt a previous checkpoint.
+
+### 4. Per-Field Checkpointing
+
+`save_state()` is called after every successful Ollama response. Any completed fields
+don't need to be extracted again on the next run. 
+
+### 5. Resume Logic
+
+`main_loop()` calls `load_state()` at startup. If a matching checkpoint
+exists, the prior JSON is loaded and `_target_fields` is filtered to skip
+any field already present:
+```python
+fields_to_process = [f for f in all_field_names if f not in self._json]
+```
+
+### 6. Ctrl+C Handling
+
+A `SIGINT` handler is registered at the start of `main_loop()`. Pressing
+`Ctrl+C` calls `save_state()` before the process exits.
+
+### 7. Cleanup on Success
+
+`clear_state()` removes the checkpoint file automatically when all fields
+are extracted.
+
+### 8. Error Logging
+
+When Ollama returns `-1` (field not found in transcript), the event is tracked in:
+```
+$FIREFORM_LOG_DIR/extraction_errors.jsonl
+```
+
+### 9. Retry on Timeout
+
+If Ollama times out, the pipeline retries up to 3 delays (5s, 10s, 15s). If all 
+retries are used, the checkpoint is saved before the error field so the next run resumes at the error field.
+
+---
+
+## Environment Variables
+
+| Variable             | Default                  | Description                                |
+|----------------------|--------------------------|--------------------------------------------|
+| `FIREFORM_STATE_DIR` | `/tmp/fireform_states`   | Where checkpoint `.json` files are stored  |
+| `FIREFORM_LOG_DIR`   | same as `STATE_DIR`      | Where `extraction_errors.jsonl` is written |
+| `OLLAMA_HOST`        | `http://localhost:11434` | Ollama API endpoint                        |
+
+---
+
+## Example: Testing Resumption
+```bash
+# Start extraction, interrupt it with Ctrl+C partway through
+docker compose exec app python3 src/main.py
+# ^C
+# [FireForm] Interrupted! Saving checkpoint so you can resume later...
+
+# Another run, resuming from the checkpoint automatically
+docker compose exec app python3 src/main.py
+# [LOG] Found existing state file. Resuming session a3f91b2c...
+#       (2 field(s) already extracted: ['name', 'date'])
+# [LOG] Skipping 2 already-extracted field(s). 5 remaining.
+```
+
+## Clearing a Checkpoint Manually
+
+To force a completely fresh extraction:
+```bash
+rm /tmp/fireform_states/.fireform_state_<session_id>.json
+```
+
+Or simply change the transcript or field list — that generates a new
+`session_id` automatically and the old checkpoint is ignored.

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "extraPaths": ["src"]
+}

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,16 +1,37 @@
+import datetime
+import hashlib
 import json
+import logging
 import os
+import signal
+import sys
+import time
 import requests
+
+logger = logging.getLogger(__name__)
+
+#folder for checkpoint files
+#default is /tmp/fireform_states, can override using FIREFORM_STATE_DIR env variable
+STATE_DIR = os.getenv("FIREFORM_STATE_DIR", "/tmp/fireform_states")
+
+#max # tries for an Ollama timeout
+MAX_RETRIES = 3
 
 
 class LLM:
-    def __init__(self, transcript_text=None, target_fields=None, json=None):
-        if json is None:
-            json = {}
+    def __init__(self, transcript_text=None, target_fields=None, json_data=None):
+        if json_data is None:
+            json_data = {}
         self._transcript_text = transcript_text  # str
-        self._target_fields = target_fields  # List, contains the template field.
-        self._json = json  # dictionary
+        self._target_fields = target_fields       # dict (pypdf) or list
+        self._json = json_data                    # dictionary
 
+        #LLM() is created first, _transcript_test/_target_fields created afterwards,
+        #so session ID must be computed later in _setup_checkpoint(), called by main_loop()
+        self._session_id = None
+        self._state_file = None
+
+    #type checking
     def type_check_all(self):
         if type(self._transcript_text) is not str:
             raise TypeError(
@@ -23,6 +44,117 @@ class LLM:
                 Target fields must be a list. Input:\n\ttarget_fields: {self._target_fields}"
             )
 
+    #checkpoint setup helpers
+    def _get_field_names(self):
+        """
+        Return field names as a list regardless of whether
+        _target_fields is a dict or a list. 
+        """
+        if self._target_fields is None:
+            return []
+        if isinstance(self._target_fields, dict):
+            return list(self._target_fields.keys())
+        return list(self._target_fields)
+
+    def _setup_checkpoint(self):
+        """
+        Compute the session_id and state_file path from 
+        _transcript_text and _target_fields. Called at the top of
+        main_loop().
+
+        Hashing transcript and field names means the same transcript
+        run through different form templates will produce two separate checkpoint files.
+        """
+        field_names = self._get_field_names()
+        fingerprint = (self._transcript_text or "") + str(sorted(field_names))
+        self._session_id = hashlib.md5(fingerprint.encode()).hexdigest()
+        os.makedirs(STATE_DIR, exist_ok=True)
+        self._state_file = os.path.join(
+            STATE_DIR, f".fireform_state_{self._session_id}.json"
+        )
+
+    #signal handling
+    def _handle_interrupt(self, signum, frame):
+        """On Ctrl+C, flush checkpoint before exit."""
+        logger.warning(
+            "\n[FireForm] Interrupted! Saving checkpoint so you can resume later..."
+        )
+        self.save_state()
+        sys.exit(1)
+
+    #checkpoint handling
+    def load_state(self) -> bool:
+        """
+        Load a previously saved checkpoint, returning true
+        if a checkpoint was found and loaded. False otherwise.
+        """
+        if not os.path.exists(self._state_file):
+            return False
+
+        try:
+            with open(self._state_file, "r") as f:
+                loaded = json.load(f)
+            self._json = loaded
+            already_done = [k for k, v in self._json.items() if v is not None]
+            print(
+                f"\t[LOG] Found existing state file. Resuming session "
+                f"{self._session_id[:8]}... "
+                f"({len(already_done)} field(s) already extracted: {already_done})"
+            )
+            return True
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(
+                f"[FireForm] State file found but unreadable ({e}). Starting fresh."
+            )
+            self._json = {}
+            return False
+
+    def save_state(self):
+        """
+        Writes to a .tmp file first then renames, so a crash mid-write
+        won't corrupts the checkpoint.
+        """
+        if not self._state_file:
+            return  # called before _setup_checkpoint, no write
+        tmp_path = self._state_file + ".tmp"
+        try:
+            with open(tmp_path, "w") as f:
+                json.dump(self._json, f, indent=2)
+            os.replace(tmp_path, self._state_file) 
+        except OSError as e:
+            logger.error(f"[FireForm] Failed to save checkpoint: {e}")
+
+    def clear_state(self):
+        """Remove the checkpoint file after successful completion."""
+        if self._state_file and os.path.exists(self._state_file):
+            try:
+                os.remove(self._state_file)
+                print("\t[LOG] Checkpoint cleared after successful completion.")
+            except OSError as e:
+                logger.warning(f"[FireForm] Could not remove checkpoint: {e}")
+
+    #error logging
+    def _log_extraction_error(self, field: str, raw_response: str, reason: str):
+        """
+        Append a failed field extraction event to a JSONL error log.
+        """
+        log_dir = os.getenv("FIREFORM_LOG_DIR", STATE_DIR)
+        os.makedirs(log_dir, exist_ok=True)
+        log_file = os.path.join(log_dir, "extraction_errors.jsonl")
+        entry = {
+            "timestamp": datetime.datetime.now().isoformat(),
+            "session_id": self._session_id,
+            "field": field,
+            "raw_response": raw_response[:300],
+            "reason": reason,
+        }
+        try:
+            with open(log_file, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except OSError:
+            pass 
+
+    #prompt building
     def build_prompt(self, current_field):
         """
         This method is in charge of the prompt engineering. It creates a specific prompt for each target field.
@@ -41,48 +173,97 @@ class LLM:
             
             TEXT: {self._transcript_text}
             """
-
         return prompt
 
+    #main
     def main_loop(self):
-        # self.type_check_all()
-        for field in self._target_fields.keys():
-            prompt = self.build_prompt(field)
-            # print(prompt)
-            # ollama_url = "http://localhost:11434/api/generate"
-            ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
-            ollama_url = f"{ollama_host}/api/generate"
+        self._setup_checkpoint()
 
+        #register Ctrl+C handler
+        signal.signal(signal.SIGINT, self._handle_interrupt)
+
+        #load existing checkpoints
+        self.load_state()
+
+        #determine which fields stil need extraction
+        all_field_names = self._get_field_names()
+        fields_to_process = [f for f in all_field_names if f not in self._json]
+
+        skipped = len(all_field_names) - len(fields_to_process)
+        if skipped:
+            print(
+                f"\t[LOG] Skipping {skipped} already-extracted field(s). "
+                f"{len(fields_to_process)} remaining."
+            )
+
+        ollama_host = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+        ollama_url = f"{ollama_host}/api/generate"
+
+        for field in fields_to_process:
+            prompt = self.build_prompt(field)
             payload = {
                 "model": "mistral",
                 "prompt": prompt,
-                "stream": False,  # don't really know why --> look into this later.
+                "stream": False,
             }
 
-            try:
-                response = requests.post(ollama_url, json=payload)
-                response.raise_for_status()
-            except requests.exceptions.ConnectionError:
-                raise ConnectionError(
-                    f"Could not connect to Ollama at {ollama_url}. "
-                    "Please ensure Ollama is running and accessible."
-                )
-            except requests.exceptions.HTTPError as e:
-                raise RuntimeError(f"Ollama returned an error: {e}")
+            #retry loop
+            response = None
+            for attempt in range(MAX_RETRIES):
+                try:
+                    response = requests.post(ollama_url, json=payload, timeout=120)
+                    response.raise_for_status()
+                    break  # success
 
-            # parse response
+                except requests.exceptions.Timeout:
+                    if attempt < MAX_RETRIES - 1:
+                        wait = 5.0 * (attempt + 1)
+                        logger.warning(
+                            f"[FireForm] Ollama timed out on '{field}' "
+                            f"(attempt {attempt + 1}/{MAX_RETRIES}). "
+                            f"Retrying in {wait:.0f}s..."
+                        )
+                        time.sleep(wait)
+                    else:
+                        logger.error(
+                            f"[FireForm] All {MAX_RETRIES} retries failed for "
+                            f"'{field}'. Saving checkpoint."
+                        )
+                        self.save_state()
+                        raise
+
+                except requests.exceptions.ConnectionError:
+                    self.save_state()
+                    raise ConnectionError(
+                        f"Could not connect to Ollama at {ollama_url}. "
+                        "Please ensure Ollama is running and accessible."
+                    )
+
+                except requests.exceptions.HTTPError as e:
+                    raise RuntimeError(f"Ollama returned an error: {e}")
+
             json_data = response.json()
             parsed_response = json_data["response"]
-            # print(parsed_response)
+
+            #Ollama value not found
+            if parsed_response.strip() == "-1":
+                self._log_extraction_error(
+                    field, parsed_response,
+                    "model returned -1 (value not found in transcript)"
+                )
+
             self.add_response_to_json(field, parsed_response)
+            self.save_state()  # checkpoint after every successful field
 
         print("----------------------------------")
         print("\t[LOG] Resulting JSON created from the input text:")
         print(json.dumps(self._json, indent=2))
         print("--------- extracted data ---------")
 
+        self.clear_state()
         return self
 
+    #json helpers
     def add_response_to_json(self, field, value):
         """
         this method adds the following value under the specified field,
@@ -128,7 +309,6 @@ class LLM:
                 values[current] = clean_value
 
         print(f"\t[LOG]: Resulting formatted list of values: {values}")
-
         return values
 
     def get_data(self):

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ import os
 from commonforms import prepare_form 
 from pypdf import PdfReader
 from controller import Controller
+from typing import Union
 
 def input_fields(num_fields: int):
     fields = []

--- a/tests/test_llm_checkpoint.py
+++ b/tests/test_llm_checkpoint.py
@@ -5,6 +5,7 @@ tests/test_llm_checkpoint.py
 import os
 import sys
 import unittest
+import tempfile
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -22,6 +23,27 @@ TRANSCRIPT = (
 FIELDS_LIST = ["name", "date", "location"]
 FIELDS_DICT = {"name": None, "date": None, "location": None}
 
+class CheckpointTestCase(unittest.TestCase):
+    """
+    Base class that redirects STATE_DIR to a temp directory for each test
+    so tests never write to /tmp/fireform_states or interfere with each other.
+    """
+ 
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.patcher = patch.object(llm_module, "STATE_DIR", self.tmp_dir)
+        self.patcher.start()
+ 
+    def tearDown(self):
+        self.patcher.stop()
+        import shutil
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+ 
+    def make_llm(self, fields=None, transcript=None):
+        inst = LLM()
+        inst._transcript_text = transcript or TRANSCRIPT
+        inst._target_fields = fields if fields is not None else FIELDS_LIST
+        return inst
 
 #session id tests
 class TestSessionId(unittest.TestCase):
@@ -125,6 +147,72 @@ class TestGetFieldNames(unittest.TestCase):
         inst._target_fields = {}
         self.assertEqual(inst._get_field_names(), [])
 
+
+#checkpoint I/O tests 
+class TestCheckpointIO(CheckpointTestCase):
+ 
+    def test_save_creates_file(self):
+        llm = self.make_llm()
+        llm._setup_checkpoint()
+        assert llm._state_file is not None
+        llm._json = {"name": "Jane Smith"}
+        llm.save_state()
+        self.assertTrue(os.path.exists(llm._state_file))
+ 
+    def test_load_restores_json(self):
+        llm = self.make_llm()
+        llm._setup_checkpoint()
+        llm._json = {"name": "Jane Smith"}
+        llm.save_state()
+ 
+        fresh = self.make_llm()
+        fresh._setup_checkpoint()
+        resumed = fresh.load_state()
+ 
+        self.assertTrue(resumed)
+        self.assertEqual(fresh._json, {"name": "Jane Smith"})
+ 
+    def test_load_returns_false_when_no_state_file(self):
+        llm = self.make_llm()
+        llm._setup_checkpoint()
+        self.assertFalse(llm.load_state())
+ 
+    def test_clear_removes_file(self):
+        llm = self.make_llm()
+        llm._setup_checkpoint()
+        assert llm._state_file is not None
+        llm._json = {"name": "Jane Smith"}
+        llm.save_state()
+        llm.clear_state()
+        self.assertFalse(os.path.exists(llm._state_file))
+ 
+    def test_load_handles_corrupt_file_gracefully(self):
+        llm = self.make_llm()
+        llm._setup_checkpoint()
+        assert llm._state_file is not None
+        with open(llm._state_file, "w") as f:
+            f.write("{{ not valid JSON !!!")
+        result = llm.load_state()
+        self.assertFalse(result)
+        self.assertEqual(llm._json, {})
+ 
+    def test_save_is_atomic_no_tmp_file_left(self):
+        """After save_state(), no .tmp file should remain."""
+        llm = self.make_llm()
+        llm._setup_checkpoint()
+        llm._json = {"name": "Jane Smith"}
+        llm.save_state()
+        assert llm._state_file is not None
+        self.assertFalse(os.path.exists(llm._state_file + ".tmp"))
+        self.assertTrue(os.path.exists(llm._state_file))
+ 
+    def test_save_before_setup_is_safe_noop(self):
+        """save_state() before _setup_checkpoint() must not raise."""
+        llm = LLM()
+        try:
+            llm.save_state()
+        except Exception as e:
+            self.fail(f"save_state() raised unexpectedly before setup: {e}")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_checkpoint.py
+++ b/tests/test_llm_checkpoint.py
@@ -1,0 +1,130 @@
+"""
+tests/test_llm_checkpoint.py 
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import llm as llm_module
+from llm import LLM
+
+
+#helpers
+TRANSCRIPT = (
+    "The employee name is John Smith. "
+    "The date is March 1. "
+    "The location is Fire Station HQ."
+)
+FIELDS_LIST = ["name", "date", "location"]
+FIELDS_DICT = {"name": None, "date": None, "location": None}
+
+
+#session id tests
+class TestSessionId(unittest.TestCase):
+    """Session ID must be deterministic and must not collide across templates."""
+
+    def test_same_inputs_produce_same_session_id(self):
+        a = LLM()
+        a._transcript_text = TRANSCRIPT
+        a._target_fields = FIELDS_LIST
+        a._setup_checkpoint()
+
+        b = LLM()
+        b._transcript_text = TRANSCRIPT
+        b._target_fields = FIELDS_LIST
+        b._setup_checkpoint()
+
+        self.assertEqual(a._session_id, b._session_id)
+
+    def test_different_transcript_produces_different_id(self):
+        a = LLM()
+        a._transcript_text = "Hello world"
+        a._target_fields = FIELDS_LIST
+        a._setup_checkpoint()
+
+        b = LLM()
+        b._transcript_text = "Different text"
+        b._target_fields = FIELDS_LIST
+        b._setup_checkpoint()
+
+        self.assertNotEqual(a._session_id, b._session_id)
+
+    def test_different_fields_produce_different_id(self):
+        """Same transcript, different form templates must not share a session_id."""
+        a = LLM()
+        a._transcript_text = TRANSCRIPT
+        a._target_fields = ["name", "date"]
+        a._setup_checkpoint()
+
+        b = LLM()
+        b._transcript_text = TRANSCRIPT
+        b._target_fields = ["unit", "location"]
+        b._setup_checkpoint()
+
+        self.assertNotEqual(a._session_id, b._session_id)
+
+    def test_field_order_does_not_matter(self):
+        """Field list order must not change the session_id (we sort before hashing)."""
+        a = LLM()
+        a._transcript_text = TRANSCRIPT
+        a._target_fields = ["a", "b", "c"]
+        a._setup_checkpoint()
+
+        b = LLM()
+        b._transcript_text = TRANSCRIPT
+        b._target_fields = ["c", "a", "b"]
+        b._setup_checkpoint()
+
+        self.assertEqual(a._session_id, b._session_id)
+
+    def test_dict_fields_same_as_list_fields(self):
+        """Dict and list with the same keys must produce the same session_id."""
+        a = LLM()
+        a._transcript_text = TRANSCRIPT
+        a._target_fields = FIELDS_LIST
+        a._setup_checkpoint()
+
+        b = LLM()
+        b._transcript_text = TRANSCRIPT
+        b._target_fields = FIELDS_DICT
+        b._setup_checkpoint()
+
+        self.assertEqual(a._session_id, b._session_id)
+
+
+#get field name tests
+class TestGetFieldNames(unittest.TestCase):
+    """_get_field_names() must handle None, dict, and list correctly."""
+
+    def test_none_returns_empty_list(self):
+        inst = LLM()
+        inst._target_fields = None
+        self.assertEqual(inst._get_field_names(), [])
+
+    def test_list_returned_as_is(self):
+        inst = LLM()
+        inst._target_fields = ["a", "b"]
+        self.assertEqual(inst._get_field_names(), ["a", "b"])
+
+    def test_dict_returns_keys(self):
+        inst = LLM()
+        inst._target_fields = {"name": None, "date": "March 1"}
+        self.assertCountEqual(inst._get_field_names(), ["name", "date"])
+
+    def test_empty_list(self):
+        inst = LLM()
+        inst._target_fields = []
+        self.assertEqual(inst._get_field_names(), [])
+
+    def test_empty_dict(self):
+        inst = LLM()
+        inst._target_fields = {}
+        self.assertEqual(inst._get_field_names(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Closes #131

Implements a checkpointed LLM extraction pipeline so that an interrupted run (container crash, Ollama timeout, Ctrl+C) resumes exactly where it left off without re-processing already-extracted fields.

Also fixes a `ModuleNotFoundError: No module named 'src'` that prevented `make exec` from running, caused by an incomplete `PYTHONPATH`. Fixes #116 and #118.

### `src/llm.py`
- Session ID computed lazily at start of `main_loop()`
- Session ID hashes transcript and field names, so two different form templates on the same transcript won't share a checkpoint (addition to PR #133, which only hashes the transcript)
- `_get_field_names()` handles `_target_fields` as either a `dict` (from `pypdf`) or a `list` 
- Atomic checkpoint writes via `.tmp` + `os.replace()` 
- `SIGINT` handler so Ctrl+C flushes the checkpoint before exit
- Retry loop (3 attempts, backoff) on Ollama timeouts with checkpoint saved 
- JSONL error log for `-1` responses to help with debugging
- Renamed `json=None` param to `json_data=None` 

### `src/main.py`
- Added missing `from typing import Union` (pre-existing bug from issue #

### `docker-compose.yml` + `Dockerfile`
- `PYTHONPATH=/app/src` changed to `PYTHONPATH=/app:/app/src`

### `docs/session_resumption.md` *(new)*
- Documents checkpoint mechanism, env vars, and usage examples as required by #131 acceptance criteria

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- **PYTHONPATH fix**: `make exec` runs successfully
- **Checkpointing logic**: has not been tested

- [x] Test A — `make exec` completes without import errors

**Test Configuration**: Docker Desktop, `python:3.11-slim`, Ollama + Mistral

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

> Tests for the checkpoint logic are in progress. 

Coming across this issue was interesting because I've implemented a similar checkpointing and resuming process in LLM benchmarking, so I was able to reuse some of the error log, checkpoint write, and retry loop logic. Please let me know if there's anything I can improve! 