### PR TITLE
feat(zip): add offline US ZIP enrichment to form-fill pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ numpy<2
 ollama
 pypdf
 python-multipart
+
+uszipcode

--- a/src/filler.py
+++ b/src/filler.py
@@ -1,5 +1,6 @@
 from pdfrw import PdfReader, PdfWriter
 from src.llm import LLM
+from src.zip_resolver import ZipResolver
 from datetime import datetime
 
 
@@ -22,6 +23,7 @@ class Filler:
         # Generate dictionary of answers from your original function
         t2j = llm.main_loop()
         textbox_answers = t2j.get_data()  # This is a dictionary
+        textbox_answers = ZipResolver().enrich(textbox_answers)
 
         answers_list = list(textbox_answers.values())
 

--- a/src/test/test_zip_resolver.py
+++ b/src/test/test_zip_resolver.py
@@ -1,0 +1,124 @@
+from unittest.mock import MagicMock
+import pytest
+
+from zip_resolver import ZipResolver, _is_missing, _normalize_state
+
+
+class TestHelpers:
+    def test_is_missing_none(self):
+        assert _is_missing(None)
+
+    def test_is_missing_empty(self):
+        assert _is_missing("")
+
+    def test_is_missing_minus_one(self):
+        assert _is_missing("-1")
+
+    def test_is_missing_na(self):
+        assert _is_missing("N/A")
+
+    def test_not_missing_valid_zip(self):
+        assert not _is_missing("95814")
+
+    def test_normalize_state_abbreviation(self):
+        assert _normalize_state("CA") == "CA"
+
+    def test_normalize_state_full_name(self):
+        assert _normalize_state("California") == "CA"
+
+    def test_normalize_state_lowercase(self):
+        assert _normalize_state("california") == "CA"
+
+    def test_normalize_state_unknown(self):
+        assert _normalize_state("Nowhere") is None
+
+
+def _mock_engine(zipcode: str = "95814"):
+    result = MagicMock()
+    result.zipcode = zipcode
+    engine = MagicMock()
+    engine.by_city_and_state.return_value = [result]
+    return engine
+
+
+class TestZipResolver:
+    def test_fills_missing_zip_from_city_state(self):
+        data = {"Incident City": "Sacramento", "State": "CA", "ZIP Code": "-1"}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("95814")
+        result = resolver.enrich(data)
+        assert result["ZIP Code"] == "95814"
+
+    def test_does_not_overwrite_existing_zip(self):
+        data = {"City": "Sacramento", "State": "CA", "Zip": "90210"}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("95814")
+        result = resolver.enrich(data)
+        assert result["Zip"] == "90210"
+
+    def test_extracts_embedded_zip_from_address(self):
+        data = {"Address": "123 Main St, Sacramento, CA 95814", "ZIP Code": ""}
+        resolver = ZipResolver()
+        resolver._engine = MagicMock()
+        result = resolver.enrich(data)
+        assert result["ZIP Code"] == "95814"
+
+    def test_no_zip_field_returns_unchanged(self):
+        data = {"City": "Sacramento", "State": "CA"}
+        resolver = ZipResolver()
+        resolver._engine = MagicMock()
+        result = resolver.enrich(data)
+        assert result == data
+
+    def test_leaves_blank_when_no_context(self):
+        data = {"ZIP Code": "-1"}
+        resolver = ZipResolver()
+        engine = MagicMock()
+        engine.by_city_and_state.return_value = []
+        resolver._engine = engine
+        result = resolver.enrich(data)
+        assert _is_missing(result["ZIP Code"])
+
+    def test_handles_full_state_name(self):
+        data = {"City": "Pine Valley", "State": "California", "Postal Code": "-1"}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("91962")
+        result = resolver.enrich(data)
+        assert result["Postal Code"] == "91962"
+        resolver._engine.by_city_and_state.assert_called_once_with("Pine Valley", "CA", returns=1)
+
+    def test_parses_city_state_from_address_field(self):
+        data = {"Incident Location": "Pine Valley, CA", "ZIP": ""}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("91962")
+        result = resolver.enrich(data)
+        assert result["ZIP"] == "91962"
+
+    def test_disabled_when_uszipcode_missing(self):
+        data = {"City": "Sacramento", "State": "CA", "ZIP": "-1"}
+        resolver = ZipResolver()
+        resolver._engine = False
+        result = resolver.enrich(data)
+        assert _is_missing(result["ZIP"])
+
+    def test_does_not_mutate_original_dict(self):
+        original = {"City": "Sacramento", "State": "CA", "ZIP": "-1"}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("95814")
+        result = resolver.enrich(original)
+        assert original["ZIP"] == "-1"
+        assert result["ZIP"] == "95814"
+
+    def test_county_field_used_for_city_state_parsing(self):
+        data = {"County": "Sacramento County, CA", "zip_code": ""}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("95814")
+        result = resolver.enrich(data)
+        assert result["zip_code"] == "95814"
+
+    def test_case_insensitive_zip_field_detection(self):
+        data = {"City": "Sacramento", "State": "CA", "zip code": ""}
+        resolver = ZipResolver()
+        resolver._engine = _mock_engine("95814")
+        result = resolver.enrich(data)
+        assert result["zip code"] == "95814"

