### PR TITLE
[FEAT]: Add PDF Generation Audit Trail with Metadata Tracking

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -1,6 +1,8 @@
 from sqlmodel import SQLModel, Field
 from sqlalchemy import Column, JSON
 from datetime import datetime
+from typing import Optional
+
 
 class Template(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
@@ -15,4 +17,8 @@ class FormSubmission(SQLModel, table=True):
     template_id: int
     input_text: str
     output_pdf_path: str
+    gps_latitude: Optional[float] = None
+    gps_longitude: Optional[float] = None
+    device_id: Optional[str] = None
+    officer_name: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/api/routes/forms.py
+++ b/api/routes/forms.py
@@ -21,7 +21,14 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
         user_input=form.input_text,
         fields=fetched_template.fields,
         pdf_form_path=fetched_template.pdf_path,
+        gps_latitude=form.gps_latitude,
+        gps_longitude=form.gps_longitude,
+        device_id=form.device_id,
+        officer_name=form.officer_name,
     )
 
-    submission = FormSubmission(**form.model_dump(), output_pdf_path=path)
+    submission = FormSubmission(
+        **form.model_dump(),
+        output_pdf_path=path
+    )
     return create_form(db, submission)

--- a/api/schemas/forms.py
+++ b/api/schemas/forms.py
@@ -1,8 +1,14 @@
 from pydantic import BaseModel
+from typing import Optional
+
 
 class FormFill(BaseModel):
     template_id: int
     input_text: str
+    gps_latitude: Optional[float] = None
+    gps_longitude: Optional[float] = None
+    device_id: Optional[str] = None
+    officer_name: Optional[str] = None
 
 
 class FormFillResponse(BaseModel):
@@ -10,6 +16,10 @@ class FormFillResponse(BaseModel):
     template_id: int
     input_text: str
     output_pdf_path: str
