### PR TITLE
feat: Backend change for field mapping wizard

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routes import forms, templates
+from api.routes import forms, templates, wizard
 
 app = FastAPI()
 
@@ -24,3 +24,4 @@ app.add_middleware(
 
 app.include_router(templates.router)
 app.include_router(forms.router)
+app.include_router(wizard.router)

--- a/api/routes/wizard.py
+++ b/api/routes/wizard.py
@@ -1,0 +1,64 @@
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from api.schemas.wizard import DetectFieldsResponse
+from src.controller import Controller
+
+router = APIRouter(prefix="/wizard", tags=["wizard"])
+
+
+@router.post("/detect-fields", response_model=DetectFieldsResponse)
+async def detect_fields(file: UploadFile = File(...)):
+    """Upload a PDF and detect all interactive form fields.
+
+    Parses the PDF's /Annots annotations for /Widget subtypes and
+    returns each field's name, type (Text, Button, Choice), and
+    bounding box coordinates (X, Y, Width, Height).
+
+    This endpoint powers the Field Mapping Wizard, enabling
+    non-technical users to see all fillable fields in a PDF
+    before mapping them to FireForm's data schema.
+
+    **Supported field types:**
+    - Text (/Tx): Text inputs and text areas
+    - Button (/Btn): Checkboxes and radio buttons
+    - Choice (/Ch): Dropdowns and list boxes
+
+    **Note:** Only digitally created fillable PDFs (AcroForms) are
+    supported. Scanned/image-based PDFs will return zero fields.
+    """
+    filename = Path(file.filename or "").name
+    if not filename:
+        raise HTTPException(status_code=400, detail="A PDF filename is required.")
+
+    if not filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Only PDF files are supported.")
+
+    try:
+        content = await file.read()
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = tmp.name
+
+        controller = Controller()
+        result = controller.detect_fields(tmp_path)
+        result["filename"] = filename
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to process PDF: {str(e)}",
+        )
+    finally:
+        # Clean up temp file
+        try:
+            Path(tmp_path).unlink(missing_ok=True)
+        except (NameError, OSError):
+            pass
+
+    return result