--- a/src/zip_resolver.py
+++ b/src/zip_resolver.py
@@ -1,0 +1,130 @@
+import re
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_STATE_ABBREVIATIONS = {
+    "alabama": "AL", "alaska": "AK", "arizona": "AZ", "arkansas": "AR",
+    "california": "CA", "colorado": "CO", "connecticut": "CT", "delaware": "DE",
+    "florida": "FL", "georgia": "GA", "hawaii": "HI", "idaho": "ID",
+    "illinois": "IL", "indiana": "IN", "iowa": "IA", "kansas": "KS",
+    "kentucky": "KY", "louisiana": "LA", "maine": "ME", "maryland": "MD",
+    "massachusetts": "MA", "michigan": "MI", "minnesota": "MN", "mississippi": "MS",
+    "missouri": "MO", "montana": "MT", "nebraska": "NE", "nevada": "NV",
+    "new hampshire": "NH", "new jersey": "NJ", "new mexico": "NM", "new york": "NY",
+    "north carolina": "NC", "north dakota": "ND", "ohio": "OH", "oklahoma": "OK",
+    "oregon": "OR", "pennsylvania": "PA", "rhode island": "RI", "south carolina": "SC",
+    "south dakota": "SD", "tennessee": "TN", "texas": "TX", "utah": "UT",
+    "vermont": "VT", "virginia": "VA", "washington": "WA", "west virginia": "WV",
+    "wisconsin": "WI", "wyoming": "WY",
+}
+
+_ZIP_FIELD_RE = re.compile(r'\b(zip|postal|zip[\s_\-]?code|postal[\s_\-]?code)\b', re.I)
+_CITY_FIELD_RE = re.compile(r'\b(city|town|municipality|district)\b', re.I)
+_STATE_FIELD_RE = re.compile(r'\b(state|province)\b', re.I)
+_ADDRESS_FIELD_RE = re.compile(r'\b(address|addr|location|street)\b', re.I)
+_COUNTY_FIELD_RE = re.compile(r'\b(county)\b', re.I)
+_EMBEDDED_ZIP_RE = re.compile(r'\b(\d{5})(?:-\d{4})?\b')
+_CITY_STATE_RE = re.compile(r'([A-Za-z][A-Za-z\s]+),\s*([A-Za-z]{2})\b')
+
+
+def _is_missing(value) -> bool:
+    if value is None:
+        return True
+    return str(value).strip() in ("", "-1", "N/A", "n/a", "None", "none")
+
+
+def _normalize_state(raw: str) -> Optional[str]:
+    s = raw.strip()
+    upper = s.upper()
+    if len(s) == 2 and upper in _STATE_ABBREVIATIONS.values():
+        return upper
+    return _STATE_ABBREVIATIONS.get(s.lower())
+
+
+class ZipResolver:
+    """
+    Offline US ZIP code enricher.
+
+    Scans an extracted field dict for missing ZIP entries and attempts to
+    fill them from sibling fields (city, state, address, county).
+    Uses uszipcode for lookups — data is bundled as a local SQLite DB,
+    so no network calls occur at fill time.
+    """
+
+    def __init__(self):
+        self._engine = None
+
+    def _get_engine(self):
+        if self._engine is None:
+            try:
+                from uszipcode import SearchEngine
+                self._engine = SearchEngine()
+            except ImportError:
+                logger.warning("uszipcode not installed; ZIP enrichment disabled")
+                self._engine = False
+        return self._engine if self._engine is not False else None
+
+    def _lookup(self, city: str, state: str) -> Optional[str]:
+        engine = self._get_engine()
+        if engine is None:
+            return None
+        state_abbr = _normalize_state(state)
+        if state_abbr is None:
+            return None
+        results = engine.by_city_and_state(city.strip(), state_abbr, returns=1)
+        if results:
+            return results[0].zipcode
+        return None
+
+    def _infer_zip(self, data: dict) -> Optional[str]:
+        # 1. Look for embedded 5-digit ZIP in any address field
+        for key, val in data.items():
+            if _ADDRESS_FIELD_RE.search(key) and not _is_missing(val):
+                m = _EMBEDDED_ZIP_RE.search(str(val))
+                if m:
+                    return m.group(1)
+
+        # 2. city + state lookup
+        city_val = next(
+            (str(v) for k, v in data.items()
+             if _CITY_FIELD_RE.search(k) and not _is_missing(v)),
+            None,
+        )
+        state_val = next(
+            (str(v) for k, v in data.items()
+             if _STATE_FIELD_RE.search(k) and not _is_missing(v)),
+            None,
+        )
+        if city_val and state_val:
+            result = self._lookup(city_val, state_val)
+            if result:
+                return result
+
+        # 3. Parse "City, ST" from address or county fields
+        for key, val in data.items():
+            if (_ADDRESS_FIELD_RE.search(key) or _COUNTY_FIELD_RE.search(key)) \
+                    and not _is_missing(val):
+                m = _CITY_STATE_RE.search(str(val))
+                if m:
+                    result = self._lookup(m.group(1), m.group(2))
+                    if result:
+                        return result
+        return None
+
+    def enrich(self, extracted_data: dict) -> dict:
+        """
+        Return a copy of extracted_data with missing ZIP fields inferred where
+        possible. Existing non-empty ZIP values are never overwritten.
+        """
+        enriched = dict(extracted_data)
+        for key in list(enriched.keys()):
+            if _ZIP_FIELD_RE.search(key) and _is_missing(enriched[key]):
+                inferred = self._infer_zip(enriched)
+                if inferred:
+                    logger.info("ZIP enriched for field '%s': %s", key, inferred)
+                    enriched[key] = inferred
+                else:
+                    logger.debug("Could not infer ZIP for field '%s'", key)
+        return enriched