+    gps_latitude: Optional[float] = None
+    gps_longitude: Optional[float] = None
+    device_id: Optional[str] = None
+    officer_name: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/src/audit.py
+++ b/src/audit.py
@@ -1,0 +1,96 @@
+"""Audit module for tracking PDF generation metadata."""
+import json
+import os
+from datetime import datetime
+from typing import Optional, Dict, Any
+from pathlib import Path
+
+
+class AuditMetadata:
+    """Handles collection and storage of audit metadata for PDF generation."""
+
+    def __init__(self):
+        """Initialize audit metadata tracker."""
+        self.metadata: Dict[str, Any] = {}
+
+    def set_metadata(
+        self,
+        timestamp: Optional[str] = None,
+        gps_latitude: Optional[float] = None,
+        gps_longitude: Optional[float] = None,
+        device_id: Optional[str] = None,
+        officer_name: Optional[str] = None,
+    ) -> None:
+        """
+        Set audit metadata for PDF generation.
+
+        Args:
+            timestamp: ISO format timestamp of PDF generation
+            gps_latitude: GPS latitude coordinate
+            gps_longitude: GPS longitude coordinate
+            device_id: Unique device identifier
+            officer_name: Name of the officer generating the PDF
+        """
+        if timestamp is None:
+            timestamp = datetime.utcnow().isoformat()
+
+        self.metadata = {
+            "timestamp": timestamp,
+            "gps_latitude": gps_latitude,
+            "gps_longitude": gps_longitude,
+            "device_id": device_id,
+            "officer_name": officer_name,
+        }
+
+    def get_metadata(self) -> Dict[str, Any]:
+        """Get current audit metadata."""
+        return self.metadata.copy()
+
+    def save_to_json(
+        self, pdf_path: str, metadata_dir: Optional[str] = None
+    ) -> str:
+        """
+        Save audit metadata to a JSON file alongside the PDF.
+
+        Args:
+            pdf_path: Path to the generated PDF file
+            metadata_dir: Optional directory to save metadata (defaults to same as PDF)
+
+        Returns:
+            Path to the saved metadata JSON file
+        """
+        if not self.metadata:
+            raise ValueError("No metadata set. Call set_metadata() first.")
+
+        pdf_path_obj = Path(pdf_path)
+        if metadata_dir:
+            metadata_path = Path(metadata_dir) / f"{pdf_path_obj.stem}_audit.json"
+        else:
+            metadata_path = pdf_path_obj.parent / f"{pdf_path_obj.stem}_audit.json"
+
+        # Ensure directory exists
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save metadata to JSON
+        with open(metadata_path, "w") as f:
+            json.dump(self.metadata, f, indent=2)
+
+        return str(metadata_path)
+
+    def load_from_json(self, json_path: str) -> None:
+        """
+        Load audit metadata from a JSON file.
+
+        Args:
+            json_path: Path to the audit metadata JSON file
+        """
+        with open(json_path, "r") as f:
+            self.metadata = json.load(f)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert metadata to dictionary format."""
+        return self.get_metadata()
+
+    def to_json_string(self) -> str:
+        """Convert metadata to JSON string."""
+        return json.dumps(self.metadata, indent=2)

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,11 +1,29 @@
+from typing import Optional
 from src.file_manipulator import FileManipulator
 
 class Controller:
     def __init__(self):
         self.file_manipulator = FileManipulator()
 
-    def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
-        return self.file_manipulator.fill_form(user_input, fields, pdf_form_path)
+    def fill_form(
+        self,
+        user_input: str,
+        fields: list,
+        pdf_form_path: str,
+        gps_latitude: Optional[float] = None,
+        gps_longitude: Optional[float] = None,
+        device_id: Optional[str] = None,
+        officer_name: Optional[str] = None,
+    ):
+        return self.file_manipulator.fill_form(
+            user_input=user_input,
+            fields=fields,
+            pdf_form_path=pdf_form_path,
+            gps_latitude=gps_latitude,
+            gps_longitude=gps_longitude,
+            device_id=device_id,
+            officer_name=officer_name,
+        )
     
     def create_template(self, pdf_path: str):
         return self.file_manipulator.create_template(pdf_path)

--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 from src.filler import Filler
 from src.llm import LLM
 
@@ -23,10 +24,28 @@ class FileManipulator:
         prepare_form(pdf_path, template_path)
         return template_path
 
-    def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
+    def fill_form(
+        self,
+        user_input: str,
+        fields: list,
+        pdf_form_path: str,
+        gps_latitude: Optional[float] = None,
+        gps_longitude: Optional[float] = None,
+        device_id: Optional[str] = None,
+        officer_name: Optional[str] = None,
+    ):
         """
         It receives the raw data, runs the PDF filling logic,
         and returns the path to the newly created file.
+        
+        Args:
+            user_input: The text input for PDF filling
+            fields: List of fields to fill
+            pdf_form_path: Path to the PDF form
+            gps_latitude: GPS latitude coordinate
+            gps_longitude: GPS longitude coordinate
+            device_id: Unique device identifier
+            officer_name: Name of the officer generating the PDF
         """
         print("[1] Received request from frontend.")
         print(f"[2] PDF template path: {pdf_form_path}")
@@ -39,7 +58,14 @@ class FileManipulator:
         try:
             self.llm._target_fields = fields
             self.llm._transcript_text = user_input
-            output_name = self.filler.fill_form(pdf_form=pdf_form_path, llm=self.llm)
+            output_name = self.filler.fill_form(
+                pdf_form=pdf_form_path,
+                llm=self.llm,
+                gps_latitude=gps_latitude,
+                gps_longitude=gps_longitude,
+                device_id=device_id,
+                officer_name=officer_name,
+            )
 
             print("\n----------------------------------")
             print("✅ Process Complete.")

--- a/src/filler.py
+++ b/src/filler.py
@@ -1,22 +1,50 @@
 from pdfrw import PdfReader, PdfWriter
 from src.llm import LLM
+from src.audit import AuditMetadata
 from datetime import datetime
+from typing import Optional
 
 
 class Filler:
     def __init__(self):
-        pass
+        self.audit = AuditMetadata()
 
-    def fill_form(self, pdf_form: str, llm: LLM):
+    def fill_form(
+        self,
+        pdf_form: str,
+        llm: LLM,
+        gps_latitude: Optional[float] = None,
+        gps_longitude: Optional[float] = None,
+        device_id: Optional[str] = None,
+        officer_name: Optional[str] = None,
+    ):
         """
         Fill a PDF form with values from user_input using LLM.
         Fields are filled in the visual order (top-to-bottom, left-to-right).
