### PR TITLE
 End-to-End Field Mapping Wizard (Backend + Frontend)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routes import forms, templates
+from api.routes import forms, templates, wizard
 
 app = FastAPI()
 
@@ -24,3 +24,4 @@ app.add_middleware(
 
 app.include_router(templates.router)
 app.include_router(forms.router)
+app.include_router(wizard.router)

--- a/api/routes/wizard.py
+++ b/api/routes/wizard.py
@@ -1,0 +1,63 @@
+import tempfile
+from pathlib import Path
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from api.schemas.wizard import DetectFieldsResponse
+from src.controller import Controller
+
+router = APIRouter(prefix="/wizard", tags=["wizard"])
+
+
+@router.post("/detect-fields", response_model=DetectFieldsResponse)
+async def detect_fields(file: UploadFile = File(...)):
+    """Upload a PDF and detect all interactive form fields.
+
+    Parses the PDF's /Annots annotations for /Widget subtypes and
+    returns each field's name, type (Text, Button, Choice), and
+    bounding box coordinates (X, Y, Width, Height).
+
+    This endpoint powers the Field Mapping Wizard, enabling
+    non-technical users to see all fillable fields in a PDF
+    before mapping them to FireForm's data schema.
+
+    **Supported field types:**
+    - Text (/Tx): Text inputs and text areas
+    - Button (/Btn): Checkboxes and radio buttons
+    - Choice (/Ch): Dropdowns and list boxes
+
+    **Note:** Only digitally created fillable PDFs (AcroForms) are
+    supported. Scanned/image-based PDFs will return zero fields.
+    """
+    filename = Path(file.filename or "").name
+    if not filename:
+        raise HTTPException(status_code=400, detail="A PDF filename is required.")
+
+    if not filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Only PDF files are supported.")
+
+    try:
+        content = await file.read()
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = tmp.name
+
+        controller = Controller()
+        result = controller.detect_fields(tmp_path)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to process PDF: {str(e)}",
+        )
+    finally:
+        # Clean up temp file
+        try:
+            Path(tmp_path).unlink(missing_ok=True)
+        except (NameError, OSError):
+            pass
+
+    return result

