### PR TITLE
CI CD test failure fixed

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,4 +15,4 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t fireform:test .
+          docker build -t fireform:test -f docker/prod/Dockerfile .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,11 +4,26 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main,development]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: fireform
+          POSTGRES_PASSWORD: fireform
+          POSTGRES_DB: fireform
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U fireform"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4
@@ -33,5 +48,7 @@ jobs:
       - name: Check for un-migrated model changes
         env:
           PYTHONPATH: .
+          DATABASE_URL: postgresql://fireform:fireform@localhost:5432/fireform
         run: |
+          python -m alembic upgrade head
           python -m alembic check


### PR DESCRIPTION


# Fix CI failures: alembic check + docker build

## Problem
Two CI jobs failing on PRs:
- **Tests / alembic check** - `python -m alembic check` connected to default postgres at `localhost:5432`; no DB in CI → `connection refused`.
- **Docker Build** - `docker build .` looked for `./Dockerfile`, which doesn't exist (Dockerfiles live under `docker/prod/` and `docker/dev/`).

## Changes
- **tests.yml**: added a `postgres:16` service container, run `alembic upgrade head` then `alembic check` against it with `DATABASE_URL` set. Also extended PR triggers to `development`.
- **docker-build.yml**: build with `-f docker/prod/Dockerfile .` (verified COPY paths are repo-root relative).

fixes #592