### PR TITLE
Add common contract schemas and standardized error handling (#543)

### DIFF
--- a/app/api/routes/forms.py
+++ b/app/api/routes/forms.py
@@ -23,7 +23,7 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
 
     fetched_template = get_template(db, form.template_id)
     if not fetched_template:
-        raise AppError("Template not found", status_code=404)
+        raise AppError("Template not found", status_code=404, error_code="TEMPLATE_NOT_FOUND")
 
     controller = Controller()
     try:
@@ -40,7 +40,7 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
         )
         return create_form(db, submission)
     except Exception as e:
-        raise AppError(str(e), status_code=500)
+        raise AppError(str(e), status_code=500, error_code="FORM_FILL_ERROR")
 
 
 @router.get("/models", response_model=ModelsResponse)
@@ -93,9 +93,10 @@ def transcribe(audio: UploadFile = File(...)):
             f"Could not connect to the speech-to-text service at {whisper_url}. "
             "Please ensure the whisper service is running.",
             status_code=503,
+            error_code="STT_UNAVAILABLE",
         )
     except requests.exceptions.RequestException as e:
-        raise AppError(f"Transcription failed: {e}", status_code=502)
+        raise AppError(f"Transcription failed: {e}", status_code=502, error_code="TRANSCRIPTION_FAILED")
 
     try:
         text = (response.json().get("text") or "").strip()

--- a/app/api/schemas/common.py
+++ b/app/api/schemas/common.py
@@ -1,14 +1,55 @@
-from pydantic import BaseModel
+from __future__ import annotations
+
+from datetime import datetime
 from typing import Any
 
-class SuccessResponse(BaseModel):
-    success: bool = True
-    data: Any
+from pydantic import BaseModel, ConfigDict
 
-class ErrorDetail(BaseModel):
-    code: str
-    message: str
+from app.api.schemas.enums import JobStatus, JobType
+
+
+class ValidationErrorItem(BaseModel):
+    model_config = ConfigDict()
+    field: str | None = None
+    issue: str | None = None
+    value: Any = None
+
 
 class ErrorResponse(BaseModel):
-    success: bool = False
-    error: ErrorDetail
+    model_config = ConfigDict()
+    error_code: str
+    message: str
+    detail: dict[str, Any] | None = None
+    retry_after_seconds: int | None = None
+    validation_errors: list[ValidationErrorItem] | None = None
+
+
+class Pagination(BaseModel):
+    model_config = ConfigDict()
+    total: int
+    page: int
+    per_page: int
+    total_pages: int
+    has_next: bool
+    has_prev: bool
+
+
+class AsyncJobResponse(BaseModel):
+    model_config = ConfigDict()
+    job_id: str
+    job_type: JobType | None = None
+    status: JobStatus
+    estimated_seconds: int | None = None
+    poll_url: str | None = None
+
+
+class Job(BaseModel):
+    model_config = ConfigDict()
+    job_id: str
+    job_type: JobType
+    status: JobStatus
+    progress_percent: int | None = None
+    result_url: str | None = None
+    error: ErrorResponse | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/app/api/schemas/enums.py
+++ b/app/api/schemas/enums.py
@@ -1,0 +1,111 @@
+from enum import Enum
+
+
+class InputStatus(str, Enum):
+    queued = "queued"
+    transcribing = "transcribing"
+    ready = "ready"
+    failed = "failed"
+
+
+class ExtractionStatus(str, Enum):
+    processing = "processing"
+    completed = "completed"
+    failed = "failed"
+    needs_review = "needs_review"
+
+
+class FormStatus(str, Enum):
+    queued = "queued"
+    generating = "generating"
+    completed = "completed"
+    failed = "failed"
+
+
+class ReportStatus(str, Enum):
+    draft = "draft"
+    under_review = "under_review"
+    approved = "approved"
+    submitted = "submitted"
+
+
+class JobStatus(str, Enum):
+    queued = "queued"
+    processing = "processing"
+    completed = "completed"
+    failed = "failed"
+
+
+class JobType(str, Enum):
+    transcription = "transcription"
+    extraction = "extraction"
+    form_generation = "form_generation"
+    batch_form_generation = "batch_form_generation"
+    report_generation = "report_generation"
+
+
+class FormType(str, Enum):
+    neris = "neris"
+    nemsis_epcr = "nemsis_epcr"
+    nibrs = "nibrs"
+    nfirs_basic = "nfirs_basic"
+    nfirs_fire = "nfirs_fire"
+    nfirs_structure = "nfirs_structure"
+    nfirs_wildland = "nfirs_wildland"
+    nfirs_ems = "nfirs_ems"
+    nfirs_hazmat = "nfirs_hazmat"
+    nfirs_apparatus = "nfirs_apparatus"
+    nfirs_personnel = "nfirs_personnel"
+    nfirs_arson = "nfirs_arson"
+    nfirs_casualty_civilian = "nfirs_casualty_civilian"
+    nfirs_casualty_responder = "nfirs_casualty_responder"
+    cal_fire_ics209 = "cal_fire_ics209"
+    osha_301 = "osha_301"
+    un_ssirs = "un_ssirs"
+    state_georgia = "state_georgia"
+    state_california = "state_california"
+    state_new_york = "state_new_york"
+
+
+class IncidentCategory(str, Enum):
+    fire = "fire"
+    ems = "ems"
+    rescue = "rescue"
+    hazardous_conditions = "hazardous_conditions"
+    service_call = "service_call"
+    good_intent = "good_intent"
+    false_alarm = "false_alarm"
+    law_enforcement = "law_enforcement"
+
+
+class CauseCertainty(str, Enum):
+    confirmed = "confirmed"
+    probable = "probable"
+    suspected = "suspected"
+    undetermined = "undetermined"
+
+
+class InjurySeverity(str, Enum):
+    minor = "minor"
+    moderate = "moderate"
+    severe = "severe"
+    fatal = "fatal"
+
+
+class RateOfSpread(str, Enum):
+    slow = "slow"
+    moderate = "moderate"
+    rapid = "rapid"
+    extreme = "extreme"
+
+
+class PeriodType(str, Enum):
+    monthly = "monthly"
+    quarterly = "quarterly"
+    annual = "annual"
+
+
+class OutputFormat(str, Enum):
+    pdf = "pdf"
+    json = "json"
+    both = "both"