--- a/api/schemas/wizard.py
+++ b/api/schemas/wizard.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel
+
+
+class FieldRect(BaseModel):
+    """Bounding box coordinates for a detected PDF form field."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class DetectedField(BaseModel):
+    """Metadata for a single detected interactive form field."""
+
+    field_name: str
+    field_type: str  # "Text", "Button", "Choice", or "Unknown"
+    raw_type: str  # "/Tx", "/Btn", "/Ch"
+    rect: FieldRect
+
+
+class PageFields(BaseModel):
+    """All detected fields on a single PDF page."""
+
+    page_number: int
+    fields: list[DetectedField]
+
+
+class DetectFieldsResponse(BaseModel):
+    """Response schema for the /wizard/detect-fields endpoint."""
+
+    filename: str
+    total_pages: int
+    total_fields: int
+    pages: list[PageFields]

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -27,11 +27,22 @@ const elements = {
   previewPathBtn: document.getElementById("previewPathBtn"),
   previewStatus: document.getElementById("previewStatus"),
   pdfFrame: document.getElementById("pdfFrame"),
+  wizardPdfFile: document.getElementById("wizardPdfFile"),
+  wizardDropZone: document.getElementById("wizardDropZone"),
+  wizardFileMeta: document.getElementById("wizardFileMeta"),
+  wizardDetectBtn: document.getElementById("wizardDetectBtn"),
+  wizardStatus: document.getElementById("wizardStatus"),
+  wizardResults: document.getElementById("wizardResults"),
+  wizardSummary: document.getElementById("wizardSummary"),
+  wizardFieldsList: document.getElementById("wizardFieldsList"),
+  wizardUseTemplateBtn: document.getElementById("wizardUseTemplateBtn"),
 };
 
 let templates = loadTemplates();
 let activeObjectUrl = null;
 let selectedTemplateFile = null;
+let selectedWizardFile = null;
+let lastWizardResult = null;
 
 initialize();
 
@@ -61,6 +72,14 @@ function bindEvents() {
   elements.previewPathBtn.addEventListener("click", () =>
     previewFromPath(elements.serverPdfPath.value, { switchToPreview: true })
   );
+  elements.wizardPdfFile.addEventListener("change", handleWizardFileInput);
+  elements.wizardDropZone.addEventListener("click", () => elements.wizardPdfFile.click());
+  elements.wizardDropZone.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") { e.preventDefault(); elements.wizardPdfFile.click(); }
+  });
+  bindWizardDropZoneDragEvents();
+  elements.wizardDetectBtn.addEventListener("click", handleWizardDetect);
+  elements.wizardUseTemplateBtn.addEventListener("click", useWizardAsTemplate);
 }
 
 function activateSection(targetId) {
@@ -609,4 +628,196 @@ function extractErrorMessage(responseBody, statusCode) {
     }
   }
   return `Request failed with status ${statusCode}.`;
+}
+
+// ─── Field Wizard ─────────────────────────────────────────────
+
+function bindWizardDropZoneDragEvents() {
+  ["dragenter", "dragover"].forEach((eventName) => {
+    elements.wizardDropZone.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      elements.wizardDropZone.classList.add("active");
+    });
+  });
+
+  ["dragleave", "dragend", "drop"].forEach((eventName) => {
+    elements.wizardDropZone.addEventListener(eventName, (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      elements.wizardDropZone.classList.remove("active");
+    });
+  });
+
+  elements.wizardDropZone.addEventListener("drop", (event) => {
+    const file = event.dataTransfer?.files?.[0];
+    setSelectedWizardFile(file);
+  });
+}
+
+function handleWizardFileInput(event) {
+  const file = event.target.files && event.target.files[0];
+  setSelectedWizardFile(file);
+}
+
+function setSelectedWizardFile(file) {
+  if (!file) return;
+
+  if (!isPdfFile(file)) {
+    selectedWizardFile = null;
+    elements.wizardDetectBtn.disabled = true;
+    setStatus(elements.wizardStatus, "Please select a PDF file.", "error");
+    elements.wizardFileMeta.textContent = "No PDF selected.";
+    return;
+  }
+
+  selectedWizardFile = file;
+  elements.wizardDetectBtn.disabled = false;
+  elements.wizardFileMeta.textContent = `Selected: ${file.name} (${formatBytes(file.size)})`;
+  setStatus(elements.wizardStatus, "");
+  elements.wizardResults.classList.add("hidden");
+}
+
+async function handleWizardDetect() {
+  if (!selectedWizardFile) {
+    setStatus(elements.wizardStatus, "Please select a PDF file first.", "error");
+    return;
+  }
+
+  elements.wizardDetectBtn.classList.add("loading");
+  elements.wizardDetectBtn.disabled = true;
+  elements.wizardResults.classList.add("hidden");
+  setStatus(elements.wizardStatus, "Analyzing PDF for form fields...", "info");
+
+  try {
+    const formData = new FormData();
+    formData.append("file", selectedWizardFile, selectedWizardFile.name);
+
+    const response = await fetch(`${API_BASE_URL}/wizard/detect-fields`, {
+      method: "POST",
+      body: formData,
+    });
+
+    const body = await parseJsonResponse(response);
+    if (!response.ok) {
+      throw new Error(extractErrorMessage(body, response.status));
+    }
+
+    lastWizardResult = body;
+    renderWizardResults(body);
+
+    if (body.total_fields > 0) {
+      setStatus(
+        elements.wizardStatus,
+        `Detected ${body.total_fields} field(s) across ${body.total_pages} page(s).`,
+        "success"
+      );
+    } else {
+      setStatus(
+        elements.wizardStatus,
+        "No interactive form fields detected. This may be a scanned/image PDF.",
+        "info"
+      );
+    }
+  } catch (error) {
+    setStatus(elements.wizardStatus, error.message, "error");
+  } finally {
+    elements.wizardDetectBtn.classList.remove("loading");
+    elements.wizardDetectBtn.disabled = false;
+  }
+}
+
+function renderWizardResults(data) {
+  elements.wizardResults.classList.remove("hidden");
+
+  // Summary bar
+  elements.wizardSummary.innerHTML = "";
+  elements.wizardSummary.className = data.total_fields > 0
+    ? "wizard-summary has-fields"
+    : "wizard-summary no-fields";
+  elements.wizardSummary.textContent = data.total_fields > 0
+    ? `\u2705 ${data.total_fields} field(s) found in ${data.filename} (${data.total_pages} page${data.total_pages !== 1 ? "s" : ""})`
+    : `\u26a0\ufe0f No fillable fields found in ${data.filename}`;
+
+  // Show or hide the "Use as Template" button
+  if (data.total_fields > 0) {
+    elements.wizardUseTemplateBtn.classList.remove("hidden");
+  } else {
+    elements.wizardUseTemplateBtn.classList.add("hidden");
+  }
+
+  // Fields list
+  elements.wizardFieldsList.innerHTML = "";
+
+  if (data.total_fields === 0) return;
+
+  data.pages.forEach((page) => {
+    if (page.fields.length === 0) return;
+
+    const group = document.createElement("div");
+    group.className = "wizard-page-group";
+
+    const header = document.createElement("div");
+    header.className = "wizard-page-header";
+    header.textContent = `Page ${page.page_number} \u2014 ${page.fields.length} field(s)`;
+    group.appendChild(header);
+
+    page.fields.forEach((field) => {
+      const card = document.createElement("div");
+      card.className = "wizard-field-card";
+
+      const name = document.createElement("span");
+      name.className = "wizard-field-name";
+      name.textContent = field.field_name;
+
+      const badge = document.createElement("span");
+      badge.className = `field-type-badge ${field.field_type.toLowerCase()}`;
+      badge.textContent = field.field_type;
+
+      const coords = document.createElement("span");
+      coords.className = "field-coords";
+      coords.textContent = `${field.rect.width}\u00d7${field.rect.height} @ (${field.rect.x}, ${field.rect.y})`;
+
+      card.append(name, badge, coords);
+      group.appendChild(card);
+    });
+
+    elements.wizardFieldsList.appendChild(group);
+  });
+}
+
+function useWizardAsTemplate() {
+  if (!lastWizardResult || lastWizardResult.total_fields === 0) {
+    setStatus(elements.wizardStatus, "No fields detected to use.", "error");
+    return;
+  }
+
+  // Build a fields dict: { field_name: field_type } for all pages
+  const fieldsDict = {};
+  lastWizardResult.pages.forEach((page) => {
+    page.fields.forEach((field) => {
+      fieldsDict[field.field_name] = field.field_type.toLowerCase();
+    });
+  });
+
+  // Auto-fill the template creation form
+  const filename = lastWizardResult.filename || "Untitled";
+  const templateName = filename.replace(/\.pdf$/i, "").replace(/[_-]/g, " ");
+  elements.templateName.value = templateName;
+  elements.templateFields.value = JSON.stringify(fieldsDict, null, 2);
+
+  // Transfer the wizard's PDF file to the template file selector
+  if (selectedWizardFile) {
+    selectedTemplateFile = selectedWizardFile;
+    updateSelectedFileMeta();
+  }
+
+  // Switch to the Upload Template tab
+  activateSection("uploaderSection");
+
+  setStatus(
+    elements.templateFormMessage,
+    `\u2705 Auto-filled from wizard: "${templateName}" with ${lastWizardResult.total_fields} field(s). Review and click Create Template.`,
+    "success"
+  );
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,9 @@
         <button class="tab" type="button" data-target="pdfPreviewerSection">
           PDF Preview
         </button>
+        <button class="tab" type="button" data-target="fieldWizardSection">
+          🧙 Field Wizard
+        </button>
       </nav>
 
       <section id="uploaderSection" class="panel card">
@@ -132,6 +135,39 @@
 
         <p id="previewStatus" class="status" aria-live="polite"></p>
         <iframe id="pdfFrame" title="PDF Preview"></iframe>
+      </section>
+
+      <section id="fieldWizardSection" class="panel card hidden">
+        <h2>🧙 Field Mapping Wizard</h2>
+        <p class="helper">
+          Upload a PDF to automatically detect all fillable form fields.
+          Only digitally created fillable PDFs (AcroForms) are supported.
+        </p>
+
+        <input id="wizardPdfFile" type="file" accept="application/pdf" class="hidden" />
+        <div
+          id="wizardDropZone"
+          class="dropzone"
+          role="button"
+          tabindex="0"
+          aria-label="Drag and drop a PDF to analyze or click to select"
+        >
+          <strong>Drop a PDF here to analyze</strong>
+          <span>or click to select a file</span>
+        </div>
+        <p id="wizardFileMeta" class="helper">No PDF selected.</p>
+
+        <button id="wizardDetectBtn" type="button" disabled>Detect Fields</button>
+
+        <p id="wizardStatus" class="status" aria-live="polite"></p>
+
+        <div id="wizardResults" class="wizard-results hidden">
+          <div id="wizardSummary" class="wizard-summary"></div>
+          <button id="wizardUseTemplateBtn" type="button" class="wizard-use-btn hidden">
+            🚀 Use as Template — Auto-fill the Create Template form with these fields
+          </button>
+          <div id="wizardFieldsList" class="wizard-fields-list"></div>
+        </div>
       </section>
     </main>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -292,3 +292,173 @@ button:hover {
     min-height: 420px;
   }
 }
+
+/* ─── Field Wizard ───────────────────────────────── */
+
+.wizard-results {
+  display: grid;
+  gap: 16px;
+}
+
+.wizard-summary {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.wizard-summary.has-fields {
+  background: #eef7ee;
+  border: 1px solid #b8d9b8;
+  color: #1a5c2e;
+}
+
+.wizard-summary.no-fields {
+  background: #fef7e6;
+  border: 1px solid #e3c97a;
+  color: #7a5e12;
+}
+
+.wizard-fields-list {
+  display: grid;
+  gap: 14px;
+}
+
+.wizard-page-group {
+  display: grid;
+  gap: 8px;
+}
+
+.wizard-page-header {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--primary);
+  padding: 6px 0;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.wizard-field-card {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid #d7dde3;
+  border-radius: 10px;
+  background: #fcfdfe;
+  transition: box-shadow 0.15s ease;
+}
+
+.wizard-field-card:hover {
+  box-shadow: 0 2px 8px rgba(16, 44, 70, 0.08);
+}
+
+.wizard-field-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.field-type-badge {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.field-type-badge.text {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.field-type-badge.button {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.field-type-badge.choice {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.field-type-badge.unknown {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.field-coords {
+  font-family: "IBM Plex Mono", "Menlo", "Consolas", monospace;
+  font-size: 0.78rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+#wizardDetectBtn {
+  justify-self: start;
+}
+
+#wizardDetectBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+#wizardDetectBtn.loading {
+  position: relative;
+  color: transparent;
+  pointer-events: none;
+}
+
+#wizardDetectBtn.loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  margin: -9px 0 0 -9px;
+  border: 2px solid #fff;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: wizard-spin 0.6s linear infinite;
+}
+
+@keyframes wizard-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 720px) {
+  .wizard-field-card {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+}
+
+.wizard-use-btn {
+  width: 100%;
+  padding: 14px 18px;
+  background: var(--success);
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.wizard-use-btn:hover {
+  background: #15673d;
+  transform: translateY(-1px);
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 pdfrw
+pypdf
 flask
 commonforms
 fastapi

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,11 +1,16 @@
 from src.file_manipulator import FileManipulator
+from src.field_detector import PDFFieldDetector
 
 class Controller:
     def __init__(self):
         self.file_manipulator = FileManipulator()
+        self.field_detector = PDFFieldDetector()
 
     def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
         return self.file_manipulator.fill_form(user_input, fields, pdf_form_path)
     
     def create_template(self, pdf_path: str):
         return self.file_manipulator.create_template(pdf_path)
+
+    def detect_fields(self, pdf_path: str):
+        return self.field_detector.detect_fields(pdf_path)

--- a/src/field_detector.py
+++ b/src/field_detector.py
@@ -1,0 +1,191 @@
+"""
+PDF Field Detector Module
+=========================
+Detects and extracts interactive form field metadata from PDF files.
+
+This module parses PDF annotations (/Annots with /Widget subtypes) to
+extract field names, types, and bounding box coordinates. It is the
+backend engine that powers the Field Mapping Wizard (Issue #111).
+
+Supported field types:
+    - /Tx  → Text (text inputs, text areas)
+    - /Btn → Button (checkboxes, radio buttons)
+    - /Ch  → Choice (dropdowns, list boxes)
+
+Note: This detector works with digitally created fillable PDFs
+(AcroForms). Scanned/image-based PDFs are not supported and would
+require OCR integration as a future enhancement.
+"""
+
+from pypdf import PdfReader
+
+
+class PDFFieldDetector:
+    """Detects and extracts interactive form field metadata from PDF files.
+
+    Parses each page's /Annots annotations, filters for /Widget subtypes
+    (interactive form fields), and extracts:
+        - Field name (from the /T key)
+        - Field type (/Tx, /Btn, /Ch)
+        - Bounding box coordinates (X, Y, Width, Height)
+
+    This data is structured for frontend visual rendering and eventual
+    drag-and-drop field mapping.
+    """
+
+    FIELD_TYPE_MAP = {
+        "/Tx": "Text",
+        "/Btn": "Button",
+        "/Ch": "Choice",
+    }
+
+    def detect_fields(self, pdf_path: str) -> dict:
+        """Parse a PDF and return all detected interactive form fields.
+
+        Args:
+            pdf_path: Absolute or relative path to the PDF file.
+
+        Returns:
+            A dictionary with the following structure::
+
+                {
+                    "filename": "form.pdf",
+                    "total_pages": 3,
+                    "total_fields": 12,
+                    "pages": [
+                        {
+                            "page_number": 1,
+                            "fields": [
+                                {
+                                    "field_name": "Employee Name",
+                                    "field_type": "Text",
+                                    "raw_type": "/Tx",
+                                    "rect": {
+                                        "x": 72.0,
+                                        "y": 700.0,
+                                        "width": 200.0,
+                                        "height": 20.0
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+
+        Raises:
+            FileNotFoundError: If the PDF file does not exist.
+            Exception: If the PDF cannot be parsed.
+        """
+        reader = PdfReader(pdf_path)
+        filename = pdf_path.split("/")[-1].split("\\")[-1]
+
+        pages = []
+        total_fields = 0
+
+        for page_index, page in enumerate(reader.pages):
+            page_fields = self._extract_page_fields(page)
+            total_fields += len(page_fields)
+            pages.append(
+                {
+                    "page_number": page_index + 1,
+                    "fields": page_fields,
+                }
+            )
+
+        return {
+            "filename": filename,
+            "total_pages": len(reader.pages),
+            "total_fields": total_fields,
+            "pages": pages,
+        }
+
+    def _extract_page_fields(self, page) -> list:
+        """Extract form fields from a single PDF page.
+
+        Args:
+            page: A pypdf PageObject.
+
+        Returns:
+            A list of field metadata dictionaries. Returns an empty
+            list if the page has no annotations or no widget fields.
+        """
+        annotations = page.get("/Annots")
+        if not annotations:
+            return []
+
+        fields = []
+        for annotation in annotations:
+            annotation_obj = annotation.get_object()
+            field = self._parse_annotation(annotation_obj)
+            if field is not None:
+                fields.append(field)
+
+        return fields
+
+    def _parse_annotation(self, annotation) -> dict | None:
+        """Parse a single annotation into field metadata.
+
+        Only processes /Widget subtype annotations that have a field
+        name (/T key) and a recognized field type (/FT key).
+
+        Args:
+            annotation: A resolved PDF annotation dictionary object.
+
+        Returns:
+            A field metadata dictionary, or None if the annotation
+            is not a recognized interactive form field.
+        """
+        subtype = annotation.get("/Subtype")
+        if subtype != "/Widget":
+            return None
+
+        field_name = annotation.get("/T")
+        if not field_name:
+            return None
+
+        raw_type = annotation.get("/FT", "")
+        field_type = self.FIELD_TYPE_MAP.get(raw_type, "Unknown")
+
+        rect = self._extract_rect(annotation)
+
+        return {
+            "field_name": str(field_name),
+            "field_type": field_type,
+            "raw_type": str(raw_type),
+            "rect": rect,
+        }
+
+    @staticmethod
+    def _extract_rect(annotation) -> dict:
+        """Extract bounding box coordinates from an annotation's /Rect.
+
+        The PDF /Rect array is [x1, y1, x2, y2] where (x1, y1) is the
+        lower-left corner and (x2, y2) is the upper-right corner.
+        This method converts it to {x, y, width, height} for easier
+        frontend rendering.
+
+        Args:
+            annotation: A resolved PDF annotation dictionary object.
+
+        Returns:
+            A dictionary with x, y, width, and height. Returns all
+            zeros if no /Rect is found.
+        """
+        rect_array = annotation.get("/Rect")
+        if not rect_array or len(rect_array) < 4:
+            return {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+
+        try:
+            x1 = float(rect_array[0])
+            y1 = float(rect_array[1])
+            x2 = float(rect_array[2])
+            y2 = float(rect_array[3])
+        except (ValueError, TypeError):
+            return {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.0}
+
+        return {
+            "x": round(min(x1, x2), 2),
+            "y": round(min(y1, y2), 2),
+            "width": round(abs(x2 - x1), 2),
+            "height": round(abs(y2 - y1), 2),
+        }

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,0 +1,221 @@
+"""
+Tests for the Field Mapping Wizard endpoint and PDFFieldDetector.
+
+These tests create minimal PDF files with form fields programmatically
+using pypdf, so no external test fixtures are needed.
+"""
+
+import io
+
+from pypdf import PdfWriter
+from pypdf.annotations import FreeText
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    FloatObject,
+    NameObject,
+    TextStringObject,
+)
+
+
+def _create_pdf_with_fields(fields: list[dict]) -> bytes:
+    """Create a minimal PDF with form widget annotations.
+
+    Args:
+        fields: List of dicts with keys:
+            - name (str): Field name
+            - field_type (str): "/Tx", "/Btn", or "/Ch"
+            - rect (list[float]): [x1, y1, x2, y2]
+
+    Returns:
+        PDF content as bytes.
+    """
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+
+    for field_spec in fields:
+        annotation = DictionaryObject()
+        annotation.update(
+            {
+                NameObject("/Type"): NameObject("/Annot"),
+                NameObject("/Subtype"): NameObject("/Widget"),
+                NameObject("/T"): TextStringObject(field_spec["name"]),
+                NameObject("/FT"): NameObject(field_spec["field_type"]),
+                NameObject("/Rect"): ArrayObject(
+                    [FloatObject(v) for v in field_spec["rect"]]
+                ),
+            }
+        )
+        writer.add_annotation(page_number=0, annotation=annotation)
+
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def _create_blank_pdf() -> bytes:
+    """Create a minimal PDF with no form fields."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+# ─── Endpoint Tests ───────────────────────────────────────────────
+
+
+def test_detect_fields_valid_pdf(client):
+    """Upload a PDF with known form fields and verify detection."""
+    fields = [
+        {"name": "employee_name", "field_type": "/Tx", "rect": [72, 700, 272, 720]},
+        {"name": "is_active", "field_type": "/Btn", "rect": [72, 660, 92, 680]},
+        {"name": "department", "field_type": "/Ch", "rect": [72, 620, 272, 640]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("test_form.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["filename"] == "test_form.pdf"
+    assert data["total_pages"] == 1
+    assert data["total_fields"] == 3
+
+    page = data["pages"][0]
+    assert page["page_number"] == 1
+    assert len(page["fields"]) == 3
+
+    # Verify field types are correctly classified
+    type_map = {f["field_name"]: f["field_type"] for f in page["fields"]}
+    assert type_map["employee_name"] == "Text"
+    assert type_map["is_active"] == "Button"
+    assert type_map["department"] == "Choice"
+
+
+def test_detect_fields_bounding_box(client):
+    """Verify bounding box coordinates are correctly extracted."""
+    fields = [
+        {"name": "test_field", "field_type": "/Tx", "rect": [72.0, 700.0, 272.0, 720.0]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("test_rect.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    rect = data["pages"][0]["fields"][0]["rect"]
+
+    assert rect["x"] == 72.0
+    assert rect["y"] == 700.0
+    assert rect["width"] == 200.0
+    assert rect["height"] == 20.0
+
+
+def test_detect_fields_no_widgets(client):
+    """Upload a PDF without form fields and verify graceful handling."""
+    pdf_bytes = _create_blank_pdf()
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("blank.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total_fields"] == 0
+    assert data["total_pages"] == 1
+    assert len(data["pages"]) == 1
+    assert len(data["pages"][0]["fields"]) == 0
+
+
+def test_detect_fields_non_pdf(client):
+    """Upload a non-PDF file and expect 400 error."""
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("readme.txt", b"Hello world", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "PDF" in response.json()["detail"]
+
+
+def test_detect_fields_no_file(client):
+    """POST with no file and expect 422 validation error."""
+    response = client.post("/wizard/detect-fields")
+    assert response.status_code == 422
+
+
+def test_detect_fields_mixed_types(client):
+    """Upload a PDF with all three field types and verify all are detected."""
+    fields = [
+        {"name": "full_name", "field_type": "/Tx", "rect": [50, 700, 250, 720]},
+        {"name": "email", "field_type": "/Tx", "rect": [50, 660, 250, 680]},
+        {"name": "agree_terms", "field_type": "/Btn", "rect": [50, 620, 70, 640]},
+        {"name": "priority", "field_type": "/Ch", "rect": [50, 580, 200, 600]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("mixed_form.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["total_fields"] == 4
+
+    types = [f["field_type"] for f in data["pages"][0]["fields"]]
+    assert "Text" in types
+    assert "Button" in types
+    assert "Choice" in types
+
+
+def test_detect_fields_response_schema(client):
+    """Verify the response matches the expected schema structure."""
+    fields = [
+        {"name": "test", "field_type": "/Tx", "rect": [0, 0, 100, 20]},
+    ]
+    pdf_bytes = _create_pdf_with_fields(fields)
+
+    response = client.post(
+        "/wizard/detect-fields",
+        files={"file": ("schema_test.pdf", pdf_bytes, "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Top-level keys
+    assert "filename" in data
+    assert "total_pages" in data
+    assert "total_fields" in data
+    assert "pages" in data
+
+    # Page-level keys
+    page = data["pages"][0]
+    assert "page_number" in page
+    assert "fields" in page
+
+    # Field-level keys
+    field = page["fields"][0]
+    assert "field_name" in field
+    assert "field_type" in field
+    assert "raw_type" in field
+    assert "rect" in field
+
+    # Rect keys
+    rect = field["rect"]
+    assert "x" in rect
+    assert "y" in rect
+    assert "width" in rect
+    assert "height" in rect


### PR DESCRIPTION


## Summary

This PR implements the complete Field Mapping Wizard (#111), enabling users to upload a PDF, automatically detect all form fields, and create a template in a single flow.

It includes:

* Backend PDF field detection engine
* Frontend Wizard UI
* One-click template creation workflow

This reduces template setup time from manual effort (~30 minutes) to a few seconds.

---

## Problem

Creating templates from fillable PDFs currently requires:

1. Manually inspecting each field in the PDF
2. Copying field names
3. Writing a JSON mapping
4. Handling errors manually

This becomes inefficient and error-prone for PDFs with many fields.

---

## Solution

A unified wizard that:

1. Accepts a PDF upload
2. Detects all form fields automatically
3. Displays them in the UI
4. Allows instant template creation

---

###Screenshots and Videos 

<img width="1873" height="871" alt="Screenshot 2026-04-16 125347" src="https://github.com/user-attachments/assets/71f13fc9-db6b-4412-986f-afbd82720842" />

<img width="1526" height="874" alt="Screenshot 2026-04-16 124121" src="https://github.com/user-attachments/assets/13073a43-94ec-4334-aee0-4491453fd906" />



## Key Features

### Backend: Field Detection API

* Endpoint: `POST /wizard/detect-fields`
* Extracts:

  * Field name
  * Field type (`Text`, `Button`, `Choice`)
  * Raw PDF type
  * Bounding box coordinates
* Returns structured, page-wise metadata
* Built using `pypdf`

Example response:

```json
{
  "filename": "fire_response_report.pdf",
  "total_pages": 1,
  "total_fields": 50,
  "pages": [
    {
      "page_number": 1,
      "fields": [
        {
          "field_name": "Incident_Report_Number",
          "field_type": "Text",
          "raw_type": "/Tx",
          "rect": { "x": 72.0, "y": 660.0, "width": 150.0, "height": 18.0 }
        }
      ]
    }
  ]
}
```

---

### Frontend: Field Wizard UI

* New “Field Wizard” tab
* Drag-and-drop PDF upload
* Field detection trigger
* Visual display grouped by page
* Type-based field labeling

---

### One-Click Template Creation

* Converts detected fields into JSON mapping
* Auto-generates template name from filename
* Transfers PDF to template upload
* Pre-fills template creation form

User only needs to submit the form.

---

## Implementation Details

### Backend

* `src/field_detector.py`: Field extraction logic
* `src/controller.py`: Detection integration
* `api/routes/wizard.py`: API endpoint
* `api/schemas/wizard.py`: Response models
* `tests/test_wizard.py`: Test coverage
* `requirements.txt`: Added `pypdf`

### Frontend

* `frontend/index.html`: Wizard UI
* `frontend/styles.css`: Layout and styling
* `frontend/app.js`: API integration and workflow logic

---

## Relation to Existing Code

* Reuses PDF parsing logic from `src/filler.py`
* Refactors it into a reusable detection module
* Extends it with structured output and API exposure

---

## Limitations

* Supports only fillable PDFs (AcroForms)
* Scanned/image PDFs return no fields
* No OCR support
* No AI dependency

---

## How to Test

### Backend

```bash
python -m pytest tests/test_wizard.py -v
```

Run API:

```bash
python -m uvicorn api.main:app --reload --port 8000
```

---

### Frontend

```bash
cd frontend
python -m http.server 5173
```

Open:
`http://127.0.0.1:5173`

Flow:

1. Upload PDF
2. Detect fields
3. Use as template

---

## Future Work

* Visual PDF canvas with field overlays
* Drag-and-drop schema mapping
* Field renaming
* OCR for scanned PDFs
* AI-based field mapping

---

Closes Phase 1 and 2 of #111
