### PR TITLE
Add make docs to render OpenAPI contracts as Swagger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init fireform build up down logs logs-app logs-ollama shell pull-model test clean super-clean status ready-banner sync
+.PHONY: help init fireform build up down logs logs-app logs-ollama shell pull-model test clean super-clean status ready-banner sync docs
 
 COMPOSE     = docker compose -f docker/dev/compose.yml --env-file docker/.env.dev
 ENV_DEV     = docker/.env.dev
@@ -31,6 +31,7 @@ help:
 	@echo "make shell        - Open shell in running app container"
 	@echo "make pull-model   - Pull Ollama model from .env.dev ($(OLLAMA_MODEL))"
 	@echo "make test         - Run test suite"
+	@echo "make docs         - Serve interactive API docs from the OpenAPI contract"
 	@echo "make migrate      - Run pending Alembic migrations"
 	@echo "make migration    - Generate new migration (msg='description')"
 	@echo "make clean        - Stop containers (preserves volumes)"
@@ -104,6 +105,10 @@ pull-model:
 
 test:
 	@$(COMPOSE) exec -T app python3 -m pytest tests/ -v
+
+docs:
+	@echo "Serving Swagger UI from contracts/openapi.yaml at http://localhost:8088"
+	@npx --yes swagger-ui-watcher contracts/openapi.yaml --port 8088
 
 migrate:
 	@$(COMPOSE) exec -T app alembic upgrade head


### PR DESCRIPTION
# Add `make docs` to view the contracts as Swagger

Closes the issue about viewing the OpenAPI contracts as Swagger. #599 

## Why

The contract sits in `contracts/` as several files tied together by references. There was no quick way to see it as a Swagger page while working on it. Reading raw YAML is slow, and the backend `/docs` shows what the code serves, not what the contract files say.

## What this adds

A `make docs` command. It serves the contract as a Swagger page at http://localhost:8088 and opens it in the browser.

It uses `swagger-ui-watcher`, run through npx so there is nothing to install. The tool resolves the references across the path and schema files into one spec and reloads when any of them change, so you edit a file and the page updates.

Port 8088 is used so it does not clash with the backend on 8000.

## How to use

```
make docs
```

Then open http://localhost:8088 if it does not open on its own.

---
Fixes issue: #599