### PR TITLE
Add isolated PostgreSQL Docker Compose for production

### DIFF
--- a/docker/prod/compose.postgres.yml
+++ b/docker/prod/compose.postgres.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: fireform-postgres-prod
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-fireform}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-fireform}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5432:5432"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-fireform}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+    driver: local

--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -53,7 +53,6 @@ services:
               "--access-logfile", "-",
               "--error-logfile", "-"]
     volumes:
-      - fireform_db:/data/db
       - fireform_uploads:/data/uploads
     ports:
       - "${APP_PORT}:8000"
@@ -61,11 +60,11 @@ services:
       - PYTHONUNBUFFERED=1
       - CUDA_VISIBLE_DEVICES=
       - PYTHONPATH=/app
+      - DATABASE_URL=${DATABASE_URL}
       - OLLAMA_HOST=${OLLAMA_HOST}
       - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT}
       - OLLAMA_MODEL=${OLLAMA_MODEL}
       - WHISPER_HOST=${WHISPER_HOST}
-      - FIREFORM_DB_PATH=/data/db/fireform.db
       - FIREFORM_DATA_DIR=/data/uploads
       - FIREFORM_TEMPLATE_DIR=/data/uploads
       - FIREFORM_DB_ECHO=false
@@ -79,8 +78,6 @@ volumes:
   ollama_data:
     driver: local
   whisper_models:
-    driver: local
-  fireform_db:
     driver: local
   fireform_uploads:
     driver: local


### PR DESCRIPTION


## Description

### Summary
- Added `docker/prod/compose.postgres.yml` standalone PostgreSQL instance isolated from the main app compose
- Updated `docker/prod/compose.yml` to read `DATABASE_URL` from env instead of mounting SQLite volume
- Production postgres data mounted to its own `postgres_data` volume app stack crashes or `down -v` won't affect it

### Reference
https://github.com/orgs/fireform-core/discussions/540

Fixes: #558 
