### PR TITLE
Migrate from SQLite to PostgreSQL

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -26,11 +26,10 @@ DATA_DIR = Path(os.getenv("FIREFORM_DATA_DIR", BASE_DIR / "data")).resolve()
 DEFAULT_TEMPLATE_DIR = os.getenv("FIREFORM_TEMPLATE_DIR", "data/inputs")
 
 # --- Database -------------------------------------------------------------
-# Keep the SQLite file in the user's home so it survives container rebuilds.
-_APP_HOME = Path(os.path.expanduser("~")) / ".fireform"
-_APP_HOME.mkdir(parents=True, exist_ok=True)
-DB_PATH = Path(os.getenv("FIREFORM_DB_PATH", _APP_HOME / "fireform.db"))
-DATABASE_URL = f"sqlite:///{DB_PATH}"
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://fireform:fireform@localhost:5432/fireform",
+)
 DB_ECHO = os.getenv("FIREFORM_DB_ECHO", "true").lower() == "true"
 
 # --- External services ----------------------------------------------------

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -2,11 +2,7 @@ from sqlmodel import Session, create_engine
 
 from app.core.config import DATABASE_URL, DB_ECHO
 
-engine = create_engine(
-    DATABASE_URL,
-    echo=DB_ECHO,
-    connect_args={"check_same_thread": False},
-)
+engine = create_engine(DATABASE_URL, echo=DB_ECHO)
 
 
 def get_session():

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,6 +3,10 @@
 # --- App ------------------------------------------------------------------
 APP_PORT=8000
 
+# --- Database -------------------------------------------------------------
+# Dev: postgres runs inside Docker Compose, no config needed.
+DATABASE_URL=postgresql://fireform:fireform@localhost:5432/fireform
+
 # --- Ollama ---------------------------------------------------------------
 # Ollama runs in Docker with port mapped to host. App runs on host.
 # Override to point at an external Ollama instance (e.g. a GPU server).

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -1,4 +1,23 @@
 services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: fireform-postgres
+    environment:
+      POSTGRES_USER: fireform
+      POSTGRES_PASSWORD: fireform
+      POSTGRES_DB: fireform
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
+    networks:
+      - fireform-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U fireform"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   ollama:
     image: ollama/ollama:latest
     container_name: fireform-ollama
@@ -41,6 +60,8 @@ services:
       dockerfile: docker/dev/Dockerfile
     container_name: fireform-app
     depends_on:
+      postgres:
+        condition: service_healthy
       ollama:
         condition: service_healthy
       whisper:
@@ -49,7 +70,6 @@ services:
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     volumes:
       - ../..:/app
-      - fireform_db:/data/db
       - fireform_uploads:/data/uploads
     ports:
       - "${APP_PORT:-8000}:8000"
@@ -57,11 +77,11 @@ services:
       - PYTHONUNBUFFERED=1
       - CUDA_VISIBLE_DEVICES=
       - PYTHONPATH=/app
+      - DATABASE_URL=postgresql://fireform:fireform@postgres:5432/fireform
       - OLLAMA_HOST=${OLLAMA_HOST:-http://ollama:11434}
       - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-300}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:1.5b}
       - WHISPER_HOST=${WHISPER_HOST:-http://whisper:9000}
-      - FIREFORM_DB_PATH=/data/db/fireform.db
       - FIREFORM_DATA_DIR=/data/uploads
       - FIREFORM_TEMPLATE_DIR=/data/uploads
       - FIREFORM_DB_ECHO=${FIREFORM_DB_ECHO:-true}
@@ -70,11 +90,11 @@ services:
       - fireform-network
 
 volumes:
+  postgres_data:
+    driver: local
   ollama_data:
     driver: local
   whisper_models:
-    driver: local
-  fireform_db:
     driver: local
   fireform_uploads:
     driver: local

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Ensure data directories exist (volumes may be empty on first run)
-mkdir -p /data/db /data/uploads
+mkdir -p /data/uploads
 
 # Run DB migrations / init before starting the server
 python3 -m app.db.init_db

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ fastapi
 uvicorn
 pydantic
 sqlmodel
+psycopg2-binary
 pytest
 httpx
 numpy<2


### PR DESCRIPTION


## Description

### Summary
- Replaced SQLite with PostgreSQL as the database backend
- Added `postgres` service (postgres:17-alpine) to dev Docker Compose with healthcheck and persistent volume
- Removed SQLite-specific code (`check_same_thread`, `FIREFORM_DB_PATH`, `~/.fireform` directory creation)
- Added `psycopg2-binary` driver to requirements
- App reads `DATABASE_URL` from environment, defaults to local PostgreSQL

### Reference
https://github.com/orgs/fireform-core/discussions/540

Fixes: #558 