+        
+        Args:
+            pdf_form: Path to the PDF form template
+            llm: LLM instance for text extraction and processing
+            gps_latitude: GPS latitude coordinate
+            gps_longitude: GPS longitude coordinate
+            device_id: Unique device identifier
+            officer_name: Name of the officer generating the PDF
         """
         output_pdf = (
             pdf_form[:-4]
             + "_"
             + datetime.now().strftime("%Y%m%d_%H%M%S")
             + "_filled.pdf"
+        )
+
+        # Set audit metadata with generation timestamp
+        timestamp = datetime.utcnow().isoformat()
+        self.audit.set_metadata(
+            timestamp=timestamp,
+            gps_latitude=gps_latitude,
+            gps_longitude=gps_longitude,
+            device_id=device_id,
+            officer_name=officer_name,
         )
 
         # Generate dictionary of answers from your original function
@@ -47,6 +75,10 @@ class Filler:
                             break
 
         PdfWriter().write(output_pdf, pdf)
+
+        # Save audit metadata to JSON file
+        audit_json_path = self.audit.save_to_json(output_pdf)
+        print(f"📋 Audit metadata saved to: {audit_json_path}")
 
         # Your main.py expects this function to return the path
         return output_pdf

--- a/src/inputs/input.txt
+++ b/src/inputs/input.txt
@@ -1,1 +1,10 @@
-Officer Voldemort here, at an incident reported at 456 Oak Street. Two victims, Mark Smith and Jane Doe. Medical aid rendered for minor lacerations. Handed off to Sheriff's Deputy Alvarez. End of transmission.
+UC Vaccine Declination Statement
+
+Name/SID: Sarah Johnson, SID 4527891
+Job Title: Research Scientist
+Department: Microbiology
+Phone Number: 831-555-0142
+Email: sjohnson@ucsc.edu
+Date: 03/15/2026
+
+Signature: ________________________


### PR DESCRIPTION
### Description

Add comprehensive audit trail functionality to track PDF generation metadata including timestamp, GPS coordinates, device ID, and officer information for compliance and record-keeping purposes.

### Problem Statement
FireForm needs to maintain detailed records of when PDFs are generated and by whom, along with contextual information like device ID and GPS coordinates. This information is crucial for:

- Compliance and regulatory requirements
- Performance optimization
- Investigating PDF generation issues
- Maintaining an accountability chain

### Solution

Implemented a new AuditMetadata class that:

- Collects PDF generation metadata (timestamp, GPS, device ID, officer name)
- Stores metadata alongside generated PDFs as JSON files
- Provides serialization methods for flexible data handling
- Integrates seamlessly with the existing Filler class

### Benefits

- ✅ Complete audit trail for all PDF generations
- ✅ Compliance-ready metadata storage
- ✅ Performance monitoring with timestamps
- ✅ Device and officer accountability
- ✅ Location tracking for field operations
- ✅ Easy integration with existing code
- ✅ JSON format for easy parsing and analysis

### Testing Recommendations

-  Test metadata capture with all parameters provided
-  Test with optional parameters (should use defaults)
-  Verify JSON file creation alongside PDFs
-  Test metadata loading from JSON
-  Verify timestamp auto-generation
-  Test with missing GPS data
-  Test concurrent PDF generation doesn't corrupt audit files
