### PR TITLE
Frontend: prevent duplicate submit requests in template and fill workflows

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -32,6 +32,8 @@ const elements = {
 let templates = loadTemplates();
 let activeObjectUrl = null;
 let selectedTemplateFile = null;
+let isTemplateSubmitting = false;
+let isFillSubmitting = false;
 
 initialize();
 
@@ -246,6 +248,14 @@ function normalizeFields(rawFields) {
 
 async function handleTemplateSubmit(event) {
   event.preventDefault();
+
+  if (isTemplateSubmitting) {
+    setStatus(elements.templateFormMessage, "Request already in progress...", "info");
+    return;
+  }
+
+  isTemplateSubmitting = true;
+
   clearJson(elements.templateFormResponse);
   setStatus(elements.templateFormMessage, "");
 
@@ -259,11 +269,13 @@ async function handleTemplateSubmit(event) {
       "Name, PDF file, and template directory are required.",
       "error"
     );
+    isTemplateSubmitting = false;
     return;
   }
 
   if (normalized.error) {
     setStatus(elements.templateFormMessage, normalized.error, "error");
+    isTemplateSubmitting = false;
     return;
   }
 
@@ -280,6 +292,7 @@ async function handleTemplateSubmit(event) {
     };
 
     setStatus(elements.templateFormMessage, "Creating template...", "info");
+
     const response = await fetch(`${API_BASE_URL}/templates/create`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -287,12 +300,14 @@ async function handleTemplateSubmit(event) {
     });
 
     const body = await parseJsonResponse(response);
+
     if (!response.ok) {
       throw new Error(extractErrorMessage(body, response.status));
     }
 
     upsertTemplate(body);
     await refreshTemplatesFromApi();
+
     elements.fillTemplateId.value = String(body.id || "");
     elements.serverPdfPath.value = body.pdf_path || "";
 
@@ -301,11 +316,15 @@ async function handleTemplateSubmit(event) {
       `Template created (id: ${body.id}). PDF saved at ${upload.pdf_path}.`,
       "success"
     );
+
     showJson(elements.templateFormResponse, body);
   } catch (error) {
     setStatus(elements.templateFormMessage, error.message, "error");
+  } finally {
+    isTemplateSubmitting = false;
   }
 }
+
 
 async function uploadTemplatePdf(file, directory) {
   const formData = new FormData();
@@ -327,6 +346,14 @@ async function uploadTemplatePdf(file, directory) {
 
 async function handleFillSubmit(event) {
   event.preventDefault();
+
+  if (isFillSubmitting) {
+    setStatus(elements.fillFormMessage, "Request already in progress...", "info");
+    return;
+  }
+
+  isFillSubmitting = true;
+
   clearJson(elements.fillFormResponse);
   setStatus(elements.fillFormMessage, "");
 
@@ -335,11 +362,13 @@ async function handleFillSubmit(event) {
 
   if (!Number.isInteger(templateId) || templateId < 1) {
     setStatus(elements.fillFormMessage, "Template ID must be a positive integer.", "error");
+    isFillSubmitting = false;
     return;
   }
 
   if (!inputText) {
     setStatus(elements.fillFormMessage, "Input text is required.", "error");
+    isFillSubmitting = false;
     return;
   }
 
@@ -350,6 +379,7 @@ async function handleFillSubmit(event) {
 
   try {
     setStatus(elements.fillFormMessage, "Submitting form fill request...", "info");
+
     const response = await fetch(`${API_BASE_URL}/forms/fill`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -357,6 +387,7 @@ async function handleFillSubmit(event) {
     });
 
     const body = await parseJsonResponse(response);
+
     if (!response.ok) {
       throw new Error(extractErrorMessage(body, response.status));
     }
@@ -372,9 +403,12 @@ async function handleFillSubmit(event) {
       `Form filled (submission id: ${body.id}).`,
       "success"
     );
+
     showJson(elements.fillFormResponse, body);
   } catch (error) {
     setStatus(elements.fillFormMessage, error.message, "error");
+  } finally {
+    isFillSubmitting = false;
   }
 }
 

--- a/tests/test_template_file_routes.py
+++ b/tests/test_template_file_routes.py
@@ -1,0 +1,71 @@
+from fastapi.testclient import TestClient
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_upload_template_pdf():
+    pdf_content = b"%PDF-1.4 test pdf content"
+
+    files = {
+        "file": ("sample_test.pdf", pdf_content, "application/pdf")
+    }
+
+    data = {
+        "directory": "src/inputs"
+    }
+
+    response = client.post(
+        "/templates/upload",
+        files=files,
+        data=data
+    )
+
+    assert response.status_code == 200
+
+    response_data = response.json()
+
+    assert "filename" in response_data
+    assert "pdf_path" in response_data
+    assert response_data["filename"].endswith(".pdf")
+
+
+def test_preview_template_pdf():
+    response = client.get(
+        "/templates/preview",
+        params={"path": "src/inputs/file.pdf"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/pdf"
+    
+def test_upload_non_pdf_should_fail():
+    files = {
+        "file": ("sample.txt", b"not a pdf", "text/plain")
+    }
+
+    response = client.post(
+        "/templates/upload",
+        files=files,
+        data={"directory": "src/inputs"}
+    )
+
+    assert response.status_code == 400
+
+
+def test_preview_missing_file_should_fail():
+    response = client.get(
+        "/templates/preview",
+        params={"path": "src/inputs/does_not_exist.pdf"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_preview_outside_project_should_fail():
+    response = client.get(
+        "/templates/preview",
+        params={"path": "/etc/passwd"}
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
## 🚀 Summary

This PR improves frontend production stability by preventing duplicate submissions in both template creation and form fill workflows.

---

## ✨ What Changed

Added request lock state handling in:

```text id="file1"
frontend/app.js
```

New submission flags:

```javascript id="code1"
let isTemplateSubmitting = false;
let isFillSubmitting = false;
```

Applied duplicate-click prevention to:

* `handleTemplateSubmit()`
* `handleFillSubmit()`

---

## 💡 Why This Helps

This prevents:

* duplicate API calls
* accidental double-click submissions
* repeated template creation
* repeated form fill requests
* frontend race-condition style issues

This significantly improves request-flow stability and overall UX.

---

## 🎯 Production Impact

This hardens the frontend for real-world usage and improves reliability under fast repeated user interactions.
