### PR TITLE
feat: :bug: implement deletes, purges, apikey for security and update…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,74 @@ FireForm is designed from the ground up to ensure that all generated and collect
 
 ## 🔒 Privacy & Applicable Laws
 
-FireForm is built on a local-first architecture, ensuring that all processing (including AI extraction) occurs locally on the user's hardware. We do not collect, process, or share any Personally Identifiable Information (PII) with third parties. By keeping data completely offline, FireForm natively assists deploying organizations in complying with strict data protection laws such as **HIPAA**, **CCPA**, and **GDPR**. 
+FireForm is built on a **local-first architecture**: all processing (including AI extraction) occurs locally on the operator's hardware and nothing is transmitted to external servers by default. However, operators should be aware of the following:
 
-For complete details on our data handling, consent management procedures, and how the solution was designed to comply with HIPAA, CCPA, and GDPR, please review our public [Privacy Policy](https://fireform-core.github.io/FireForm/privacy.html).
+- **PII is processed locally.** Incident descriptions, names, dates, and other personally identifiable information are extracted by the local LLM, written into filled PDF files, and persisted in the local database (`FormSubmission` records). These files and records remain on disk until explicitly deleted.
+- **No external transmission.** Data does not leave the machine by default. Audio transcription (Whisper) and LLM inference (Ollama) are both local services.
+- **Operator responsibility.** Because PII is stored locally, the security of that data depends entirely on the operator's host system, filesystem permissions, backup practices, and access controls.
+
+For complete details on data handling and compliance guidance, please review our public [Privacy Policy](https://fireform-core.github.io/FireForm/privacy.html).
+
+## 🗑️ Data Deletion & Retention
+
+FireForm provides API endpoints and an automated purge mechanism to manage stored PII.
+
+### Deleting individual records
+
+```bash
+# Delete a single form submission (removes DB record + output PDF)
+curl -X DELETE http://localhost:8000/api/v1/forms/{submission_id} \
+  -H "X-API-Key: your-key"
+
+# Delete a template and all associated submissions
+curl -X DELETE http://localhost:8000/api/v1/templates/{template_id} \
+  -H "X-API-Key: your-key"
+```
+
+### Bulk purge
+
+```bash
+# Purge all submissions older than 30 days
+curl -X POST "http://localhost:8000/api/v1/forms/purge?days=30" \
+  -H "X-API-Key: your-key"
+```
+
+### Automated retention
+
+Set `RETENTION_PERIOD_DAYS` in `docker/.env.dev` (default: `30`). Celery Beat will automatically run a purge job every night at 03:00 UTC:
+
+```env
+RETENTION_PERIOD_DAYS=30
+```
+
+To enable the scheduler: `celery -A app.core.celery beat -l info`
+
+## 🔑 Access Control
+
+Deletion and purge endpoints can be protected by setting an API key:
+
+```env
+FIREFORM_API_KEY=your-strong-secret-key
+```
+
+When set, all `DELETE` and `POST /purge` requests must include one of:
+- **Header:** `X-API-Key: your-strong-secret-key`
+- **Bearer token:** `Authorization: Bearer your-strong-secret-key`
+
+Read-only endpoints (list, preview, fill) do **not** require authentication.
+
+## 🛡️ Operator Hardening Recommendations
+
+- **Filesystem permissions:** Restrict access to `data/inputs/` and `data/outputs/` to the application user only (`chmod 700`).
+- **Backups:** Encrypt any backups containing output PDFs.
+- **HTTPS:** Deploy behind a reverse proxy (e.g., nginx) with TLS enabled.
+- **API key rotation:** Rotate `FIREFORM_API_KEY` regularly and never commit it to version control.
+- **Retention policy:** Configure `RETENTION_PERIOD_DAYS` in line with applicable regulations (HIPAA, GDPR, CCPA).
 
 ## 🛡️ Do No Harm by Design
 
 FireForm is built to anticipate and prevent harm:
-- **Data Privacy & Security (9A):** We handle sensitive incident data entirely offline. By never transmitting data to the cloud, we natively prevent online data breaches of PII.
+- **Data Privacy & Security (9A):** We handle sensitive incident data entirely offline. By never transmitting data to the cloud, we natively prevent online data breaches of PII. Operators are responsible for securing local storage; see the Operator Hardening Recommendations above.
 - **Inappropriate Content (9B):** The application is an internal productivity tool without public social interactions or user-generated content hosting, completely mitigating the risks of public harassment or illegal content distribution.
 - **Protection from Harassment (9C):** For our open-source contributor community, we strictly enforce our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a safe, harassment-free environment for all contributors.
 

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,4 +1,20 @@
 from app.db.database import get_session
+from fastapi import Header, Request
+from app.core.config import FIREFORM_API_KEY
+from app.core.errors.base import AppError
 
 def get_db():
     yield from get_session()
+
+def verify_api_key(request: Request, x_api_key: str | None = Header(None)):
+    if not FIREFORM_API_KEY:
+        return
+    
+    provided_key = x_api_key
+    if not provided_key:
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Bearer "):
+            provided_key = auth_header[len("Bearer "):]
+            
+    if not provided_key or provided_key != FIREFORM_API_KEY:
+        raise AppError("Unauthorized", status_code=401, error_code="UNAUTHORIZED")

--- a/app/api/routes/forms.py
+++ b/app/api/routes/forms.py
@@ -1,19 +1,39 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 import requests
-from fastapi import APIRouter, Depends, File, UploadFile
-from sqlmodel import Session
+from fastapi import APIRouter, Depends, File, UploadFile, Query
+from sqlmodel import Session, select
 
-from app.api.deps import get_db
+from app.api.deps import get_db, verify_api_key
 from app.api.schemas.forms import (
     FormFill,
     FormFillResponse,
     ModelsResponse,
     TranscriptionResponse,
 )
-from app.core.config import OLLAMA_HOST, OLLAMA_MODEL, WHISPER_HOST
+from app.core.config import OLLAMA_HOST, OLLAMA_MODEL, WHISPER_HOST, BASE_DIR, RETENTION_PERIOD_DAYS
 from app.core.errors.base import AppError
-from app.db.repositories import create_form, get_template
+from app.db.repositories import create_form, get_template, get_form_submission, delete_form_submission
 from app.models import FormSubmission
 from app.services.controller import Controller
+
+PROJECT_ROOT = BASE_DIR
+
+def _resolve_project_file(file_path: str) -> Path:
+    raw_path = (file_path or "").strip()
+    if not raw_path:
+        raise AppError("Path is required", status_code=400)
+
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = (PROJECT_ROOT / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
+        raise AppError("Path must be inside the project", status_code=400)
+
+    return candidate
 
 router = APIRouter(prefix="/forms", tags=["forms"])
 
@@ -104,3 +124,45 @@ def transcribe(audio: UploadFile = File(...)):
         text = response.text.strip()
 
     return TranscriptionResponse(text=text)
+
+
+@router.delete("/{submission_id}", dependencies=[Depends(verify_api_key)])
+def delete_submission_endpoint(submission_id: int, db: Session = Depends(get_db)):
+    sub = get_form_submission(db, submission_id)
+    if not sub:
+        raise AppError("Submission not found", status_code=404, error_code="SUBMISSION_NOT_FOUND")
+
+    if sub.output_pdf_path:
+        try:
+            resolved_out = _resolve_project_file(sub.output_pdf_path)
+            if resolved_out.exists() and resolved_out.is_file():
+                resolved_out.unlink()
+        except Exception:
+            pass
+
+    delete_form_submission(db, sub)
+    return {"status": "success", "message": "Submission and associated output file deleted"}
+
+
+@router.post("/purge", dependencies=[Depends(verify_api_key)])
+def purge_submissions_endpoint(days: int = Query(default=None), db: Session = Depends(get_db)):
+    retention_days = days if days is not None else RETENTION_PERIOD_DAYS
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=retention_days)
+
+    statement = select(FormSubmission).where(FormSubmission.created_at < cutoff_date)
+    submissions = list(db.exec(statement))
+
+    purged_count = 0
+    for sub in submissions:
+        if sub.output_pdf_path:
+            try:
+                resolved_out = _resolve_project_file(sub.output_pdf_path)
+                if resolved_out.exists() and resolved_out.is_file():
+                    resolved_out.unlink()
+            except Exception:
+                pass
+        delete_form_submission(db, sub)
+        purged_count += 1
+
+    return {"status": "success", "purged_count": purged_count, "retention_days_used": retention_days}
+

--- a/app/api/routes/templates.py
+++ b/app/api/routes/templates.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Upload
 from fastapi.responses import FileResponse
 from sqlmodel import Session
 
-from app.api.deps import get_db
+from app.api.deps import get_db, verify_api_key
 from app.api.schemas.templates import (
     TemplateCreate,
     TemplateResponse,
@@ -15,9 +15,10 @@ from app.api.schemas.templates import (
     MakeFillableResponse,
 )
 from app.core.config import BASE_DIR, DEFAULT_TEMPLATE_DIR
-from app.db.repositories import create_template, list_templates
-from app.models import Template
+from app.db.repositories import create_template, list_templates, get_template, delete_template
+from app.models import Template, FormSubmission, Job
 from app.services.controller import Controller
+from sqlmodel import select
 
 router = APIRouter(prefix="/templates", tags=["templates"])
 PROJECT_ROOT = BASE_DIR
@@ -197,3 +198,43 @@ def make_fillable(req: MakeFillableRequest):
         pdf_path=relative_path,
         field_count=_count_pdf_widgets(relative_path),
     )
+
+
+@router.delete("/{template_id}", dependencies=[Depends(verify_api_key)])
+def delete_template_endpoint(template_id: int, db: Session = Depends(get_db)):
+    template = get_template(db, template_id)
+    if not template:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    # 1. Clean up associated submissions and their generated PDFs
+    sub_stmt = select(FormSubmission).where(FormSubmission.template_id == template_id)
+    submissions = list(db.exec(sub_stmt))
+    for sub in submissions:
+        if sub.output_pdf_path:
+            try:
+                resolved_out = _resolve_project_file(sub.output_pdf_path)
+                if resolved_out.exists() and resolved_out.is_file():
+                    resolved_out.unlink()
+            except Exception:
+                pass
+        db.delete(sub)
+
+    # 2. Clean up associated jobs
+    job_stmt = select(Job).where(Job.template_id == template_id)
+    jobs = list(db.exec(job_stmt))
+    for job in jobs:
+        db.delete(job)
+
+    # 3. Delete template PDF file
+    if template.pdf_path:
+        try:
+            resolved_pdf = _resolve_project_file(template.pdf_path)
+            if resolved_pdf.exists() and resolved_pdf.is_file():
+                resolved_pdf.unlink()
+        except Exception:
+            pass
+
+    # 4. Delete the template itself
+    delete_template(db, template)
+    return {"status": "success", "message": "Template and all associated data deleted"}
+

--- a/app/core/celery.py
+++ b/app/core/celery.py
@@ -16,4 +16,14 @@ celery_app.conf.update(
     result_expires=86400,
 )
 
-celery_app.conf.include = ["app.tasks.fill"]
+celery_app.conf.include = ["app.tasks.fill", "app.tasks.purge"]
+
+# Optional Celery Beat schedule — runs purge_old_submissions once a day.
+# Enable by running: celery -A app.core.celery beat
+from celery.schedules import crontab  # noqa: E402
+celery_app.conf.beat_schedule = {
+    "daily-submission-purge": {
+        "task": "purge_old_submissions",
+        "schedule": crontab(hour=3, minute=0),  # 03:00 UTC daily
+    },
+}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -56,3 +56,9 @@ RETRY_AFTER_SECONDS = 30
 
 # --- API Versioning -------------------------------------------------------
 API_PREFIX = "/api/v1"
+
+# --- Security & Access Control ---------------------------------------------
+FIREFORM_API_KEY = os.getenv("FIREFORM_API_KEY", "")
+
+# --- Data Retention --------------------------------------------------------
+RETENTION_PERIOD_DAYS = int(os.getenv("RETENTION_PERIOD_DAYS", "30"))

--- a/app/db/repositories.py
+++ b/app/db/repositories.py
@@ -51,3 +51,18 @@ def update_job(session: Session, job: Job) -> Job:
     session.commit()
     session.refresh(job)
     return job
+
+
+def delete_template(session: Session, template: Template) -> None:
+    session.delete(template)
+    session.commit()
+
+
+def get_form_submission(session: Session, submission_id: int) -> FormSubmission | None:
+    return session.get(FormSubmission, submission_id)
+
+
+def delete_form_submission(session: Session, submission: FormSubmission) -> None:
+    session.delete(submission)
+    session.commit()
+

--- a/app/tasks/purge.py
+++ b/app/tasks/purge.py
@@ -1,0 +1,90 @@
+"""Celery beat task: purge form submissions older than RETENTION_PERIOD_DAYS.
+
+Runs automatically if Celery Beat is configured. Can also be triggered manually
+via the API endpoint POST /api/v1/forms/purge.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.core.celery import celery_app
+from app.core.config import BASE_DIR, RETENTION_PERIOD_DAYS
+from app.db.database import get_session
+from app.db.repositories import delete_form_submission
+from app.models import FormSubmission
+from sqlmodel import select
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = BASE_DIR
+
+
+def _safe_delete_file(file_path: str) -> bool:
+    """Delete a project-relative or absolute file safely. Returns True if deleted."""
+    try:
+        candidate = Path(file_path)
+        if not candidate.is_absolute():
+            candidate = (PROJECT_ROOT / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+
+        # Safety: must stay inside project root
+        if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
+            logger.warning("Skipping file outside project root: %s", candidate)
+            return False
+
+        if candidate.exists() and candidate.is_file():
+            candidate.unlink()
+            return True
+    except Exception as exc:
+        logger.error("Failed to delete file %s: %s", file_path, exc)
+    return False
+
+
+@celery_app.task(name="purge_old_submissions")
+def purge_old_submissions(retention_days: int | None = None) -> dict:
+    """Delete form submissions (and associated output PDFs) older than retention_days.
+
+    Args:
+        retention_days: Number of days to retain data. Defaults to the
+            RETENTION_PERIOD_DAYS environment variable (default: 30).
+
+    Returns:
+        dict with purged_count and retention_days_used.
+    """
+    days = retention_days if retention_days is not None else RETENTION_PERIOD_DAYS
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    logger.info("Purging submissions older than %s days (cutoff: %s)", days, cutoff)
+
+    session = next(get_session())
+    purged_count = 0
+    files_deleted = 0
+
+    try:
+        statement = select(FormSubmission).where(FormSubmission.created_at < cutoff)
+        submissions = list(session.exec(statement))
+
+        for sub in submissions:
+            if sub.output_pdf_path:
+                if _safe_delete_file(sub.output_pdf_path):
+                    files_deleted += 1
+            delete_form_submission(session, sub)
+            purged_count += 1
+
+        logger.info(
+            "Purge complete: removed %d submissions and %d output files",
+            purged_count,
+            files_deleted,
+        )
+        return {
+            "purged_count": purged_count,
+            "files_deleted": files_deleted,
+            "retention_days_used": days,
+        }
+
+    except Exception as exc:
+        logger.exception("purge_old_submissions task failed: %s", exc)
+        raise
+    finally:
+        session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from sqlmodel import SQLModel, Session, create_engine
 
 from app.main import app
 from app.api.deps import get_db
+from app.core.config import API_PREFIX  # single source of truth for all tests
 from app.models import Template, FormSubmission, Job  # noqa: F401 — registers tables
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ All heavy dependencies (LLM, commonforms, filesystem) are mocked via conftest.
 from sqlmodel import select
 
 from app.models import Template, FormSubmission
+from app.core.config import API_PREFIX
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -83,7 +84,7 @@ class TestDBModels:
 class TestTemplateEndpoints:
 
     def test_list_templates_empty(self, client):
-        resp = client.get("/templates")
+        resp = client.get(f"{API_PREFIX}/templates")
         assert resp.status_code == 200
         assert resp.json() == []
 
@@ -97,7 +98,7 @@ class TestTemplateEndpoints:
                 "Location": "string",
             },
         }
-        resp = client.post("/templates/create", json=payload)
+        resp = client.post(f"{API_PREFIX}/templates/create", json=payload)
         assert resp.status_code == 200
 
         data = resp.json()
@@ -110,12 +111,12 @@ class TestTemplateEndpoints:
 
     def test_create_then_list(self, client, mock_controller):
         """Creating a template should make it appear in the list."""
-        client.post("/templates/create", json={
+        client.post(f"{API_PREFIX}/templates/create", json={
             "name": "T1",
             "pdf_path": "a.pdf",
             "fields": {"f": "string"},
         })
-        resp = client.get("/templates")
+        resp = client.get(f"{API_PREFIX}/templates")
         assert resp.status_code == 200
         assert len(resp.json()) == 1
         assert resp.json()[0]["name"] == "T1"
@@ -129,7 +130,7 @@ class TestTemplateEndpoints:
             tmp_path,
         )
         resp = client.post(
-            "/templates/upload",
+            f"{API_PREFIX}/templates/upload",
             files=[pdf_upload],
             data={"directory": str(tmp_path)},
         )
@@ -141,19 +142,19 @@ class TestTemplateEndpoints:
     def test_upload_non_pdf_rejected(self, client):
         import io
         bad_file = ("file", ("notes.txt", io.BytesIO(b"hello"), "text/plain"))
-        resp = client.post("/templates/upload", files=[bad_file])
+        resp = client.post(f"{API_PREFIX}/templates/upload", files=[bad_file])
         assert resp.status_code == 400
         assert "PDF" in resp.json()["detail"]
 
     def test_preview_missing_file(self, client):
-        resp = client.get("/templates/preview", params={"path": "src/inputs/nonexistent.pdf"})
+        resp = client.get(f"{API_PREFIX}/templates/preview", params={"path": "src/inputs/nonexistent.pdf"})
         assert resp.status_code == 404
 
     def test_directory_traversal_blocked(self, client):
         import io
         pdf = ("file", ("evil.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"))
         resp = client.post(
-            "/templates/upload",
+            f"{API_PREFIX}/templates/upload",
             files=[pdf],
             data={"directory": "/etc"},
         )
@@ -169,7 +170,7 @@ class TestFormEndpoints:
 
     def _seed_template(self, client, mock_controller):
         """Helper: create a template and return its ID."""
-        resp = client.post("/templates/create", json={
+        resp = client.post(f"{API_PREFIX}/templates/create", json={
             "name": "Employee Form",
             "pdf_path": "src/inputs/employee.pdf",
             "fields": {
@@ -182,7 +183,7 @@ class TestFormEndpoints:
     def test_fill_form_success(self, client, mock_controller):
         tpl_id = self._seed_template(client, mock_controller)
 
-        resp = client.post("/forms/fill", json={
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": tpl_id,
             "input_text": "The employee is John Doe, email jdoe@ucsc.edu",
         })
@@ -195,7 +196,7 @@ class TestFormEndpoints:
         mock_controller["form_ctrl"].fill_form.assert_called_once()
 
     def test_fill_form_missing_template(self, client, mock_controller):
-        resp = client.post("/forms/fill", json={
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": 9999,
             "input_text": "some text",
         })
@@ -205,7 +206,7 @@ class TestFormEndpoints:
         tpl_id = self._seed_template(client, mock_controller)
         mock_controller["form_ctrl"].fill_form.side_effect = FileNotFoundError("PDF template not found")
 
-        resp = client.post("/forms/fill", json={
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": tpl_id,
             "input_text": "some text",
         })
@@ -215,7 +216,7 @@ class TestFormEndpoints:
 
     def test_fill_form_validates_body(self, client):
         """Missing required fields → 422 with contract envelope."""
-        resp = client.post("/forms/fill", json={})
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={})
         assert resp.status_code == 422
         body = resp.json()
         assert body["error_code"] == "VALIDATION_ERROR"
@@ -243,7 +244,7 @@ class TestFormEndpoints:
         monkeypatch.setattr("app.api.routes.forms.requests.post", fake_post)
 
         audio = ("audio", ("recording.wav", io.BytesIO(b"RIFFfake"), "audio/wav"))
-        resp = client.post("/forms/transcribe", files=[audio])
+        resp = client.post(f"{API_PREFIX}/forms/transcribe", files=[audio])
 
         assert resp.status_code == 200
         assert resp.json()["text"] == "structure fire on main street"
@@ -252,7 +253,7 @@ class TestFormEndpoints:
         assert captured["params"]["output"] == "json"
 
     def test_list_models(self, client, monkeypatch):
-        """/forms/models lists Ollama models and always includes the default."""
+        ""f"{API_PREFIX}/forms/models lists Ollama models and always includes the default."""
         from unittest.mock import MagicMock
 
         fake_response = MagicMock()
@@ -261,7 +262,7 @@ class TestFormEndpoints:
         monkeypatch.setattr("app.api.routes.forms.requests.get", lambda *a, **k: fake_response)
         monkeypatch.setenv("OLLAMA_MODEL", "qwen2.5:1.5b")
 
-        resp = client.get("/forms/models")
+        resp = client.get(f"{API_PREFIX}/forms/models")
         assert resp.status_code == 200
         body = resp.json()
         assert body["default"] == "qwen2.5:1.5b"
@@ -278,14 +279,14 @@ class TestFormEndpoints:
         monkeypatch.setattr("app.api.routes.forms.requests.get", boom)
         monkeypatch.setenv("OLLAMA_MODEL", "qwen2.5:1.5b")
 
-        resp = client.get("/forms/models")
+        resp = client.get(f"{API_PREFIX}/forms/models")
         assert resp.status_code == 200
         assert resp.json()["models"] == ["qwen2.5:1.5b"]
 
     def test_fill_form_passes_model_override(self, client, mock_controller):
         """A `model` in the request reaches Controller.fill_form but isn't persisted."""
         tpl_id = self._seed_template(client, mock_controller)
-        resp = client.post("/forms/fill", json={
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": tpl_id,
             "input_text": "John Doe",
             "model": "qwen2.5:3b",
@@ -305,7 +306,7 @@ class TestFormEndpoints:
         monkeypatch.setattr("app.api.routes.forms.requests.post", fake_post)
 
         audio = ("audio", ("recording.wav", io.BytesIO(b"data"), "audio/wav"))
-        resp = client.post("/forms/transcribe", files=[audio])
+        resp = client.post(f"{API_PREFIX}/forms/transcribe", files=[audio])
         assert resp.status_code == 503
 
 
@@ -323,7 +324,7 @@ class TestE2EPipeline:
         # -- Step 1: Upload a PDF --
         monkeypatch.setattr("app.api.routes.templates.PROJECT_ROOT", tmp_path)
         upload_resp = client.post(
-            "/templates/upload",
+            f"{API_PREFIX}/templates/upload",
             files=[pdf_upload],
             data={"directory": str(tmp_path)},
         )
@@ -332,7 +333,7 @@ class TestE2EPipeline:
         assert uploaded_path.endswith(".pdf")
 
         # -- Step 2: Create a template from the uploaded PDF --
-        create_resp = client.post("/templates/create", json={
+        create_resp = client.post(f"{API_PREFIX}/templates/create", json={
             "name": "Incident Report",
             "pdf_path": uploaded_path,
             "fields": {
@@ -348,13 +349,13 @@ class TestE2EPipeline:
         assert template_id is not None
 
         # -- Step 3: Verify template appears in list --
-        list_resp = client.get("/templates")
+        list_resp = client.get(f"{API_PREFIX}/templates")
         assert list_resp.status_code == 200
         templates = list_resp.json()
         assert any(t["id"] == template_id for t in templates)
 
         # -- Step 4: Fill the form --
-        fill_resp = client.post("/forms/fill", json={
+        fill_resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": template_id,
             "input_text": (
                 "Officer Jane Smith, badge 4521. On January 15 2025 at "

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -1,0 +1,257 @@
+"""Tests for DELETE /api/v1/templates/{id}, DELETE /api/v1/forms/{id},
+POST /api/v1/forms/purge, and API-key access control.
+"""
+
+import io
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.models import FormSubmission, Template
+from app.core.config import API_PREFIX
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _seed_template(client, name="T1", pdf_path="src/inputs/t.pdf"):
+    resp = client.post(f"{API_PREFIX}/templates/create", json={
+        "name": name,
+        "pdf_path": pdf_path,
+        "fields": {"name": "string"},
+    })
+    assert resp.status_code == 200, resp.json()
+    return resp.json()["id"]
+
+
+def _seed_submission(db, template_id, output_pdf_path="src/outputs/out.pdf"):
+    sub = FormSubmission(
+        template_id=template_id,
+        input_text="John Doe, firefighter",
+        output_pdf_path=output_pdf_path,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub.id
+
+
+# ===========================================================================
+# DELETE /api/v1/templates/{template_id}
+# ===========================================================================
+
+class TestDeleteTemplate:
+
+    def test_delete_template_no_key_required_when_unconfigured(self, client):
+        """No API key needed when FIREFORM_API_KEY is empty (default)."""
+        tpl_id = _seed_template(client)
+        resp = client.delete(f"{API_PREFIX}/templates/{tpl_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "success"
+
+    def test_delete_template_removes_from_db(self, client, db):
+        tpl_id = _seed_template(client)
+        client.delete(f"{API_PREFIX}/templates/{tpl_id}")
+        assert db.get(Template, tpl_id) is None
+
+    def test_delete_template_not_found(self, client):
+        resp = client.delete(f"{API_PREFIX}/templates/99999")
+        assert resp.status_code == 404
+
+    def test_delete_template_cascades_submissions(self, client, db):
+        tpl_id = _seed_template(client)
+        sub_id = _seed_submission(db, tpl_id)
+
+        client.delete(f"{API_PREFIX}/templates/{tpl_id}")
+
+        assert db.get(FormSubmission, sub_id) is None
+        assert db.get(Template, tpl_id) is None
+
+    def test_delete_template_deletes_pdf_file(self, client, tmp_path, monkeypatch):
+        """Verify the template PDF file is removed from disk on delete."""
+        monkeypatch.setattr("app.api.routes.templates.PROJECT_ROOT", tmp_path)
+        pdf_file = tmp_path / "myform.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 fake")
+
+        relative_path = "myform.pdf"
+        tpl_id = _seed_template(client, pdf_path=relative_path)
+
+        client.delete(f"{API_PREFIX}/templates/{tpl_id}")
+        assert not pdf_file.exists()
+
+    def test_delete_template_deletes_submission_output_pdfs(self, client, db, tmp_path, monkeypatch):
+        """Output PDFs of related submissions should be wiped on template deletion."""
+        monkeypatch.setattr("app.api.routes.templates.PROJECT_ROOT", tmp_path)
+
+        out_pdf = tmp_path / "filled.pdf"
+        out_pdf.write_bytes(b"%PDF-1.4 filled")
+
+        tpl_id = _seed_template(client, pdf_path="tpl.pdf")
+        sub_id = _seed_submission(db, tpl_id, output_pdf_path="filled.pdf")
+
+        client.delete(f"{API_PREFIX}/templates/{tpl_id}")
+        assert not out_pdf.exists()
+
+
+# ===========================================================================
+# DELETE /api/v1/forms/{submission_id}
+# ===========================================================================
+
+class TestDeleteSubmission:
+
+    def test_delete_submission_no_key_when_unconfigured(self, client, db):
+        tpl_id = _seed_template(client)
+        sub_id = _seed_submission(db, tpl_id)
+        resp = client.delete(f"{API_PREFIX}/forms/{sub_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "success"
+
+    def test_delete_submission_removes_from_db(self, client, db):
+        tpl_id = _seed_template(client)
+        sub_id = _seed_submission(db, tpl_id)
+        client.delete(f"{API_PREFIX}/forms/{sub_id}")
+        assert db.get(FormSubmission, sub_id) is None
+
+    def test_delete_submission_not_found(self, client):
+        resp = client.delete(f"{API_PREFIX}/forms/99999")
+        assert resp.status_code == 404
+
+    def test_delete_submission_removes_output_pdf(self, client, db, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.api.routes.forms.PROJECT_ROOT", tmp_path)
+        out_pdf = tmp_path / "filled_out.pdf"
+        out_pdf.write_bytes(b"%PDF-1.4")
+
+        tpl_id = _seed_template(client)
+        sub_id = _seed_submission(db, tpl_id, output_pdf_path="filled_out.pdf")
+
+        client.delete(f"{API_PREFIX}/forms/{sub_id}")
+        assert not out_pdf.exists()
+
+
+# ===========================================================================
+# POST /api/v1/forms/purge
+# ===========================================================================
+
+class TestPurgeSubmissions:
+
+    def _seed_old_submission(self, db, tpl_id, days_old=40):
+        old_ts = datetime.now(timezone.utc) - timedelta(days=days_old)
+        sub = FormSubmission(
+            template_id=tpl_id,
+            input_text="old data",
+            output_pdf_path="src/outputs/old.pdf",
+            created_at=old_ts,
+        )
+        db.add(sub)
+        db.commit()
+        db.refresh(sub)
+        return sub.id
+
+    def test_purge_removes_old_submissions(self, client, db):
+        tpl_id = _seed_template(client)
+        old_id = self._seed_old_submission(db, tpl_id, days_old=40)
+        new_id = _seed_submission(db, tpl_id)  # recent
+
+        resp = client.post(f"{API_PREFIX}/forms/purge?days=30")
+        assert resp.status_code == 200
+        assert resp.json()["purged_count"] == 1
+
+        assert db.get(FormSubmission, old_id) is None
+        assert db.get(FormSubmission, new_id) is not None
+
+    def test_purge_nothing_to_remove(self, client, db):
+        tpl_id = _seed_template(client)
+        _seed_submission(db, tpl_id)  # recent
+        resp = client.post(f"{API_PREFIX}/forms/purge?days=30")
+        assert resp.status_code == 200
+        assert resp.json()["purged_count"] == 0
+
+    def test_purge_removes_output_pdf_file(self, client, db, tmp_path, monkeypatch):
+        monkeypatch.setattr("app.api.routes.forms.PROJECT_ROOT", tmp_path)
+        out_pdf = tmp_path / "old_filled.pdf"
+        out_pdf.write_bytes(b"%PDF-1.4")
+
+        tpl_id = _seed_template(client)
+        old_ts = datetime.now(timezone.utc) - timedelta(days=50)
+        sub = FormSubmission(
+            template_id=tpl_id,
+            input_text="old",
+            output_pdf_path="old_filled.pdf",
+            created_at=old_ts,
+        )
+        db.add(sub)
+        db.commit()
+
+        resp = client.post(f"{API_PREFIX}/forms/purge?days=30")
+        assert resp.status_code == 200
+        assert not out_pdf.exists()
+
+
+# ===========================================================================
+# API-Key Access Control
+# ===========================================================================
+
+class TestApiKeyAccessControl:
+
+    @pytest.fixture(autouse=True)
+    def _set_api_key(self, monkeypatch):
+        monkeypatch.setattr("app.api.deps.FIREFORM_API_KEY", "secret-test-key")
+
+    def test_delete_template_requires_key_when_set(self, client):
+        tpl_id = _seed_template(client)
+        resp = client.delete(f"{API_PREFIX}/templates/{tpl_id}")
+        assert resp.status_code == 401
+
+    def test_delete_template_with_valid_x_api_key(self, client):
+        tpl_id = _seed_template(client)
+        resp = client.delete(
+            f"{API_PREFIX}/templates/{tpl_id}",
+            headers={"X-API-Key": "secret-test-key"},
+        )
+        assert resp.status_code == 200
+
+    def test_delete_template_with_bearer_token(self, client):
+        tpl_id = _seed_template(client)
+        resp = client.delete(
+            f"{API_PREFIX}/templates/{tpl_id}",
+            headers={"Authorization": "Bearer secret-test-key"},
+        )
+        assert resp.status_code == 200
+
+    def test_delete_template_wrong_key_rejected(self, client):
+        tpl_id = _seed_template(client)
+        resp = client.delete(
+            f"{API_PREFIX}/templates/{tpl_id}",
+            headers={"X-API-Key": "wrong-key"},
+        )
+        assert resp.status_code == 401
+
+    def test_delete_submission_requires_key_when_set(self, client, db):
+        tpl_id = _seed_template(client)
+        sub_id = _seed_submission(db, tpl_id)
+        resp = client.delete(f"{API_PREFIX}/forms/{sub_id}")
+        assert resp.status_code == 401
+
+    def test_delete_submission_with_valid_key(self, client, db):
+        tpl_id = _seed_template(client)
+        sub_id = _seed_submission(db, tpl_id)
+        resp = client.delete(
+            f"{API_PREFIX}/forms/{sub_id}",
+            headers={"X-API-Key": "secret-test-key"},
+        )
+        assert resp.status_code == 200
+
+    def test_purge_requires_key_when_set(self, client):
+        resp = client.post(f"{API_PREFIX}/forms/purge?days=30")
+        assert resp.status_code == 401
+
+    def test_purge_with_valid_key(self, client, db):
+        tpl_id = _seed_template(client)
+        resp = client.post(
+            f"{API_PREFIX}/forms/purge?days=30",
+            headers={"X-API-Key": "secret-test-key"},
+        )
+        assert resp.status_code == 200

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,12 +1,13 @@
 """Tests for async job submission and status endpoints."""
 
 from unittest.mock import patch, MagicMock
+from app.core.config import API_PREFIX
 
 
 class TestJobEndpoints:
 
     def _seed_template(self, client):
-        resp = client.post("/templates/create", json={
+        resp = client.post(f"{API_PREFIX}/templates/create", json={
             "name": "Test Template",
             "pdf_path": "test.pdf",
             "fields": {"name": "string"},
@@ -20,7 +21,7 @@ class TestJobEndpoints:
         mock_task.delay.return_value = mock_result
 
         tpl_id = self._seed_template(client)
-        resp = client.post("/forms/jobs", json={
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [tpl_id],
             "input_text": "John Doe firefighter",
         })
@@ -29,7 +30,7 @@ class TestJobEndpoints:
         assert len(data["jobs"]) == 1
         assert data["jobs"][0]["status"] == "queued"
         assert "job_id" in data["jobs"][0]
-        assert data["jobs"][0]["poll_url"].startswith("/api/v1/jobs/")
+        assert data["jobs"][0]["poll_url"].startswith(f"{API_PREFIX}/jobs/")
         mock_task.delay.assert_called_once_with(tpl_id, "John Doe firefighter", None)
 
     @patch("app.api.routes.jobs.fill_form_task")
@@ -41,7 +42,7 @@ class TestJobEndpoints:
 
         t1 = self._seed_template(client)
         t2 = self._seed_template(client)
-        resp = client.post("/forms/jobs", json={
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [t1, t2],
             "input_text": "batch input",
         })
@@ -53,7 +54,7 @@ class TestJobEndpoints:
 
     @patch("app.api.routes.jobs.fill_form_task")
     def test_submit_async_missing_template(self, mock_task, client):
-        resp = client.post("/forms/jobs", json={
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [9999],
             "input_text": "some text",
         })
@@ -65,13 +66,13 @@ class TestJobEndpoints:
         mock_task.delay.return_value = MagicMock(id="celery-abc")
 
         tpl_id = self._seed_template(client)
-        submit_resp = client.post("/forms/jobs", json={
+        submit_resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [tpl_id],
             "input_text": "test input",
         })
         job_id = submit_resp.json()["jobs"][0]["job_id"]
 
-        resp = client.get(f"/jobs/{job_id}")
+        resp = client.get(f"{API_PREFIX}/jobs/{job_id}")
         assert resp.status_code == 200
         data = resp.json()
         assert data["job_id"] == job_id
@@ -80,7 +81,7 @@ class TestJobEndpoints:
         assert data["progress_percent"] == 0
 
     def test_get_job_not_found(self, client):
-        resp = client.get("/jobs/00000000-0000-0000-0000-000000000000")
+        resp = client.get(f"{API_PREFIX}/jobs/00000000-0000-0000-0000-000000000000")
         assert resp.status_code == 404
 
     @patch("app.api.routes.jobs.fill_form_task")
@@ -88,7 +89,7 @@ class TestJobEndpoints:
         mock_task.delay.return_value = MagicMock(id="celery-xyz")
 
         tpl_id = self._seed_template(client)
-        resp = client.post("/forms/jobs", json={
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [tpl_id],
             "input_text": "test",
             "model": "mistral:latest",
@@ -97,14 +98,14 @@ class TestJobEndpoints:
         mock_task.delay.assert_called_once_with(tpl_id, "test", "mistral:latest")
 
     def test_submit_empty_template_ids(self, client):
-        resp = client.post("/forms/jobs", json={
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [],
             "input_text": "test",
         })
         assert resp.status_code == 422
 
     def test_submit_empty_input_text(self, client):
-        resp = client.post("/forms/jobs", json={
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [1],
             "input_text": "",
         })

--- a/tests/test_v1_system.py
+++ b/tests/test_v1_system.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 import requests as requests_lib
 
-import app.api.v1.routes.system as system_mod
+import app.api.routes.system as system_mod
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +120,7 @@ class TestHealthEndpoint:
     def test_all_healthy(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
 
@@ -139,7 +139,7 @@ class TestHealthEndpoint:
     def test_ollama_down_returns_200_degraded(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_ollama_down)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_ollama_down)
 
         resp = client.get("/api/v1/health")
 
@@ -153,7 +153,7 @@ class TestHealthEndpoint:
     def test_whisper_down_returns_200_degraded(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_whisper_down)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_whisper_down)
 
         resp = client.get("/api/v1/health")
 
@@ -166,7 +166,7 @@ class TestHealthEndpoint:
     def test_db_down_returns_503_unhealthy(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_down())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
 
@@ -182,7 +182,7 @@ class TestHealthEndpoint:
         """
         monkeypatch.setattr(system_mod, "engine", _mock_engine_execute_fails())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
 
@@ -196,7 +196,7 @@ class TestHealthEndpoint:
         """current_load must be absent or null — never a made-up value."""
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
@@ -209,7 +209,7 @@ class TestHealthEndpoint:
         """
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
         monkeypatch.setattr(system_mod, "_SLOW_MS", -1)
 
         resp = client.get("/api/v1/health")
@@ -222,7 +222,7 @@ class TestHealthEndpoint:
         """models_available is built from /api/tags; loaded=True only for models in /api/ps."""
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
@@ -238,7 +238,7 @@ class TestHealthEndpoint:
     def test_model_loaded_reflects_running_model(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
@@ -248,7 +248,7 @@ class TestHealthEndpoint:
     def test_ollama_version_present(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
@@ -258,7 +258,7 @@ class TestHealthEndpoint:
     def test_storage_disk_free_present(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil(free_bytes=200 * 1024 ** 3))
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
@@ -269,7 +269,7 @@ class TestHealthEndpoint:
     def test_storage_unavailable_is_degraded(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil(raise_oserror=True))
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
@@ -280,15 +280,15 @@ class TestHealthEndpoint:
     def test_uptime_seconds_is_non_negative(self, client, monkeypatch):
         monkeypatch.setattr(system_mod, "engine", _mock_engine_healthy())
         monkeypatch.setattr(system_mod, "shutil", _mock_shutil())
-        monkeypatch.setattr("app.api.v1.routes.system.requests.get", _fake_get_all_healthy)
+        monkeypatch.setattr("app.api.routes.system.requests.get", _fake_get_all_healthy)
 
         resp = client.get("/api/v1/health")
         assert resp.status_code == 200
         assert resp.json()["uptime_seconds"] >= 0
 
     def test_existing_routes_not_displaced(self, client):
-        """Sanity: adding v1_router must not break the existing /templates endpoint."""
-        resp = client.get("/templates")
+        """Sanity: adding v1_router must not break the existing /api/v1/templates endpoint."""
+        resp = client.get("/api/v1/templates")
         assert resp.status_code == 200
 
 


### PR DESCRIPTION
# Walkthrough — Bug #588: PII Retention & Access Control

## What Was Done

### 1. Fixed broken test imports
- [`tests/test_v1_system.py`](file:///Users/marcvergessantiago/Desktop/FireForm/tests/test_v1_system.py): Fixed all `app.api.v1.routes.system` → `app.api.routes.system` imports and monkeypatch paths.
- [`tests/test_api.py`](file:///Users/marcvergessantiago/Desktop/FireForm/tests/test_api.py), [`tests/test_jobs.py`](file:///Users/marcvergessantiago/Desktop/FireForm/tests/test_jobs.py): Updated all bare `/templates`, `/forms`, `/jobs` paths to `/api/v1/…` to match the actual prefix.

### 2. Database — new repository helpers
[`app/db/repositories.py`](file:///Users/marcvergessantiago/Desktop/FireForm/app/db/repositories.py)
- `get_form_submission(session, id)` — lookup by PK
- `delete_form_submission(session, submission)` — remove row and commit
- `delete_template(session, template)` — remove row and commit

### 3. Config — new environment variables
[`app/core/config.py`](file:///Users/marcvergessantiago/Desktop/FireForm/app/core/config.py)
| Variable | Default | Purpose |
|---|---|---|
| `FIREFORM_API_KEY` | `""` (disabled) | API key required on admin endpoints |
| `RETENTION_PERIOD_DAYS` | `30` | Days before submissions are auto-purged |

### 4. Access-control dependency
[`app/api/deps.py`](file:///Users/marcvergessantiago/Desktop/FireForm/app/api/deps.py): `verify_api_key` — when `FIREFORM_API_KEY` is set, callers must supply it via `X-API-Key` header or `Authorization: Bearer <key>`. No-ops when the key is unconfigured.

### 5. DELETE endpoints
- [`DELETE /api/v1/templates/{id}`](file:///Users/marcvergessantiago/Desktop/FireForm/app/api/routes/templates.py) — deletes the template DB record, its source PDF, all linked `FormSubmission` rows, their output PDFs, and all linked `Job` rows.
- [`DELETE /api/v1/forms/{id}`](file:///Users/marcvergessantiago/Desktop/FireForm/app/api/routes/forms.py) — deletes the submission DB row and its output PDF.
- [`POST /api/v1/forms/purge?days=N`](file:///Users/marcvergessantiago/Desktop/FireForm/app/api/routes/forms.py) — bulk-purges all submissions older than N days (defaults to `RETENTION_PERIOD_DAYS`), including their output PDFs.

All three endpoints require the API key when one is configured.

### 6. Celery purge task
[`app/tasks/purge.py`](file:///Users/marcvergessantiago/Desktop/FireForm/app/tasks/purge.py): `purge_old_submissions` Celery task — same logic as the HTTP purge endpoint, scheduled via Celery Beat at 03:00 UTC daily.

[`app/core/celery.py`](file:///Users/marcvergessantiago/Desktop/FireForm/app/core/celery.py): registered the new task and added the `beat_schedule` entry.

### 7. Tests
[`tests/test_deletion.py`](file:///Users/marcvergessantiago/Desktop/FireForm/tests/test_deletion.py) — 21 new tests covering:
- DELETE template (not found, DB removal, file deletion, cascade to submissions)
- DELETE submission (not found, DB removal, file deletion)
- POST purge (age filter, file removal, nothing-to-purge)
- API-key access control (no key → 401, correct key → 200, wrong key → 401, Bearer token)

### 8. README
[`README.md`](file:///Users/marcvergessantiago/Desktop/FireForm/README.md)
- Removed the inaccurate "never collects PII" claim.
- Added accurate description of local PII storage and operator responsibility.
- Added **Data Deletion & Retention** section with `curl` examples.
- Added **Access Control** section with env-var setup.
- Added **Operator Hardening Recommendations** section.
- Updated the "Do No Harm" bullet to reflect operator responsibility.

## Test Results
```
74 passed, 5 warnings in 1.11s
```
