### PR TITLE
Fix contract so it matches the backend Swagger

### DIFF
--- a/contracts/openapi.yaml
+++ b/contracts/openapi.yaml
@@ -31,8 +31,10 @@ tags:
     description: Health checks, schema introspection, and system status
   - name: jobs
     description: Cross-cutting async job status polling
-  - name: external-apis
-    description: Integrations with external APIs (Weather, Zipcode)
+  - name: weather
+    description: Weather forecast lookup via external API
+  - name: zipcode
+    description: Address and postal code geocoding via external API
 
 paths:
   # ── Layer 1: Input ──────────────────────────────────────────────
@@ -102,7 +104,5 @@ paths:
   # ── Layer 9: External APIs ─────────────────────────────────────
   /api/v1/weather/forecast:
     $ref: "path/weather.yaml#/forecast"
-  /api/v1/zipcode/postal-code:
-    $ref: "path/zipcode.yaml#/postal_code"
-  /api/v1/zipcode/location:
-    $ref: "path/zipcode.yaml#/location"
+  /api/v1/zipcode/lookup-address:
+    $ref: "path/zipcode.yaml#/lookup_address"

--- a/contracts/path/weather.yaml
+++ b/contracts/path/weather.yaml
@@ -5,7 +5,7 @@ forecast:
       Fetch hourly weather data for the given location and date range.
       Coordinates must be provided as decimal degrees (e.g. `40.7128` for latitude, `-74.0060` for longitude).
     tags:
-      - external-apis
+      - weather
     parameters:
       - name: latitude
         in: query

--- a/contracts/path/zipcode.yaml
+++ b/contracts/path/zipcode.yaml
@@ -7,7 +7,7 @@ lookup_address:
       place name, state, county, and country.
       The list is ordered by relevance (most relevant first, up to 10 results).
     tags:
-      - external-apis
+      - zipcode
     parameters:
       - name: address
         in: query


### PR DESCRIPTION
# Fix contract so it matches the backend Swagger

## Why

Once we could render `contracts/` as Swagger, a few things did not match what the backend serves at `/docs`. The contract is meant to be the source of truth, so these gaps needed fixing.

## Error logs

```
There was an error while processing your files. Please fix the error and save the file.


#/paths/~1api~1v1~1zipcode~1postal-code: JSON Pointer points to missing location: path/zipcode.yaml#/postal_code
#/paths/~1api~1v1~1zipcode~1location: JSON Pointer points to missing location: path/zipcode.yaml#/location
```

## What was wrong

**Broken zipcode paths.** The root `openapi.yaml` pointed at `path/zipcode.yaml#/postal_code` and `path/zipcode.yaml#/location`. Neither exists. The zipcode file only ever defined one operation, and the real route is `GET /api/v1/zipcode/lookup-address`. Swagger threw two errors over the missing references and the actual endpoint was not shown at all.

**Wrong grouping for weather and zipcode.** The backend shows weather and zipcode as their own sections. The contract put both under one `external-apis` tag, so the rendered docs grouped them differently from the running API.

## What changed

- Replaced the two dead zipcode paths with the one that exists, `lookup-address`, pointing at the operation actually defined in the file.
- Tagged the weather and zipcode operations with `weather` and `zipcode` to match the backend, and updated the tag list in `openapi.yaml`.

## Result

The contract now resolves with no broken references and groups endpoints the same way the backend `/docs` does.

Related issue: #599