--- a/api/schemas/wizard.py
+++ b/api/schemas/wizard.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel
+
+
+class FieldRect(BaseModel):
+    """Bounding box coordinates for a detected PDF form field."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class DetectedField(BaseModel):
+    """Metadata for a single detected interactive form field."""
+
+    field_name: str
+    field_type: str  # "Text", "Button", "Choice", or "Unknown"
+    raw_type: str  # "/Tx", "/Btn", "/Ch"
+    rect: FieldRect
+
+
+class PageFields(BaseModel):
+    """All detected fields on a single PDF page."""
+
+    page_number: int
+    fields: list[DetectedField]
+
+
+class DetectFieldsResponse(BaseModel):
+    """Response schema for the /wizard/detect-fields endpoint."""
+
+    filename: str
+    total_pages: int
+    total_fields: int
+    pages: list[PageFields]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 pdfrw
+pypdf
 flask
 commonforms
 fastapi

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,11 +1,16 @@
 from src.file_manipulator import FileManipulator
+from src.field_detector import PDFFieldDetector
 
 class Controller:
     def __init__(self):
         self.file_manipulator = FileManipulator()
+        self.field_detector = PDFFieldDetector()
 
     def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
         return self.file_manipulator.fill_form(user_input, fields, pdf_form_path)
     
     def create_template(self, pdf_path: str):
         return self.file_manipulator.create_template(pdf_path)
+
+    def detect_fields(self, pdf_path: str):
+        return self.field_detector.detect_fields(pdf_path)

--- a/src/field_detector.py
+++ b/src/field_detector.py
@@ -1,0 +1,191 @@
+"""
+PDF Field Detector Module
+=========================
+Detects and extracts interactive form field metadata from PDF files.
+
+This module parses PDF annotations (/Annots with /Widget subtypes) to
+extract field names, types, and bounding box coordinates. It is the
+backend engine that powers the Field Mapping Wizard (Issue #111).
+
+Supported field types:
+    - /Tx  → Text (text inputs, text areas)
+    - /Btn → Button (checkboxes, radio buttons)
+    - /Ch  → Choice (dropdowns, list boxes)
+
+Note: This detector works with digitally created fillable PDFs
+(AcroForms). Scanned/image-based PDFs are not supported and would
+require OCR integration as a future enhancement.
+"""
+
+from pypdf import PdfReader
+
+
+class PDFFieldDetector:
+    """Detects and extracts interactive form field metadata from PDF files.
+
+    Parses each page's /Annots annotations, filters for /Widget subtypes
+    (interactive form fields), and extracts:
+        - Field name (from the /T key)
+        - Field type (/Tx, /Btn, /Ch)
+        - Bounding box coordinates (X, Y, Width, Height)
+
+    This data is structured for frontend visual rendering and eventual
+    drag-and-drop field mapping.
+    """
+
+    FIELD_TYPE_MAP = {
+        "/Tx": "Text",
+        "/Btn": "Button",
+        "/Ch": "Choice",
+    }
+
+    def detect_fields(self, pdf_path: str) -> dict:
+        """Parse a PDF and return all detected interactive form fields.
+
+        Args:
+            pdf_path: Absolute or relative path to the PDF file.
+
+        Returns:
+            A dictionary with the following structure::
+
+                {
+                    "filename": "form.pdf",
+                    "total_pages": 3,
+                    "total_fields": 12,
+                    "pages": [
+                        {
+                            "page_number": 1,
+                            "fields": [
+                                {
+                                    "field_name": "Employee Name",
+                                    "field_type": "Text",
+                                    "raw_type": "/Tx",
+                                    "rect": {
+                                        "x": 72.0,
+                                        "y": 700.0,
+                                        "width": 200.0,
+                                        "height": 20.0
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+
+        Raises:
+            FileNotFoundError: If the PDF file does not exist.
+            Exception: If the PDF cannot be parsed.
+        """
+        reader = PdfReader(pdf_path)
+        filename = pdf_path.split("/")[-1].split("\\")[-1]
+
+        pages = []
+        total_fields = 0
+
+        for page_index, page in enumerate(reader.pages):
+            page_fields = self._extract_page_fields(page)
+            total_fields += len(page_fields)
+            pages.append(
+                {
+                    "page_number": page_index + 1,
+                    "fields": page_fields,
+                }
+            )
+
+        return {
+            "filename": filename,
+            "total_pages": len(reader.pages),
+            "total_fields": total_fields,
+            "pages": pages,
+        }
+
+    def _extract_page_fields(self, page) -> list:
+        """Extract form fields from a single PDF page.
+
+        Args:
+            page: A pypdf PageObject.
+
+        Returns:
+            A list of field metadata dictionaries. Returns an empty
+            list if the page has no annotations or no widget fields.
+        """
+        annotations = page.get("/Annots")
+        if not annotations:
+            return []
+
+        fields = []
+        for annotation in annotations:
+            annotation_obj = annotation.get_object()
+            field = self._parse_annotation(annotation_obj)
+            if field is not None:
+                fields.append(field)
+
+        return fields
+
+    def _parse_annotation(self, annotation) -> dict | None:
+        """Parse a single annotation into field metadata.
+
+        Only processes /Widget subtype annotations that have a field
+        name (/T key) and a recognized field type (/FT key).
+
+        Args:
+            annotation: A resolved PDF annotation dictionary object.
+
+        Returns:
+            A field metadata dictionary, or None if the annotation
+            is not a recognized interactive form field.
+        """
+        subtype = annotation.get("/Subtype")
+        if subtype != "/Widget":
+            return None
+
+        field_name = annotation.get("/T")
+        if not field_name:
+            return None
+
+        raw_type = annotation.get("/FT", "")
+        field_type = self.FIELD_TYPE_MAP.get(raw_type, "Unknown")
+
+        rect = self._extract_rect(annotation)
+
+        return {
+            "field_name": str(field_name),
+            "field_type": field_type,
+            "raw_type": str(raw_type),
+            "rect": rect,
+        }
+
+    @staticmethod
+    def _extract_rect(annotation) -> dict:
+        """Extract bounding box coordinates from an annotation's /Rect.
+
+        The PDF /Rect array is [x1, y1, x2, y2] where (x1, y1) is the
+        lower-left corner and (x2, y2) is the upper-right corner.
+        This method converts it to {x, y, width, height} for easier
+        frontend rendering.
+
+        Args:
+            annotation: A resolved PDF annotation dictionary object.
+
+        Returns:
+            A dictionary with x, y, width, and height. Returns all
+            zeros if no /Rect is found.
+        """
+        rect_array = annotation.get("/Rect")
+        if not rect_array or len(rect_array) < 4:
+            return {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+
+        try:
+            x1 = float(rect_array[0])
+            y1 = float(rect_array[1])
+            x2 = float(rect_array[2])
+            y2 = float(rect_array[3])
+        except (ValueError, TypeError):
+            return {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+
+        return {
+            "x": round(min(x1, x2), 2),
+            "y": round(min(y1, y2), 2),
+            "width": round(abs(x2 - x1), 2),
+            "height": round(abs(y2 - y1), 2),
+        }

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,221 @@
+"""
+Tests for the Field Mapping Wizard endpoint and PDFFieldDetector.
+
+These tests create minimal PDF files with form fields programmatically
+using pypdf, so no external test fixtures are needed.
+"""
+
+import io
+
+from pypdf import PdfWriter
+from pypdf.annotations import FreeText
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    FloatObject,
+    NameObject,
+    TextStringObject,
+)
+
+
+def _create_pdf_with_fields(fields: list[dict]) -> bytes:
+    """Create a minimal PDF with form widget annotations.
+
+    Args:
+        fields: List of dicts with keys:
+            - name (str): Field name
+            - field_type (str): "/Tx", "/Btn", or "/Ch"
+            - rect (list[float]): [x1, y1, x2, y2]
+
+    Returns:
+        PDF content as bytes.
+    """
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+
+    for field_spec in fields:
+        annotation = DictionaryObject()
+        annotation.update(
+            {
+                NameObject("/Type"): NameObject("/Annot"),
+                NameObject("/Subtype"): NameObject("/Widget"),
+                NameObject("/T"): TextStringObject(field_spec["name"]),
+                NameObject("/FT"): NameObject(field_spec["field_type"]),
+                NameObject("/Rect"): ArrayObject(
+                    [FloatObject(v) for v in field_spec["rect"]]
+                ),
+            }
+        )
+        writer.add_annotation(page_number=0, annotation=annotation)
+
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def _create_blank_pdf() -> bytes:
+    """Create a minimal PDF with no form fields."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+# ─── Endpoint Tests ───────────────────────────────────────────────
+
+
+def test_detect_fields_valid_pdf(client):
+    """Upload a PDF with known form fields and verify detection."""
+    fields = [
+        {"name": "employee_name", "field_type": "/Tx", "rect": [72, 700, 272, 720]},
+        {"name": "is_active", "field_type": "/Btn", "rect": [72, 660, 92, 680]},
+        {"name": "department", "field_type": "/Ch", "rect": [72, 620, 272, 640]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("test_form.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["filename"] == "test_form.pdf"
+    assert data["total_pages"] == 1
+    assert data["total_fields"] == 3
+
+    page = data["pages"][0]
+    assert page["page_number"] == 1
+    assert len(page["fields"]) == 3
+
+    # Verify field types are correctly classified
+    type_map = {f["field_name"]: f["field_type"] for f in page["fields"]}
+    assert type_map["employee_name"] == "Text"
+    assert type_map["is_active"] == "Button"
+    assert type_map["department"] == "Choice"
+
+
+def test_detect_fields_bounding_box(client):
+    """Verify bounding box coordinates are correctly extracted."""
+    fields = [
+        {"name": "test_field", "field_type": "/Tx", "rect": [72.0, 700.0, 272.0, 720.0]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("test_rect.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    rect = data["pages"][0]["fields"][0]["rect"]
+
+    assert rect["x"] == 72.0
+    assert rect["y"] == 700.0
+    assert rect["width"] == 200.0
+    assert rect["height"] == 20.0
+
+
+def test_detect_fields_no_widgets(client):
+    """Upload a PDF without form fields and verify graceful handling."""
+    pdf_bytes = _create_blank_pdf()
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("blank.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total_fields"] == 0
+    assert data["total_pages"] == 1
+    assert len(data["pages"]) == 1
+    assert len(data["pages"][0]["fields"]) == 0
+
+
+def test_detect_fields_non_pdf(client):
+    """Upload a non-PDF file and expect 400 error."""
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("readme.txt", b"Hello world", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "PDF" in response.json()["detail"]
+
+
+def test_detect_fields_no_file(client):
+    """POST with no file and expect 422 validation error."""
+    response = client.post("/wizard/detect-fields")
+    assert response.status_code == 422
+
+
+def test_detect_fields_mixed_types(client):
+    """Upload a PDF with all three field types and verify all are detected."""
+    fields = [
+        {"name": "full_name", "field_type": "/Tx", "rect": [50, 700, 250, 720]},
+        {"name": "email", "field_type": "/Tx", "rect": [50, 660, 250, 680]},
+        {"name": "agree_terms", "field_type": "/Btn", "rect": [50, 620, 70, 640]},
+        {"name": "priority", "field_type": "/Ch", "rect": [50, 580, 200, 600]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("mixed_form.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total_fields"] == 4
+
+    types = [f["field_type"] for f in data["pages"][0]["fields"]]
+    assert "Text" in types
+    assert "Button" in types
+    assert "Choice" in types
+
+
+def test_detect_fields_response_schema(client):
+    """Verify the response matches the expected schema structure."""
+    fields = [
+        {"name": "test", "field_type": "/Tx", "rect": [0, 0, 100, 20]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("schema_test.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Top-level keys
+    assert "filename" in data
+    assert "total_pages" in data
+    assert "total_fields" in data
+    assert "pages" in data
+
+    # Page-level keys
+    page = data["pages"][0]
+    assert "page_number" in page
+    assert "fields" in page
+
+    # Field-level keys
+    field = page["fields"][0]
+    assert "field_name" in field
+    assert "field_type" in field
+    assert "raw_type" in field
+    assert "rect" in field
+
+    # Rect keys
+    rect = field["rect"]
+    assert "x" in rect
+    assert "y" in rect
+    assert "width" in rect
+    assert "height" in rect


### PR DESCRIPTION
<img width="1884" height="200" alt="image" src="https://github.com/user-attachments/assets/4ea2f698-505c-4945-b49c-0f1c1e555b3d" />

<img width="1815" height="873" alt="image" src="https://github.com/user-attachments/assets/33ff6aaa-abe7-4f4f-9545-9e118eab2acf" />



**Title:** `feat: implement PDF field detection engine for Field Mapping Wizard (#111)`

**Description:**

---

## 📝 Summary

This PR implements **Phase 1** of the Field Mapping Wizard (#111) — the backend PDF field detection engine that automatically extracts all interactive form fields from uploaded PDFs.

### The Problem

Setting up a new agency's PDF template in FireForm currently requires a developer to manually open the PDF, inspect every field name, and hand-type a JSON dictionary. For a typical fire incident report with **50+ fields**, this is a massive bottleneck — especially for departments without dedicated IT staff.

### The Solution

A new `POST /wizard/detect-fields` endpoint that accepts a PDF upload and returns structured metadata for every fillable field:

```json
{
  "filename": "fire_response_report.pdf",
  "total_pages": 1,
  "total_fields": 50,
  "pages": [
    {
      "page_number": 1,
      "fields": [
        {
          "field_name": "Incident_Report_Number",
          "field_type": "Text",
          "raw_type": "/Tx",
          "rect": { "x": 72.0, "y": 660.0, "width": 150.0, "height": 18.0 }
        }
      ]
    }
  ]
}
```

### What was built

| File | Purpose |
|---|---|
| `src/field_detector.py` | `PDFFieldDetector` class — parses `/Annots` → `/Widget` annotations to extract field name, type, and bounding box |
| `src/controller.py` | Added `detect_fields()` method following the existing delegation pattern |
| `api/routes/wizard.py` | `POST /wizard/detect-fields` endpoint with PDF upload and validation |
| `api/schemas/wizard.py` | Pydantic response models (`DetectFieldsResponse`, `DetectedField`, `FieldRect`) |
| `api/main.py` | Registered the wizard router |
| `requirements.txt` | Added `pypdf` (was already imported in `src/main.py` but not listed) |
| `tests/test_wizard.py` | 7 tests covering valid PDFs, empty PDFs, non-PDF files, mixed field types, bounding box accuracy |

### Supported Field Types

| PDF Type | Detected As | Examples |
|---|---|---|
| `/Tx` | Text | Text inputs, text areas |
| `/Btn` | Button | Checkboxes, radio buttons |
| `/Ch` | Choice | Dropdowns, list boxes |

### How this relates to existing code

The existing `src/filler.py` already iterates `/Widget` annotations to fill PDF fields. This PR **extracts and formalizes** that logic into a standalone, reusable class that:
- Adds field **type classification** (the filler doesn't distinguish `/Tx` from `/Btn`)
- Returns structured **bounding box coordinates** (the filler only uses `Rect` for sort order)
- **Exposes this data via API** (the filler is internal-only)

### Limitations

- Only works with **digitally created fillable PDFs** (AcroForms). Scanned/image-based PDFs return zero fields — OCR integration would be a future enhancement.
- No LLM or Ollama dependency — this is pure PDF metadata parsing.

### How to Test

```bash
# Run tests
python -m pytest tests/test_wizard.py -v

# Or via Docker
docker compose exec app python3 -m pytest tests/test_wizard.py -v

# Manual test via Swagger UI
python -m uvicorn api.main:app --reload --port 8000
# Open http://localhost:8000/docs → POST /wizard/detect-fields → upload any fillable PDF
```