--- a/app/api/v1/routes/system.py
+++ b/app/api/v1/routes/system.py
@@ -161,8 +161,6 @@ def get_health():
 
 @router.get("/schema/incident", summary="Get canonical incident JSON Schema")
 def get_schema_incident():
-    # PROVISIONAL: This 501 body shape is not canonical — it will be updated
-    # to match the standardized ErrorResponse envelope once #543 lands.
     return JSONResponse(
         status_code=501,
         content={
@@ -174,7 +172,6 @@ def get_schema_incident():
 
 @router.get("/schema/incident/versions", summary="Get incident schema version history")
 def get_schema_versions():
-    # PROVISIONAL: Same as /schema/incident — shape will align with #543.
     return JSONResponse(
         status_code=501,
         content={

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -44,3 +44,8 @@ ALLOWED_ORIGINS = [
     for origin in os.getenv("FRONTEND_ORIGINS", _DEFAULT_ORIGINS).split(",")
     if origin.strip()
 ]
+
+# --- Error handling -------------------------------------------------------
+# Advisory Retry-After sent to clients on 503 responses. This is a client
+# hint, not a measured backpressure value — the app has no queue-depth signal.
+RETRY_AFTER_SECONDS = 30

--- a/app/core/errors/base.py
+++ b/app/core/errors/base.py
@@ -1,4 +1,23 @@
+def _default_error_code(status_code: int) -> str:
+    return {
+        400: "BAD_REQUEST",
+        404: "NOT_FOUND",
+        422: "VALIDATION_ERROR",
+        500: "INTERNAL_ERROR",
+        502: "BAD_GATEWAY",
+        503: "SERVICE_UNAVAILABLE",
+    }.get(status_code, "ERROR")
+
+
 class AppError(Exception):
-    def __init__(self, message: str, status_code: int = 400):
+    def __init__(
+        self,
+        message: str,
+        status_code: int = 400,
+        error_code: str | None = None,
+        detail: dict | None = None,
+    ):
         self.message = message
         self.status_code = status_code
+        self.error_code = error_code or _default_error_code(status_code)
+        self.detail = detail

--- a/app/core/errors/handlers.py
+++ b/app/core/errors/handlers.py
@@ -1,11 +1,40 @@
 from fastapi import Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+
 from app.core.errors.base import AppError
+
+# Advisory retry hint on 503 responses — not a measured queue depth or backpressure
+# value; just a safe default so clients know when to try again.
+_RETRY_AFTER_SECONDS = 30
+
 
 def register_exception_handlers(app):
     @app.exception_handler(AppError)
     async def app_error_handler(request: Request, exc: AppError):
+        body: dict = {"error_code": exc.error_code, "message": exc.message}
+        if exc.detail is not None:
+            body["detail"] = exc.detail
+        if exc.status_code == 503:
+            body["retry_after_seconds"] = _RETRY_AFTER_SECONDS
+        return JSONResponse(status_code=exc.status_code, content=body)
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(request: Request, exc: RequestValidationError):
+        validation_errors = []
+        for error in exc.errors():
+            loc = error.get("loc", ())
+            field = ".".join(str(x) for x in loc if x != "body")
+            validation_errors.append({
+                "field": field or None,
+                "issue": error.get("msg"),
+                "value": error.get("input"),
+            })
         return JSONResponse(
-            status_code=exc.status_code,
-            content={"error": exc.message},
+            status_code=422,
+            content={
+                "error_code": "VALIDATION_ERROR",
+                "message": "Request validation failed",
+                "validation_errors": validation_errors,
+            },
         )

--- a/app/core/errors/handlers.py
+++ b/app/core/errors/handlers.py
@@ -2,11 +2,8 @@ from fastapi import Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
+from app.core.config import RETRY_AFTER_SECONDS
 from app.core.errors.base import AppError
-
-# Advisory retry hint on 503 responses — not a measured queue depth or backpressure
-# value; just a safe default so clients know when to try again.
-_RETRY_AFTER_SECONDS = 30
 
 
 def register_exception_handlers(app):
@@ -16,7 +13,7 @@ def register_exception_handlers(app):
         if exc.detail is not None:
             body["detail"] = exc.detail
         if exc.status_code == 503:
-            body["retry_after_seconds"] = _RETRY_AFTER_SECONDS
+            body["retry_after_seconds"] = RETRY_AFTER_SECONDS
         return JSONResponse(status_code=exc.status_code, content=body)
 
     @app.exception_handler(RequestValidationError)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -210,12 +210,18 @@ class TestFormEndpoints:
             "input_text": "some text",
         })
         assert resp.status_code == 500
-        assert "PDF template not found" in resp.json()["error"]
+        assert resp.json()["error_code"] == "FORM_FILL_ERROR"
+        assert "PDF template not found" in resp.json()["message"]
 
     def test_fill_form_validates_body(self, client):
-        """Missing required fields → 422."""
+        """Missing required fields → 422 with contract envelope."""
         resp = client.post("/forms/fill", json={})
         assert resp.status_code == 422
+        body = resp.json()
+        assert body["error_code"] == "VALIDATION_ERROR"
+        assert len(body["validation_errors"]) >= 1
+        assert body["validation_errors"][0]["field"] is not None
+        assert body["validation_errors"][0]["issue"] is not None
 
     def test_transcribe_success(self, client, monkeypatch):
         """Audio is forwarded to the whisper sidecar and its text returned."""


### PR DESCRIPTION
Closes #543.

Adds the shared contract schemas and standardizes error handling across the app.
Per the discussion on the issue, this is the Option A approach — the new error format
is applied everywhere, including the existing routes, rather than a v1-only split.

New error envelope (per contracts/schemas/common.yaml):
- `AppError` now carries an `error_code` and optional `detail`, falling back to a
  status-derived code so existing callers keep working.
- The handler emits `{error_code, message, detail?, retry_after_seconds?}`. A new 422
  handler maps FastAPI validation errors to the contract's `validation_errors` array
  (`field` / `issue` / `value`).
- `retry_after_seconds` on 503 is a named advisory constant (30s), commented as a
  client hint — not a measured queue depth or backpressure value.

Common schemas: added `ErrorResponse`, `ValidationErrorItem`, `Pagination`,
`AsyncJobResponse`, and `Job` (all using `ConfigDict`), plus all 11 enums from
`enums.yaml` as `str` enums in a new `enums.py`. The job models use the enums
directly rather than plain strings.

Migration of existing routes:
- The 4 `AppError` raises in `forms.py` now pass explicit codes (`TEMPLATE_NOT_FOUND`,
  `FORM_FILL_ERROR`, `STT_UNAVAILABLE`, `TRANSCRIPTION_FAILED`). `templates.py` raises
  no `AppError`, so it needed no changes.
- The old `{"error": message}` shape and the dead `SuccessResponse`/`ErrorDetail`/old
  `ErrorResponse` classes in `common.py` are removed.
- The two `/schema` stubs from #542 already matched the envelope, so their PROVISIONAL
  comments were dropped.

Tests: 36 passing. Updated the one test asserting the old shape, and the 422 test now
verifies the full contract envelope (real `validation_errors` entries, not just a
status code).