### PR TITLE
feat(tests): add incident extraction fixtures and regression tests

### DIFF
--- a/tests/fixtures/incidents/README.md
+++ b/tests/fixtures/incidents/README.md
@@ -1,0 +1,15 @@
+# Golden Incident Fixtures
+
+These fixtures provide stable sample incident narratives and expected extracted
+fields for regression testing FireForm's extraction pipeline.
+
+Each fixture should include:
+
+- `name`: a short unique fixture name.
+- `input_text`: the incident narrative or transcript text.
+- `fields`: the target extraction fields for the scenario.
+- `expected`: the expected structured values for those fields.
+
+The fixtures are intentionally small and deterministic. Tests should mock the
+LLM/Ollama layer when using them so extraction regression checks can run
+offline and reliably in CI.

--- a/tests/fixtures/incidents/basic_structure_fire.json
+++ b/tests/fixtures/incidents/basic_structure_fire.json
@@ -1,0 +1,18 @@
+{
+  "name": "basic_structure_fire",
+  "input_text": "Engine 12 responded to a structure fire at 142 Oak Street at 18:40. No injuries were reported.",
+  "fields": [
+    "incident_type",
+    "incident_address",
+    "unit",
+    "time",
+    "injuries"
+  ],
+  "expected": {
+    "incident_type": "structure fire",
+    "incident_address": "142 Oak Street",
+    "unit": "Engine 12",
+    "time": "18:40",
+    "injuries": "No injuries were reported"
+  }
+}

--- a/tests/fixtures/incidents/medical_assist.json
+++ b/tests/fixtures/incidents/medical_assist.json
@@ -1,0 +1,20 @@
+{
+  "name": "medical_assist",
+  "input_text": "Medic 4 assisted a 67-year-old patient at 500 Pine Avenue for chest pain. The patient was transported to County General Hospital.",
+  "fields": [
+    "incident_type",
+    "incident_address",
+    "unit",
+    "patient_age",
+    "chief_complaint",
+    "transport_destination"
+  ],
+  "expected": {
+    "incident_type": "medical assist",
+    "incident_address": "500 Pine Avenue",
+    "unit": "Medic 4",
+    "patient_age": "67",
+    "chief_complaint": "chest pain",
+    "transport_destination": "County General Hospital"
+  }
+}

--- a/tests/fixtures/incidents/missing_optional_fields.json
+++ b/tests/fixtures/incidents/missing_optional_fields.json
@@ -1,0 +1,18 @@
+{
+  "name": "missing_optional_fields",
+  "input_text": "Truck 2 responded to a small brush fire near Mile Marker 8. The fire was contained and no structures were threatened.",
+  "fields": [
+    "incident_type",
+    "incident_location",
+    "unit",
+    "acres_burned",
+    "structures_threatened"
+  ],
+  "expected": {
+    "incident_type": "brush fire",
+    "incident_location": "Mile Marker 8",
+    "unit": "Truck 2",
+    "acres_burned": null,
+    "structures_threatened": "no structures were threatened"
+  }
+}

--- a/tests/test_extraction_fixtures.py
+++ b/tests/test_extraction_fixtures.py
@@ -1,0 +1,66 @@
+"""Regression fixture tests for incident extraction scenarios."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "incidents"
+REQUIRED_FIXTURE_KEYS = {"name", "input_text", "fields", "expected"}
+
+
+def load_incident_fixtures():
+    return [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(FIXTURE_DIR.glob("*.json"))
+    ]
+
+
+def compare_extraction(expected, actual):
+    """Return field mismatches between expected and actual extraction output."""
+    mismatches = {}
+
+    for field, expected_value in expected.items():
+        actual_value = actual.get(field)
+        if actual_value != expected_value:
+            mismatches[field] = {
+                "expected": expected_value,
+                "actual": actual_value,
+            }
+
+    return mismatches
+
+
+@pytest.mark.parametrize("fixture", load_incident_fixtures(), ids=lambda item: item["name"])
+def test_incident_fixture_contract(fixture):
+    assert REQUIRED_FIXTURE_KEYS.issubset(fixture)
+    assert isinstance(fixture["name"], str)
+    assert fixture["name"]
+    assert isinstance(fixture["input_text"], str)
+    assert fixture["input_text"]
+    assert isinstance(fixture["fields"], list)
+    assert fixture["fields"]
+    assert isinstance(fixture["expected"], dict)
+    assert fixture["expected"]
+    assert set(fixture["expected"]).issubset(set(fixture["fields"]))
+
+
+@pytest.mark.parametrize("fixture", load_incident_fixtures(), ids=lambda item: item["name"])
+def test_fixture_expected_output_matches_golden_values(fixture):
+    # Future LLM tests can replace this deterministic mock with mocked Ollama output.
+    mocked_extraction_output = dict(fixture["expected"])
+
+    assert compare_extraction(fixture["expected"], mocked_extraction_output) == {}
+
+
+def test_compare_extraction_reports_field_level_mismatches():
+    expected = {"incident_address": "142 Oak Street", "unit": "Engine 12"}
+    actual = {"incident_address": "142 Oak Street", "unit": "Engine 9"}
+
+    assert compare_extraction(expected, actual) == {
+        "unit": {
+            "expected": "Engine 12",
+            "actual": "Engine 9",
+        }
+    }


### PR DESCRIPTION
## Summary
Fixes: #482 

Adds a small set of golden incident fixtures for extraction regression testing.

This PR introduces realistic sample incident narratives paired with expected structured extraction outputs. These fixtures can be used as a stable baseline for future work on LLM extraction, prompt changes, schema validation, confidence scoring, and hallucination reduction.

## What Changed

- Added `tests/fixtures/incidents/` with 3 sample incident fixtures:
  - `basic_structure_fire.json`
  - `medical_assist.json`
  - `missing_optional_fields.json`
- Added `tests/fixtures/incidents/README.md` documenting the fixture format.
- Added `tests/test_extraction_fixtures.py` to validate:
  - fixture contract/shape,
  - expected fields are aligned with target fields,
  - field-level mismatch reporting helper works correctly.

## Why

FireForm’s extraction pipeline is evolving quickly. Having small, deterministic golden fixtures makes it easier to verify that future extraction changes do not accidentally break expected behavior.

This is especially useful for comparing future improvements such as:

- batch JSON extraction,
- prompt updates,
- schema validation,
- confidence scoring,
- evidence-backed extraction.

## Scope

This PR is intentionally test-only:

- no production API changes,
- no database changes,
- no Ollama calls,
- no PDF filling changes,
- no new dependencies.

## Testing

I validated the new files with:

```bash
python -m compileall tests/test_extraction_fixtures.py
python -m json.tool tests/fixtures/incidents/basic_structure_fire.json
python -m json.tool tests/fixtures/incidents/medical_assist.json
python -m json.tool tests/fixtures/incidents/missing_optional_fields.json
