### PR TITLE
fix: resolve lint error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main,development]
   pull_request:
-    branches: [main]
+    branches: [main,development]
 
 jobs:
   lint:

--- a/app/services/input.py
+++ b/app/services/input.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timezone
 from sqlmodel import Session
 
 from app.api.schemas.enums import InputStatus, InputType
-from app.core.config import AUDIO_CONTENT_TYPES, AUDIO_DIR
+from app.core.config import AUDIO_DIR
 from app.db.repositories import create_input, create_job, update_job
 from app.models import Input, Job
 from app.tasks.transcribe import transcribe_audio_task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ from sqlmodel import SQLModel, Session, create_engine
 
 from app.main import app
 from app.api.deps import get_db
-from app.core.config import API_PREFIX  # single source of truth for all tests
 from app.models import Template, FormSubmission, Job, Input, Extraction, Incident, Form, Report  # noqa: F401 — registers tables
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -2,10 +2,7 @@
 POST /api/v1/forms/purge, and API-key access control.
 """
 
-import io
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -90,7 +87,6 @@ class TestDeleteTemplate:
         out_pdf.write_bytes(b"%PDF-1.4 filled")
 
         tpl_id = _seed_template(client, pdf_path="tpl.pdf")
-        sub_id = _seed_submission(db, tpl_id, output_pdf_path="filled.pdf")
 
         client.delete(f"{API_PREFIX}/templates/{tpl_id}")
         assert not out_pdf.exists()
@@ -249,7 +245,6 @@ class TestApiKeyAccessControl:
         assert resp.status_code == 401
 
     def test_purge_with_valid_key(self, client, db):
-        tpl_id = _seed_template(client)
         resp = client.post(
             f"{API_PREFIX}/forms/purge?days=30",
             headers={"X-API-Key": "secret-test-key"},

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -87,6 +87,7 @@ class TestDeleteTemplate:
         out_pdf.write_bytes(b"%PDF-1.4 filled")
 
         tpl_id = _seed_template(client, pdf_path="tpl.pdf")
+        _seed_submission(db, tpl_id, output_pdf_path="filled.pdf")
 
         client.delete(f"{API_PREFIX}/templates/{tpl_id}")
         assert not out_pdf.exists()

--- a/tests/test_v1_input.py
+++ b/tests/test_v1_input.py
@@ -4,7 +4,6 @@ Uses the shared in-memory SQLite engine from conftest.py.  No Ollama or
 Whisper involvement — text input is fully synchronous.
 """
 
-import pytest
 
 TEXT_URL = "/api/v1/input/text"
 INPUT_URL = "/api/v1/input"

--- a/tests/test_v1_voice.py
+++ b/tests/test_v1_voice.py
@@ -5,7 +5,6 @@ Task tests: called directly with an injected test session and mocked call_whispe
 """
 
 import io
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
# Fix lint errors
This PR fixes the lint errors that were present in the latest commits merged to development branch. Updated github workflows to run Lint CI for PRs pointing to development branch.

## What changed
- Cleaned up the files that were failing lint checks.
- Kept the code style consistent with the rest of the project.
- Updated the lint workflow to include the `development` branch, since PRs now use `development` as the base instead of `main`.

## Why

The recent commits introduced lint failures, and the workflow also missed the `development` branch after the PR base changed.