### PR TITLE
Test: add edge case coverage for template upload and preview routes

### DIFF
--- a/tests/test_template_file_routes.py
+++ b/tests/test_template_file_routes.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_upload_template_pdf():
+    pdf_content = b"%PDF-1.4 test pdf content"
+
+    files = {
+        "file": ("sample_test.pdf", pdf_content, "application/pdf")
+    }
+
+    data = {
+        "directory": "src/inputs"
+    }
+
+    response = client.post(
+        "/templates/upload",
+        files=files,
+        data=data
+    )
+
+    assert response.status_code == 200
+
+    response_data = response.json()
+
+    assert "filename" in response_data
+    assert "pdf_path" in response_data
+    assert response_data["filename"].endswith(".pdf")
+
+
+def test_preview_template_pdf():
+    response = client.get(
+        "/templates/preview",
+        params={"path": "src/inputs/file.pdf"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    
+def test_upload_non_pdf_should_fail():
+    files = {
+        "file": ("sample.txt", b"not a pdf", "text/plain")
+    }
+
+    response = client.post(
+        "/templates/upload",
+        files=files,
+        data={"directory": "src/inputs"}
+    )
+
+    assert response.status_code == 400
+
+
+def test_preview_missing_file_should_fail():
+    response = client.get(
+        "/templates/preview",
+        params={"path": "src/inputs/does_not_exist.pdf"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_preview_outside_project_should_fail():
+    response = client.get(
+        "/templates/preview",
+        params={"path": "/etc/passwd"}
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
Closes #24 
## 🚀 Summary

This PR extends route-level integration coverage for the newly added template file endpoints by adding negative-path and edge-case test scenarios.

The focus is to improve regression safety and ensure the routes behave correctly under invalid inputs.

---

## ✨ What Changed

Extended:

```text id="file1"
tests/test_template_file_routes.py
```

with additional integration tests covering invalid request scenarios.

---

## 🧪 New Test Coverage Added

### 1) Non-PDF upload should fail

Validates that uploading unsupported file types correctly returns:

```text id="code1"
400 Bad Request
```

This ensures file type validation remains enforced.

---

### 2) Missing preview file should return 404

Verifies that requesting a non-existent PDF path correctly returns:

```text id="code2"
404 Not Found
```

---

### 3) Outside-project file access should fail

Tests path validation and ensures attempts to preview files outside the project directory return:

```text id="code3"
400 Bad Request
```

This strengthens route safety and path validation behavior.

---

## 💡 Why This Helps

These tests improve:

* edge-case reliability
* invalid input handling
* route-level regression safety
* path validation confidence

This is especially important for file-based routes.

---

## 🧪 Local Validation

Executed locally using:

```bash id="cmd4"
PYTHONPATH=. pytest tests/test_template_file_routes.py -q
```

and verified successful execution of all added scenarios.

---

## 🎯 Impact

This improves production confidence for the newly introduced upload and preview endpoints by validating failure-path behavior in addition to happy-path flows.
