### PR TITLE
feat(extraction): add FieldSource enum

### DIFF
--- a/app/api/schemas/enums.py
+++ b/app/api/schemas/enums.py
@@ -114,3 +114,10 @@ class OutputFormat(str, Enum):
     pdf = "pdf"
     json = "json"
     both = "both"
+
+
+class FieldSource(str, Enum):
+    schema = "schema"
+    static = "static"
+    manual = "manual"
+    open = "open"

--- a/tests/test_v1_enums.py
+++ b/tests/test_v1_enums.py
@@ -1,0 +1,18 @@
+from app.api.schemas.enums import FieldSource
+
+
+class TestFieldSource:
+    def test_members_and_values(self):
+        assert FieldSource.schema.value == "schema"
+        assert FieldSource.static.value == "static"
+        assert FieldSource.manual.value == "manual"
+        assert FieldSource.open.value == "open"
+
+    def test_is_str_enum(self):
+        assert FieldSource.manual == "manual"
+        assert set(FieldSource) == {
+            FieldSource.schema,
+            FieldSource.static,
+            FieldSource.manual,
+            FieldSource.open,
+        }


### PR DESCRIPTION
Closes #624

Adds the `FieldSource` enum (`schema`, `static`, `manual`, `open`) so the readiness and validation responses have a real type for the `source` on each field gap. Values match the contract. Small test covers the members and their string values.
