### PR TITLE
fix: remove duplicate imports

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,7 +6,6 @@ from api.routes import templates, forms
 from api.db.init_db import init_db
 from api.errors.handlers import register_exception_handlers
 from fastapi.middleware.cors import CORSMiddleware
-from api.routes import forms, templates
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):


### PR DESCRIPTION
## Description

Removes a duplicate import in `api/main.py`. `from api.routes import templates, forms` was imported twice on lines 5 and 10.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified the application starts correctly with no import errors after removing the duplicate.

**Test Configuration**:
* Python version: 3.11
* Docker/Compose version:
* OS:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings