### PR TITLE
fix: add file size limit on PDF template upload to prevent DoS

### DIFF
--- a/api/routes/templates.py
+++ b/api/routes/templates.py
@@ -75,6 +75,8 @@ async def upload_template_pdf(
         target_path = target_dir / f"{target_path.stem}_{timestamp}{target_path.suffix}"
 
     content = await file.read()
+    if len(content) > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File too large. Maximum size is 10MB.")
     with target_path.open("wb") as output_file:
         output_file.write(content)
 

--- a/api/routes/templates.py
+++ b/api/routes/templates.py
@@ -17,6 +17,7 @@ from src.controller import Controller
 router = APIRouter(prefix="/templates", tags=["templates"])
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_TEMPLATE_DIR = "src/inputs"
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
 
 
 def _resolve_target_directory(directory: str) -> Path:


### PR DESCRIPTION
## Summary

Fixes #460

The `POST /templates/upload` endpoint was reading the entire uploaded file into memory without any size validation, making it vulnerable to memory exhaustion from large file uploads.

## Changes

- Added `MAX_UPLOAD_SIZE = 10 * 1024 * 1024` (10MB) constant
- After reading the file content, added a size check that returns `HTTP 413` if the file exceeds the limit

## Why 10MB?

Typical PDF form templates are well under 1MB. A 10MB cap gives reasonable headroom while still protecting against oversized uploads that could exhaust server memory or cause a DoS.

## Test Plan

- [ ] Upload a PDF under 10MB — should succeed as before
- [ ] Upload a file over 10MB — should receive `413 File too large. Maximum size is 10MB.`
- [ ] Existing upload functionality unaffected