### PR TITLE
Run Tests workflow only when Python changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,19 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main,development]
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - 'alembic.ini'
+      - '.github/workflows/tests.yml'
   pull_request:
     branches: [main,development]
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - 'alembic.ini'
+      - '.github/workflows/tests.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Run Tests workflow only when Python changes

Right now the Tests workflow runs on every PR, even when the change is only docs or the OpenAPI contract or some other file that has no Python in it. Those runs can never tell us anything new, so they just waste CI time.

This adds a `paths` filter to the workflow. Tests now run only when:

- a Python file changed (`**.py`)
- `requirements.txt` or `alembic.ini` changed
- the Tests workflow file itself changed

Everything else skips the run.

One thing to watch: if "Tests" is a required check in branch protection, a skipped run shows as pending and could block merge. If that happens we can switch to a small gate job that always reports a status. Left out for now to keep this change small.

Fixes #602