### PR TITLE
chore: docker file and docker compose for prod envirnment

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.11-slim AS builder
+
+WORKDIR /build
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    libgl1 \
+    libglib2.0-0 \
+    libxcb1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local
+
+# Copy only app code, not data/ temp/ tests/ docs/ etc.
+COPY app/ ./app/
+COPY requirements.txt .
+
+ENV PYTHONPATH=/app
+
+# Data dirs created here; actual storage comes from mounted volumes at runtime.
+RUN mkdir -p /data/db /data/uploads && chmod +x /entrypoint.sh
+
+EXPOSE 8000
+
+CMD ["gunicorn", "app.main:app", \
+     "--worker-class", "uvicorn.workers.UvicornWorker", \
+     "--bind", "0.0.0.0:8000", \
+     "--access-logfile", "-", \
+     "--error-logfile", "-"]

--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -1,0 +1,90 @@
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: fireform-ollama
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    networks:
+      - fireform-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  whisper:
+    image: onerahmet/openai-whisper-asr-webservice:latest
+    container_name: fireform-whisper
+    environment:
+      - ASR_ENGINE=faster_whisper
+      - ASR_MODEL=${WHISPER_MODEL}
+      - ASR_MODEL_PATH=/data/whisper
+    volumes:
+      - whisper_models:/data/whisper
+    ports:
+      - "127.0.0.1:9000:9000"
+    networks:
+      - fireform-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:9000/docs')\" || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  app:
+    build:
+      context: ../..
+      dockerfile: docker/prod/Dockerfile
+    container_name: fireform-app
+    depends_on:
+      ollama:
+        condition: service_healthy
+      whisper:
+        condition: service_started
+    command: ["gunicorn", "app.main:app",
+              "--worker-class", "uvicorn.workers.UvicornWorker",
+              "--bind", "0.0.0.0:8000",
+              "--access-logfile", "-",
+              "--error-logfile", "-"]
+    volumes:
+      - fireform_db:/data/db
+      - fireform_uploads:/data/uploads
+    ports:
+      - "${APP_PORT}:8000"
+    environment:
+      - PYTHONUNBUFFERED=1
+      - CUDA_VISIBLE_DEVICES=
+      - PYTHONPATH=/app
+      - OLLAMA_HOST=${OLLAMA_HOST}
+      - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT}
+      - OLLAMA_MODEL=${OLLAMA_MODEL}
+      - WHISPER_HOST=${WHISPER_HOST}
+      - FIREFORM_DB_PATH=/data/db/fireform.db
+      - FIREFORM_DATA_DIR=/data/uploads
+      - FIREFORM_TEMPLATE_DIR=/data/uploads
+      - FIREFORM_DB_ECHO=false
+      - FRONTEND_ORIGINS=${FRONTEND_ORIGINS}
+      - WEB_CONCURRENCY=${GUNICORN_WORKERS}
+    networks:
+      - fireform-network
+    restart: unless-stopped
+
+volumes:
+  ollama_data:
+    driver: local
+  whisper_models:
+    driver: local
+  fireform_db:
+    driver: local
+  fireform_uploads:
+    driver: local
+
+networks:
+  fireform-network:
+    driver: bridge


### PR DESCRIPTION
# docker/prod Production environment setup

## What changed

There was no production Docker setup. The root `Dockerfile` ran `uvicorn` with `--reload`, mounted the source tree, and had no concept of a prod environment. This PR adds `docker/prod/` with a Dockerfile and compose file built for deployment.
As per discussion in #501 
### Dockerfile (`docker/prod/Dockerfile`)

**Multi-stage build.** The dev Dockerfile is a single stage it installs dependencies and copies source in one layer, which means the final image contains build tooling that has no business being in prod.

```dockerfile
# Stage 1: install deps into a prefix
FROM python:3.11-slim AS builder
WORKDIR /build
COPY requirements.txt .
RUN pip install --no-cache-dir --prefix=/install -r requirements.txt

# Stage 2: lean runtime image
FROM python:3.11-slim
COPY --from=builder /install /usr/local
COPY app/ ./app/
```

Only `app/` is copied not `data/`, `tests/`, `docs/`, `temp/`, `examples/`, or any other dev-only directory. The builder stage is discarded after the copy.

**gunicorn instead of uvicorn --reload.** The dev Dockerfile uses `uvicorn --reload` which watches the filesystem for changes. In prod there's no source mount and no reason to watch for changes. `gunicorn` with the uvicorn worker class handles multiple concurrent requests and restarts crashed workers automatically:

```dockerfile
CMD ["gunicorn", "app.main:app",
     "--workers", "2",
     "--worker-class", "uvicorn.workers.UvicornWorker",
     "--bind", "0.0.0.0:8000",
     "--access-logfile", "-",
     "--error-logfile", "-"]
```

**Data directories pre-created in the image.** `/data/db` and `/data/uploads` are created at build time so the volume mounts have the right directory structure on first run.

### compose.yml (`docker/prod/compose.yml`)

**No source mount.** The single biggest difference from dev. The image is self-contained only the two data volumes are mounted:

```yaml
volumes:
  - fireform_db:/data/db
  - fireform_uploads:/data/uploads
```

Container upgrade or restart doesn't touch either path. `docker compose down` never removes named volumes unless `-v` is explicitly passed.

**No `${VAR:-default}` fallbacks.** Prod compose uses bare `${VAR}` with no defaults:

```yaml
- OLLAMA_MODEL=${OLLAMA_MODEL}
- FRONTEND_ORIGINS=${FRONTEND_ORIGINS}
```

A missing variable fails loudly at startup rather than silently picking a dev default in a prod environment. Values come from `docker/.env.prod` (gitignored).

**`restart: unless-stopped` on all services.** Services recover automatically after a crash or host reboot without manual intervention.

**`FIREFORM_DB_ECHO=false` hardcoded.** SQLAlchemy query logging is always off in prod it's not a tunable for production and produces a lot of noise in logs.

**Frontend service not included.** The frontend is a separate repo with its own deployment.

## Data persistence

| Volume             | Path                   | Contents                          |
| ------------------ | ---------------------- | --------------------------------- |
| `fireform_db`      | `/data/db/fireform.db` | SQLite database                   |
| `fireform_uploads` | `/data/uploads`        | Uploaded PDFs and generated files |
| `ollama_data`      | `/root/.ollama`        | Ollama model weights              |
| `whisper_models`   | `/data/whisper`        | Whisper model cache               |

All four survive `docker compose down`. A full wipe requires `docker compose down -v` which is intentionally a separate step. In future fireform can plan to decentralise database and storage completely.

## Why this matters

The old setup had no separation between dev and prod. Running the root compose in any environment used `--reload`, mounted source, and had hardcoded values. A container restart would have wiped uploads since they landed in the source mount. This gives prod a stable, self-contained deployment that doesn't depend on the host filesystem for anything except the two named volume paths.

Fixes: https://github.com/fireform-core/FireForm/issues/515
Part of https://github.com/fireform-core/FireForm/issues/512
Discussion: https://github.com/orgs/fireform-core/discussions/501