### PR TITLE
fix: form fields are passed as list instead of dict

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -4,7 +4,7 @@ class Controller:
     def __init__(self):
         self.file_manipulator = FileManipulator()
 
-    def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
+    def fill_form(self, user_input: str, fields: dict, pdf_form_path: str):
         return self.file_manipulator.fill_form(user_input, fields, pdf_form_path)
     
     def create_template(self, pdf_path: str):

--- a/src/file_manipulator.py
+++ b/src/file_manipulator.py
@@ -10,7 +10,7 @@ class FileManipulator:
 
     def create_template(self, pdf_path: str):
         """
-        By using commonforms, we create an editable .pdf template and we store it.
+        Create an editable PDF template using commonforms and write it to disk.
         """
         # Lazy import
         from commonforms import prepare_form
@@ -23,7 +23,7 @@ class FileManipulator:
         prepare_form(pdf_path, template_path)
         return template_path
 
-    def fill_form(self, user_input: str, fields: list, pdf_form_path: str):
+    def fill_form(self, user_input: str, fields: dict, pdf_form_path: str):
         """
         It receives the raw data, runs the PDF filling logic,
         and returns the path to the newly created file.

--- a/src/llm.py
+++ b/src/llm.py
@@ -9,7 +9,7 @@ class LLM:
         if json is None:
             json = {}
         self._transcript_text = transcript_text  # str
-        self._target_fields = target_fields  # List, contains the template field.
+        self._target_fields = target_fields  # dict, maps field names to their values
         self._json = json  # dictionary
 
     def type_check_all(self):
@@ -18,7 +18,7 @@ class LLM:
                 f"ERROR in LLM() attributes ->\
                 Transcript must be text. Input:\n\ttranscript_text: {self._transcript_text}"
             )
-        elif type(self._target_fields) is not list:
+        elif type(self._target_fields) is not dict:
             raise TypeError(
                 f"ERROR in LLM() attributes ->\
                 Target fields must be a list. Input:\n\ttarget_fields: {self._target_fields}"


### PR DESCRIPTION
Fields were being passed as a list. 
in main.py
```
reader = PdfReader(prepared_pdf)
    fields = reader.get_fields()
```
returns a dict.
Updated `controller.py, file_manipulator.py` to consistently use a dict. No logic changes were made.
All tests pass.
fixes issue #141 