### PR TITLE
Add v1 contract DB models and migration (#544)

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,7 +6,7 @@ from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
 
 from app.core.config import DATABASE_URL
-from app.models import FormSubmission, Job, Template 
+from app.models import Extraction, Form, FormSubmission, Incident, Input, Job, Report, Template  # noqa: F401
 
 config = context.config
 

--- a/alembic/versions/002_v1_models.py
+++ b/alembic/versions/002_v1_models.py
@@ -1,0 +1,144 @@
+"""v1 models — Input, Extraction, Incident, Form, Report tables.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-06-26
+
+JSON columns use sa.JSON (Postgres json type, not jsonb) for consistency with
+migration 001 and SQLite test-harness compatibility. A follow-up can switch
+high-query blobs (especially incident_contract) to jsonb via with_variant() if
+containment operators or GIN indexing are needed.
+
+Form.job_id and Report.job_id are plain UUID columns with no FK constraint.
+The contract Job model (UUID-PK, enum-typed) is a separate decision; the FK
+will be added when that model is resolved.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "inputs",
+        sa.Column("input_id", sa.Uuid(), primary_key=True),
+        sa.Column("input_type", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("transcript", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("original_filename", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("audio_duration_seconds", sa.Float, nullable=True),
+        sa.Column("character_count", sa.Integer, nullable=True),
+        sa.Column("word_count", sa.Integer, nullable=True),
+        sa.Column("station_id", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("responder_badge", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("incident_date_hint", sa.Date, nullable=True),
+        sa.Column("error_detail", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "extractions",
+        sa.Column("extract_id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "input_id",
+            sa.Uuid(),
+            sa.ForeignKey("inputs.input_id"),
+            nullable=False,
+        ),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("started_at", sa.DateTime, nullable=True),
+        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column("model_used", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("processing_time_seconds", sa.Float, nullable=True),
+        sa.Column("incident_contract", sa.JSON, nullable=True),
+        sa.Column("corrections", sa.JSON, nullable=True),
+        sa.Column("error_type", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("error_detail", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "incidents",
+        sa.Column("incident_id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "extract_id",
+            sa.Uuid(),
+            sa.ForeignKey("extractions.extract_id"),
+            nullable=False,
+        ),
+        sa.Column("incident_number", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("incident_name", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("incident_type", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("incident_date", sa.Date, nullable=True),
+        sa.Column("tags", sa.JSON, nullable=True),
+        sa.Column("notes", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.Column("deleted_at", sa.DateTime, nullable=True),
+    )
+
+    op.create_table(
+        "forms",
+        sa.Column("form_id", sa.Uuid(), primary_key=True),
+        sa.Column("form_type", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column(
+            "extract_id",
+            sa.Uuid(),
+            sa.ForeignKey("extractions.extract_id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "incident_id",
+            sa.Uuid(),
+            sa.ForeignKey("incidents.incident_id"),
+            nullable=True,
+        ),
+        sa.Column("job_id", sa.Uuid(), nullable=True),  # no FK — see module docstring
+        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column("pdf_ready", sa.Boolean, nullable=False),
+        sa.Column("json_ready", sa.Boolean, nullable=False),
+        sa.Column("field_mapping_summary", sa.JSON, nullable=True),
+        sa.Column("pdf_path", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("json_data", sa.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+    op.create_table(
+        "reports",
+        sa.Column("report_id", sa.Uuid(), primary_key=True),
+        sa.Column("period_type", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("period_label", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("year", sa.Integer, nullable=False),
+        sa.Column("month", sa.Integer, nullable=True),
+        sa.Column("quarter", sa.Integer, nullable=True),
+        sa.Column("output_format", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("status", sqlmodel.sql.sqltypes.AutoString, nullable=False),
+        sa.Column("generated_at", sa.DateTime, nullable=True),
+        sa.Column("summary", sa.JSON, nullable=True),
+        sa.Column("job_id", sa.Uuid(), nullable=True),  # no FK — see module docstring
+        sa.Column("pdf_path", sqlmodel.sql.sqltypes.AutoString, nullable=True),
+        sa.Column("json_data", sa.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reports")
+    op.drop_table("forms")
+    op.drop_table("incidents")
+    op.drop_table("extractions")
+    op.drop_table("inputs")

--- a/app/api/schemas/enums.py
+++ b/app/api/schemas/enums.py
@@ -1,6 +1,11 @@
 from enum import Enum
 
 
+class InputType(str, Enum):
+    voice = "voice"
+    text = "text"
+
+
 class InputStatus(str, Enum):
     queued = "queued"
     transcribing = "transcribing"

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,23 @@
 """ORM models. Import from here: `from app.models import Template`."""
 
-from app.models.models import FormSubmission, Job, Template
+from app.models.models import (
+    Extraction,
+    Form,
+    FormSubmission,
+    Incident,
+    Input,
+    Job,
+    Report,
+    Template,
+)
 
-__all__ = ["Template", "FormSubmission", "Job"]
+__all__ = [
+    "Template",
+    "FormSubmission",
+    "Job",
+    "Input",
+    "Extraction",
+    "Incident",
+    "Form",
+    "Report",
+]

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,8 +1,22 @@
 import uuid as uuid_mod
+from uuid import UUID, uuid4
+from datetime import date, datetime, timezone
 
 from sqlalchemy import Column, JSON
 from sqlmodel import SQLModel, Field
-from datetime import datetime, timezone
+from sqlmodel.sql.sqltypes import AutoString
+
+from app.api.schemas.enums import (
+    ExtractionStatus,
+    FormStatus,
+    FormType,
+    InputStatus,
+    InputType,
+    JobStatus,
+    OutputFormat,
+    PeriodType,
+    ReportStatus,
+)
 
 
 class Template(SQLModel, table=True):
@@ -33,5 +47,121 @@ class Job(SQLModel, table=True):
     result_url: str | None = None
     error: dict | None = Field(default=None, sa_column=Column(JSON))
     model: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# ---------------------------------------------------------------------------
+# v1 contract models
+# ---------------------------------------------------------------------------
+
+class Input(SQLModel, table=True):
+    __tablename__ = "inputs"
+
+    input_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    # sa_column required on all str-Enum fields: without it SQLModel emits
+    # sa.Enum(native_enum=True) which creates a Postgres ENUM type — hard to
+    # migrate and inconsistent with the VARCHAR approach used in migration 001.
+    input_type: InputType = Field(sa_column=Column(AutoString, nullable=False))
+    status: InputStatus = Field(
+        default=InputStatus.queued, sa_column=Column(AutoString, nullable=False)
+    )
+    transcript: str | None = None
+    original_filename: str | None = None
+    audio_duration_seconds: float | None = None
+    character_count: int | None = None
+    word_count: int | None = None
+    station_id: str | None = None
+    responder_badge: str | None = None
+    incident_date_hint: date | None = None
+    error_detail: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Extraction(SQLModel, table=True):
+    __tablename__ = "extractions"
+
+    extract_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    input_id: UUID = Field(foreign_key="inputs.input_id")
+    status: ExtractionStatus = Field(
+        default=ExtractionStatus.processing, sa_column=Column(AutoString, nullable=False)
+    )
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    model_used: str | None = None
+    processing_time_seconds: float | None = None
+    # Full IncidentContract superset blob; stores partial result while processing,
+    # final canonical JSON when status=completed.
+    incident_contract: dict | None = Field(default=None, sa_column=Column(JSON))
+    # Audit trail of manual corrections applied via PATCH /extract/{id}.
+    corrections: list | None = Field(default=None, sa_column=Column(JSON))
+    error_type: str | None = None
+    error_detail: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Incident(SQLModel, table=True):
+    __tablename__ = "incidents"
+
+    incident_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    extract_id: UUID = Field(foreign_key="extractions.extract_id")
+    incident_number: str | None = None
+    status: ReportStatus = Field(
+        default=ReportStatus.draft, sa_column=Column(AutoString, nullable=False)
+    )
+    incident_name: str | None = None
+    incident_type: str | None = None
+    incident_date: date | None = None
+    tags: list | None = Field(default=None, sa_column=Column(JSON))
+    notes: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    deleted_at: datetime | None = None
+
+
+class Form(SQLModel, table=True):
+    __tablename__ = "forms"
+
+    form_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    form_type: FormType = Field(sa_column=Column(AutoString, nullable=False))
+    status: FormStatus = Field(
+        default=FormStatus.queued, sa_column=Column(AutoString, nullable=False)
+    )
+    extract_id: UUID = Field(foreign_key="extractions.extract_id")
+    incident_id: UUID | None = Field(default=None, foreign_key="incidents.incident_id")
+    # Plain UUID, no FK constraint — pending contract Job model resolution (#544 decision A).
+    job_id: UUID | None = None
+    completed_at: datetime | None = None
+    pdf_ready: bool = Field(default=False)
+    json_ready: bool = Field(default=False)
+    field_mapping_summary: dict | None = Field(default=None, sa_column=Column(JSON))
+    pdf_path: str | None = None
+    json_data: dict | None = Field(default=None, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Report(SQLModel, table=True):
+    __tablename__ = "reports"
+
+    report_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    period_type: PeriodType = Field(sa_column=Column(AutoString, nullable=False))
+    period_label: str | None = None
+    year: int
+    month: int | None = None
+    quarter: int | None = None
+    # Named output_format (not format) to avoid shadowing the Python builtin.
+    output_format: OutputFormat = Field(sa_column=Column(AutoString, nullable=False))
+    status: JobStatus = Field(
+        default=JobStatus.queued, sa_column=Column(AutoString, nullable=False)
+    )
+    generated_at: datetime | None = None
+    summary: dict | None = Field(default=None, sa_column=Column(JSON))
+    # Plain UUID, no FK constraint — pending contract Job model resolution (#544 decision A).
+    job_id: UUID | None = None
+    pdf_path: str | None = None
+    json_data: dict | None = Field(default=None, sa_column=Column(JSON))
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from sqlmodel import SQLModel, Session, create_engine
 from app.main import app
 from app.api.deps import get_db
 from app.core.config import API_PREFIX  # single source of truth for all tests
-from app.models import Template, FormSubmission, Job  # noqa: F401 — registers tables
+from app.models import Template, FormSubmission, Job, Input, Extraction, Incident, Form, Report  # noqa: F401 — registers tables
 
 # ---------------------------------------------------------------------------
 # In-memory database

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -36,6 +36,11 @@ def test_upgrade_head(alembic_cfg, alembic_engine):
     assert "template" in tables
     assert "formsubmission" in tables
     assert "job" in tables
+    assert "inputs" in tables
+    assert "extractions" in tables
+    assert "incidents" in tables
+    assert "forms" in tables
+    assert "reports" in tables
     assert "alembic_version" in tables
 
 
@@ -126,3 +131,179 @@ def test_job_fk(alembic_cfg, alembic_engine):
     assert len(fks) == 1
     assert fks[0]["referred_table"] == "template"
     assert fks[0]["referred_columns"] == ["id"]
+
+
+# ---------------------------------------------------------------------------
+# 002 — v1 model tables
+# ---------------------------------------------------------------------------
+
+def test_inputs_columns(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("inputs")}
+    assert columns == {
+        "input_id",
+        "input_type",
+        "status",
+        "transcript",
+        "original_filename",
+        "audio_duration_seconds",
+        "character_count",
+        "word_count",
+        "station_id",
+        "responder_badge",
+        "incident_date_hint",
+        "error_detail",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_extractions_columns(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("extractions")}
+    assert columns == {
+        "extract_id",
+        "input_id",
+        "status",
+        "started_at",
+        "completed_at",
+        "model_used",
+        "processing_time_seconds",
+        "incident_contract",
+        "corrections",
+        "error_type",
+        "error_detail",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_extractions_fk(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    fks = inspector.get_foreign_keys("extractions")
+    assert len(fks) == 1
+    assert fks[0]["referred_table"] == "inputs"
+    assert fks[0]["referred_columns"] == ["input_id"]
+
+
+def test_incidents_columns(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("incidents")}
+    assert columns == {
+        "incident_id",
+        "extract_id",
+        "incident_number",
+        "status",
+        "incident_name",
+        "incident_type",
+        "incident_date",
+        "tags",
+        "notes",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+    }
+
+
+def test_incidents_fk(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    fks = inspector.get_foreign_keys("incidents")
+    assert len(fks) == 1
+    assert fks[0]["referred_table"] == "extractions"
+    assert fks[0]["referred_columns"] == ["extract_id"]
+
+
+def test_forms_columns(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("forms")}
+    assert columns == {
+        "form_id",
+        "form_type",
+        "status",
+        "extract_id",
+        "incident_id",
+        "job_id",
+        "completed_at",
+        "pdf_ready",
+        "json_ready",
+        "field_mapping_summary",
+        "pdf_path",
+        "json_data",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_forms_fk(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    fks = {fk["referred_table"]: fk for fk in inspector.get_foreign_keys("forms")}
+    # extract_id → extractions and incident_id → incidents; job_id has NO FK constraint
+    assert "extractions" in fks
+    assert fks["extractions"]["referred_columns"] == ["extract_id"]
+    assert "incidents" in fks
+    assert fks["incidents"]["referred_columns"] == ["incident_id"]
+    assert len(fks) == 2
+
+
+def test_reports_columns(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("reports")}
+    assert columns == {
+        "report_id",
+        "period_type",
+        "period_label",
+        "year",
+        "month",
+        "quarter",
+        "output_format",
+        "status",
+        "generated_at",
+        "summary",
+        "job_id",
+        "pdf_path",
+        "json_data",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_reports_no_fk(alembic_cfg, alembic_engine):
+    """job_id on reports is a plain UUID column — no FK constraint until contract Job is resolved."""
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    fks = inspector.get_foreign_keys("reports")
+    assert len(fks) == 0
+
+
+def test_downgrade_002(alembic_cfg, alembic_engine):
+    """Downgrade by one step removes only the 002 tables, leaving 001 tables intact."""
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "-1")
+
+    inspector = inspect(alembic_engine)
+    tables = inspector.get_table_names()
+    assert "inputs" not in tables
+    assert "extractions" not in tables
+    assert "incidents" not in tables
+    assert "forms" not in tables
+    assert "reports" not in tables
+    assert "template" in tables
+    assert "formsubmission" in tables
+    assert "job" in tables

--- a/tests/test_v1_models.py
+++ b/tests/test_v1_models.py
@@ -1,0 +1,408 @@
+"""Direct SQLModel instantiation tests for the five v1 models.
+
+Uses the same in-memory SQLite engine and _reset_tables fixture from conftest
+(autouse=True) so every test starts with a clean schema. Tests stay at the ORM
+layer — no routes, no Celery, no Ollama.
+"""
+
+from datetime import date, datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from sqlmodel import Session, select
+
+from app.api.schemas.enums import (
+    ExtractionStatus,
+    FormStatus,
+    FormType,
+    InputStatus,
+    InputType,
+    JobStatus,
+    OutputFormat,
+    PeriodType,
+    ReportStatus,
+)
+from app.models import Extraction, Form, Incident, Input, Report
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _input(db: Session, **kwargs) -> Input:
+    defaults = dict(input_type=InputType.text)
+    row = Input(**{**defaults, **kwargs})
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _extraction(db: Session, input_id: UUID, **kwargs) -> "Extraction":
+    row = Extraction(input_id=input_id, **kwargs)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Input
+# ---------------------------------------------------------------------------
+
+class TestInputModel:
+
+    def test_defaults_on_create(self, db):
+        row = _input(db)
+        assert isinstance(row.input_id, UUID)
+        assert row.status == InputStatus.queued
+        assert row.transcript is None
+        assert row.audio_duration_seconds is None
+        assert row.character_count is None
+        assert isinstance(row.created_at, datetime)
+        assert isinstance(row.updated_at, datetime)
+
+    def test_voice_fields_roundtrip(self, db):
+        row = _input(
+            db,
+            input_type=InputType.voice,
+            original_filename="call_recording.mp3",
+            audio_duration_seconds=47.3,
+            station_id="STA-12",
+            responder_badge="B-4421",
+            incident_date_hint=date(2026, 6, 1),
+        )
+        fetched = db.get(Input, row.input_id)
+        assert fetched.input_type == InputType.voice
+        assert fetched.original_filename == "call_recording.mp3"
+        assert fetched.audio_duration_seconds == pytest.approx(47.3)
+        assert fetched.station_id == "STA-12"
+        assert fetched.incident_date_hint == date(2026, 6, 1)
+
+    def test_status_transitions_persist(self, db):
+        row = _input(db)
+        row.status = InputStatus.transcribing
+        db.add(row)
+        db.commit()
+        fetched = db.get(Input, row.input_id)
+        assert fetched.status == InputStatus.transcribing
+
+    def test_error_detail_on_failed(self, db):
+        row = _input(db, status=InputStatus.failed, error_detail="Whisper timeout")
+        fetched = db.get(Input, row.input_id)
+        assert fetched.status == InputStatus.failed
+        assert fetched.error_detail == "Whisper timeout"
+
+    def test_word_and_char_counts(self, db):
+        row = _input(
+            db,
+            status=InputStatus.ready,
+            transcript="Structure fire at 4th and Main",
+            character_count=30,
+            word_count=6,
+        )
+        fetched = db.get(Input, row.input_id)
+        assert fetched.character_count == 30
+        assert fetched.word_count == 6
+
+    def test_unique_primary_keys(self, db):
+        a = _input(db)
+        b = _input(db)
+        assert a.input_id != b.input_id
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractionModel:
+
+    def test_defaults_on_create(self, db):
+        inp = _input(db)
+        ext = _extraction(db, inp.input_id)
+        assert isinstance(ext.extract_id, UUID)
+        assert ext.input_id == inp.input_id
+        assert ext.status == ExtractionStatus.processing
+        assert ext.incident_contract is None
+        assert ext.corrections is None
+        assert ext.started_at is None
+
+    def test_incident_contract_json_roundtrip(self, db):
+        inp = _input(db)
+        contract = {
+            "schema_version": "1.1.0",
+            "incident": {"name": "Structure Fire Main St", "types": []},
+            "location": {"address": "123 Main St", "state": "CA"},
+        }
+        ext = _extraction(db, inp.input_id, incident_contract=contract)
+        fetched = db.get(Extraction, ext.extract_id)
+        assert fetched.incident_contract["schema_version"] == "1.1.0"
+        assert fetched.incident_contract["location"]["state"] == "CA"
+
+    def test_corrections_json_roundtrip(self, db):
+        inp = _input(db)
+        corrections = [
+            {
+                "field_path": "incident.name",
+                "original_value": "Wildland Fire",
+                "corrected_value": "Structure Fire",
+                "corrected_at": "2026-06-26T10:00:00Z",
+                "corrected_by": "dispatcher_01",
+            }
+        ]
+        ext = _extraction(db, inp.input_id, corrections=corrections)
+        fetched = db.get(Extraction, ext.extract_id)
+        assert len(fetched.corrections) == 1
+        assert fetched.corrections[0]["field_path"] == "incident.name"
+
+    def test_completed_status_fields(self, db):
+        inp = _input(db)
+        now = datetime.now(timezone.utc)
+        ext = _extraction(
+            db,
+            inp.input_id,
+            status=ExtractionStatus.completed,
+            started_at=now,
+            completed_at=now,
+            model_used="llama3:8b",
+            processing_time_seconds=38.4,
+        )
+        fetched = db.get(Extraction, ext.extract_id)
+        assert fetched.status == ExtractionStatus.completed
+        assert fetched.model_used == "llama3:8b"
+        assert fetched.processing_time_seconds == pytest.approx(38.4)
+
+    def test_failed_status_with_error_fields(self, db):
+        inp = _input(db)
+        ext = _extraction(
+            db,
+            inp.input_id,
+            status=ExtractionStatus.failed,
+            error_type="LLM_TIMEOUT",
+            error_detail="Ollama did not respond within 120s",
+        )
+        fetched = db.get(Extraction, ext.extract_id)
+        assert fetched.status == ExtractionStatus.failed
+        assert fetched.error_type == "LLM_TIMEOUT"
+
+
+# ---------------------------------------------------------------------------
+# Incident
+# ---------------------------------------------------------------------------
+
+class TestIncidentModel:
+
+    def _make(self, db, **kwargs):
+        inp = _input(db)
+        ext = _extraction(db, inp.input_id)
+        defaults = dict(extract_id=ext.extract_id)
+        row = Incident(**{**defaults, **kwargs})
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return row
+
+    def test_defaults_on_create(self, db):
+        row = self._make(db)
+        assert isinstance(row.incident_id, UUID)
+        assert row.status == ReportStatus.draft
+        assert row.deleted_at is None
+        assert row.tags is None
+
+    def test_tags_json_roundtrip(self, db):
+        row = self._make(db, tags=["wildland", "high-priority", "multi-agency"])
+        fetched = db.get(Incident, row.incident_id)
+        assert fetched.tags == ["wildland", "high-priority", "multi-agency"]
+
+    def test_soft_delete(self, db):
+        row = self._make(db)
+        assert row.deleted_at is None
+        ts = datetime.now(timezone.utc)
+        row.deleted_at = ts
+        db.add(row)
+        db.commit()
+        fetched = db.get(Incident, row.incident_id)
+        assert fetched.deleted_at is not None
+
+    def test_incident_date_field(self, db):
+        row = self._make(db, incident_date=date(2026, 5, 15))
+        fetched = db.get(Incident, row.incident_id)
+        assert fetched.incident_date == date(2026, 5, 15)
+
+    def test_all_nullable_fields_default_none(self, db):
+        row = self._make(db)
+        assert row.incident_number is None
+        assert row.incident_name is None
+        assert row.incident_type is None
+        assert row.incident_date is None
+        assert row.notes is None
+
+
+# ---------------------------------------------------------------------------
+# Form
+# ---------------------------------------------------------------------------
+
+class TestFormModel:
+
+    def _make(self, db, **kwargs):
+        inp = _input(db)
+        ext = _extraction(db, inp.input_id)
+        defaults = dict(
+            extract_id=ext.extract_id,
+            form_type=FormType.nfirs_basic,
+        )
+        row = Form(**{**defaults, **kwargs})
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return row
+
+    def test_defaults_on_create(self, db):
+        row = self._make(db)
+        assert isinstance(row.form_id, UUID)
+        assert row.status == FormStatus.queued
+        assert row.pdf_ready is False
+        assert row.json_ready is False
+        assert row.incident_id is None
+        assert row.job_id is None
+        assert row.completed_at is None
+
+    def test_field_mapping_summary_roundtrip(self, db):
+        summary = {
+            "total_form_fields": 42,
+            "fields_filled": 38,
+            "fields_blank": 4,
+            "coverage_percent": 90.5,
+        }
+        row = self._make(db, field_mapping_summary=summary)
+        fetched = db.get(Form, row.form_id)
+        assert fetched.field_mapping_summary["total_form_fields"] == 42
+        assert fetched.field_mapping_summary["coverage_percent"] == pytest.approx(90.5)
+
+    def test_json_data_roundtrip(self, db):
+        agency_json = {"FDID": "CA99901", "INC_NO": "2026-0042", "ALARMS": 2}
+        row = self._make(db, json_data=agency_json, json_ready=True)
+        fetched = db.get(Form, row.form_id)
+        assert fetched.json_ready is True
+        assert fetched.json_data["FDID"] == "CA99901"
+
+    def test_incident_fk_links_correctly(self, db):
+        inp = _input(db)
+        ext = _extraction(db, inp.input_id)
+        incident = Incident(extract_id=ext.extract_id)
+        db.add(incident)
+        db.commit()
+        db.refresh(incident)
+
+        form = Form(
+            extract_id=ext.extract_id,
+            form_type=FormType.neris,
+            incident_id=incident.incident_id,
+        )
+        db.add(form)
+        db.commit()
+        db.refresh(form)
+        assert form.incident_id == incident.incident_id
+
+    def test_job_id_stored_without_fk(self, db):
+        """job_id is a plain UUID — can store any UUID without a FK constraint."""
+        arbitrary_uuid = uuid4()
+        row = self._make(db, job_id=arbitrary_uuid)
+        fetched = db.get(Form, row.form_id)
+        assert fetched.job_id == arbitrary_uuid
+
+    def test_all_form_types_accepted(self, db):
+        inp = _input(db)
+        ext = _extraction(db, inp.input_id)
+        for ft in FormType:
+            form = Form(extract_id=ext.extract_id, form_type=ft)
+            db.add(form)
+        db.commit()
+        results = db.exec(select(Form)).all()
+        stored_types = {f.form_type for f in results}
+        assert stored_types == set(FormType)
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+class TestReportModel:
+
+    def _make(self, db, **kwargs):
+        defaults = dict(
+            period_type=PeriodType.monthly,
+            year=2026,
+            month=6,
+            output_format=OutputFormat.pdf,
+        )
+        row = Report(**{**defaults, **kwargs})
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        return row
+
+    def test_defaults_on_create(self, db):
+        row = self._make(db)
+        assert isinstance(row.report_id, UUID)
+        assert row.status == JobStatus.queued
+        assert row.generated_at is None
+        assert row.summary is None
+        assert row.pdf_path is None
+        assert row.json_data is None
+        assert row.job_id is None
+
+    def test_summary_json_roundtrip(self, db):
+        summary = {
+            "total_incidents": 23,
+            "by_type": {"fire": 10, "ems": 13},
+            "forms_generated": 71,
+            "avg_completeness_score": 88.3,
+        }
+        row = self._make(db, summary=summary)
+        fetched = db.get(Report, row.report_id)
+        assert fetched.summary["total_incidents"] == 23
+        assert fetched.summary["avg_completeness_score"] == pytest.approx(88.3)
+
+    def test_quarterly_report(self, db):
+        row = self._make(
+            db,
+            period_type=PeriodType.quarterly,
+            year=2026,
+            month=None,
+            quarter=2,
+            output_format=OutputFormat.json,
+        )
+        fetched = db.get(Report, row.report_id)
+        assert fetched.period_type == PeriodType.quarterly
+        assert fetched.quarter == 2
+        assert fetched.month is None
+
+    def test_annual_report(self, db):
+        row = self._make(
+            db,
+            period_type=PeriodType.annual,
+            year=2025,
+            month=None,
+            quarter=None,
+            output_format=OutputFormat.both,
+        )
+        fetched = db.get(Report, row.report_id)
+        assert fetched.period_type == PeriodType.annual
+        assert fetched.year == 2025
+        assert fetched.output_format == OutputFormat.both
+
+    def test_job_id_stored_without_fk(self, db):
+        arbitrary_uuid = uuid4()
+        row = self._make(db, job_id=arbitrary_uuid)
+        fetched = db.get(Report, row.report_id)
+        assert fetched.job_id == arbitrary_uuid
+
+    def test_status_progression(self, db):
+        row = self._make(db)
+        assert row.status == JobStatus.queued
+        row.status = JobStatus.processing
+        db.add(row)
+        db.commit()
+        fetched = db.get(Report, row.report_id)
+        assert fetched.status == JobStatus.processing


### PR DESCRIPTION
Closes #544.

Adds the five v1 contract DB models — Input, Extraction, Incident, Form, Report — plus migration 002 and tests. The existing Template, FormSubmission, and Job models are left untouched.

Each model uses a UUID primary key via `sa.Uuid()` (a real UUID type on Postgres, CHAR(32) on SQLite so the migration tests pass), `created_at`/`updated_at` timestamps, and the status enums from #543. The IncidentContract superset lives as a single JSON blob on Extraction rather than separate tables, matching the contract structure. Added an `InputType` (voice/text) enum to `enums.py` — the one enum the contract referenced inline without a named entry.

Two deliberate decisions worth flagging for review:

- **Job FK**: `Form.job_id` and `Report.job_id` are plain UUID columns with no FK constraint. The contract's Job entity is UUID/enum-typed, but the existing Job model (from the async work) is int-PK and celery-shaped, so a real FK isn't possible yet. The columns exist with the right type and name so the route layer can use them; a follow-up adds the constraint once the contract Job is resolved. `Form.incident_id` does get a proper FK to `incidents`.

- **JSON vs JSONB**: all JSON columns use `sa.JSON` (Postgres `json`, not `jsonb`) for consistency with migration 001 and SQLite test compatibility. If we later need containment operators or GIN indexing on the blobs — especially `incident_contract` — a follow-up can switch via `with_variant()`.

Migration 002 was autogenerated then hand-checked; `downgrade()` drops tables in reverse dependency order. The new models are registered in `alembic/env.py` and `conftest.py` so autogenerate and the test harness pick them up.

Tests: 112 passing. `test_migrations.py` asserts the table/column sets and FK constraints (including that `job_id` has no FK); `test_v1_models.py` adds direct ORM round-trip tests covering JSON fields, soft-delete, all 20 form types, and enum status persistence.