### PR TITLE
chore: created docker file and compose for development envirnment

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Use apt cache mount to speed up system package installation across builds
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt \
+    apt-get update && apt-get install -y \
+    curl \
+    libgl1 \
+    libglib2.0-0 \
+    libxcb1
+
+COPY requirements.txt .
+
+# Use pip cache mount so it remembers downloaded wheels
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements.txt
+
+ENV PYTHONPATH=/app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -1,0 +1,83 @@
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: fireform-ollama
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    networks:
+      - fireform-network
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  whisper:
+    image: onerahmet/openai-whisper-asr-webservice:latest
+    container_name: fireform-whisper
+    environment:
+      - ASR_ENGINE=faster_whisper
+      - ASR_MODEL=${WHISPER_MODEL:-small.en}
+      - ASR_MODEL_PATH=/data/whisper
+    volumes:
+      - whisper_models:/data/whisper
+    ports:
+      - "127.0.0.1:9000:9000"
+    networks:
+      - fireform-network
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:9000/docs')\" || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  app:
+    build:
+      context: ../..
+      dockerfile: docker/dev/Dockerfile
+    container_name: fireform-app
+    depends_on:
+      ollama:
+        condition: service_healthy
+      whisper:
+        condition: service_started
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+    volumes:
+      - ../..:/app
+      - fireform_db:/data/db
+      - fireform_uploads:/data/uploads
+    ports:
+      - "${APP_PORT:-8000}:8000"
+    environment:
+      - PYTHONUNBUFFERED=1
+      - CUDA_VISIBLE_DEVICES=
+      - PYTHONPATH=/app
+      - OLLAMA_HOST=${OLLAMA_HOST:-http://ollama:11434}
+      - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-300}
+      - OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:1.5b}
+      - WHISPER_HOST=${WHISPER_HOST:-http://whisper:9000}
+      - FIREFORM_DB_PATH=/data/db/fireform.db
+      - FIREFORM_DATA_DIR=/data/uploads
+      - FIREFORM_TEMPLATE_DIR=/data/uploads
+      - FIREFORM_DB_ECHO=${FIREFORM_DB_ECHO:-true}
+      - FRONTEND_ORIGINS=${FRONTEND_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173}
+    networks:
+      - fireform-network
+
+volumes:
+  ollama_data:
+    driver: local
+  whisper_models:
+    driver: local
+  fireform_db:
+    driver: local
+  fireform_uploads:
+    driver: local
+
+networks:
+  fireform-network:
+    driver: bridge


### PR DESCRIPTION
# docker Dev environment restructure

## What changed

The project had a single `Dockerfile` and `docker-compose.yml` at the repo root serving both dev and any future prod use. This PR extracts the dev-specific setup into `docker/dev/` as the first step of splitting environments cleanly.

### Dockerfile (`docker/dev/Dockerfile`)

The original `Dockerfile` installed system packages and pip dependencies with no caching. Every `docker compose build` even when nothing changed re-downloaded apt packages and pip wheels from scratch.

The new Dockerfile uses BuildKit cache mounts:

```dockerfile
# Before
RUN apt-get update && apt-get install -y curl libgl1 libglib2.0-0 libxcb1 \
    && rm -rf /var/lib/apt/lists/*

RUN pip install --no-cache-dir -r requirements.txt

# After
RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
    apt-get update && apt-get install -y curl libgl1 libglib2.0-0 libxcb1

RUN --mount=type=cache,target=/root/.cache/pip \
    pip install -r requirements.txt
```

Cache mounts keep downloaded apt packages and pip wheels on the host across builds. Rebuilds after a `requirements.txt` change go from downloading everything again to just installing the delta. Requires Docker 24+ (BuildKit cache mounts stable).

The `--no-cache-dir` flag is removed since we're intentionally caching keeping it would have defeated the mount.

### compose.yml (`docker/dev/compose.yml`)

**Frontend service removed.** The frontend has been migrated to its own repo. The old service was `python3 -m http.server` serving static files from `frontend/` that's gone.

**All environment values moved to `${VAR}` substitution.** Previously every value was hardcoded directly in the compose file:

```yaml
# Before
- OLLAMA_MODEL=qwen2.5:1.5b
- OLLAMA_HOST=http://ollama:11434
- WHISPER_HOST=http://whisper:9000
- FRONTEND_ORIGINS=http://localhost:5173

# After
- OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:1.5b}
- OLLAMA_HOST=${OLLAMA_HOST:-http://ollama:11434}
- WHISPER_HOST=${WHISPER_HOST:-http://whisper:9000}
- FRONTEND_ORIGINS=${FRONTEND_ORIGINS:-http://localhost:5173,http://127.0.0.1:5173}
```

Dev values use `${VAR:-default}` so they work out of the box if `.env.dev` is missing a key. The actual values live in `docker/.env.dev` (gitignored, generated from `docker/.env.example` via `make init`).

**Persistent volumes for data.** The old compose mounted the entire source tree and stored the SQLite DB at `~/.fireform` via a named volume. Uploaded PDFs landed in `data/inputs` inside the source mount no volume, so a container rebuild wiped them.

```yaml
# Before - DB persisted, uploads not
volumes:
  - .:/app
  - fireform_db:/root/.fireform

# After - both persisted, paths controlled by env
volumes:
  - ../..:/app          # source mount kept for hot reload
  - fireform_db:/data/db
  - fireform_uploads:/data/uploads
```

The app reads `FIREFORM_DB_PATH` and `FIREFORM_DATA_DIR` from env (both in `config.py` already). Those are now pointed at the mounted volume paths.

**Ollama and Whisper hosts are env vars.** If someone wants to run Ollama on a separate GPU box they can point `OLLAMA_HOST` at it without touching the compose file.

Fixes: #514 
Part of #512 
Discussion: #501 