### PR DESCRIPTION
## What

Adds a `ZipResolver` class that infers missing US ZIP codes from already-extracted form fields (city/state, embedded address text, or county strings) using an offline SQLite database — no network calls at fill time.

## Why

Fixes #435

Cal Fire responders often remember a location (town, district, address) but not the ZIP code during field reporting. FireForm can now auto-fill missing ZIP fields from context already present in the transcript, reducing manual correction and speeding up report completion in low-connectivity environments.

## How

A new `src/zip_resolver.py` module provides `ZipResolver.enrich(extracted_data: dict) -> dict`. It is called in `src/filler.py` immediately after the LLM extracts field values and before they are written positionally to the PDF.

Three inference strategies run in priority order:
1. Extract an embedded 5-digit ZIP from any address field text (`"123 Main St, Sacramento, CA 95814"` → `95814`)
2. City + state lookup via `uszipcode` (handles both abbreviations `"CA"` and full names `"California"`)
3. Parse a `"City, ST"` pattern from address or county fields (`"Pine Valley, CA"` → `91962`)

Key design decisions:
- **Non-breaking**: existing non-empty ZIPs are never overwritten
- **Conservative fallback**: leaves field unchanged if ZIP cannot be inferred — a missing ZIP on an official report is better than a wrong one
- **Graceful degradation**: if `uszipcode` is not installed, enrichment is silently skipped via a `try/except ImportError`
- **Immutable**: returns a copy of the input dict, never mutates LLM state
- **`uszipcode`** was chosen over `pgeocode` for this use case: it is US-specific, bundles its data as a local SQLite DB (no GeoNames download step), and has a purpose-built city/state search API

## Scope

- **Included**: `ZipResolver` class, integration into `filler.py`, 20 unit tests, `uszipcode` dependency
- **NOT included**: non-US postal codes, integration tests requiring a live Ollama instance, UI changes

## Verification

- [x] `PYTHONPATH=src python -m pytest src/test/test_zip_resolver.py -v` → **20 passed, 0 failed**
- [x] Tests placed in `src/test/` to match the CI workflow (`tests.yml` runs `src/test/`)
- [x] No changes to existing test files; no regressions
- [x] `src/filler.py` change is 2 lines (import + one enrichment call); all existing behaviour preserved

**Test configuration:**
- Python 3.11.15
- OS: Linux (Ubuntu)
- `uszipcode` mocked in all tests — zero network dependency in the test suite

## AI Disclosure

AI-assisted implementation, manually reviewed, tested, and verified line by line.