### PR TITLE
fix: add input validation for input_text in form fill

### DIFF
--- a/api/schemas/forms.py
+++ b/api/schemas/forms.py
@@ -1,8 +1,18 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 class FormFill(BaseModel):
     template_id: int
     input_text: str
+
+    @field_validator("input_text")
+    @classmethod
+    def validate_input_text(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("input_text cannot be empty or whitespace.")
+        if len(v) > 10_000:
+            raise ValueError("input_text exceeds maximum length of 10,000 characters.")
+        return v
 
 
 class FormFillResponse(BaseModel):

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -343,6 +343,11 @@ async function handleFillSubmit(event) {
     return;
   }
 
+  if (inputText.length > 10_000) {
+    setStatus(elements.fillFormMessage, "Input text is too long (max 10,000 characters).", "error");
+    return;
+  }
+
   const payload = {
     template_id: templateId,
     input_text: inputText,


### PR DESCRIPTION

**Summary**

`POST /forms/fill` accepted any string for `input_text` — including empty strings and whitespace-only input. This caused Ollama to be called once per template field with no useful content, wasting LLM cycles and writing a useless PDF to disk.

**Changes**

- **`api/schemas/forms.py`** — added `@field_validator` on `FormFill.input_text` to reject empty/whitespace input and strings over 10,000 characters. Returns `422` automatically before the request reaches the controller.
- **`frontend/app.js`** — added max-length guard alongside the existing empty-string check so users get immediate feedback without a round trip.

**Why both layers**

Frontend validation improves UX for normal users. Backend validation is the real enforcement — it protects the API from curl, Swagger, and any future integrations that bypass the UI.

**Testing**

- `POST /forms/fill` with `""` or `"   "` → `422`
- `POST /forms/fill` with string > 10,000 chars → `422`
- Valid input → works as before, verifiable via `/docs`

**Fixes issue:** #477 