### PR TITLE
fix: update PR template test configuration fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -21,9 +21,9 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] Test B
 
 **Test Configuration**:
-* Firmware version:
-* Hardware:
-* SDK:
+* Python version:
+* Docker/Compose version:
+* OS:
 
 ## Checklist:
 


### PR DESCRIPTION
## Description

The PR template's **Test Configuration** section contains generic hardware-related fields (`Firmware version`, `Hardware`, `SDK`) that appear to be copy-pasted from a hardware project template and aren't relevant to FireForm.

Replaced with fields that match our stack:
- **Python version**
- **Docker/Compose version**
- **OS**

Fixes #458

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified the template renders correctly on GitHub by previewing the markdown.

**Test Configuration**:
* Python version: 3.11
* Docker/Compose version: 27.x / 2.x
* OS: macOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
