### PR TITLE
Updated makefile to add migration version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ migrate:
 	@$(COMPOSE) exec -T app alembic upgrade head
 
 migration:
-	@$(COMPOSE) exec -T app alembic revision --autogenerate -m "$(msg)"
+	@test -n "$(rev)" || { echo "rev is required, e.g. make migration rev=003 msg=\"...\""; exit 1; }
+	@$(COMPOSE) exec -T app alembic revision --autogenerate --rev-id "$(rev)" -m "$(msg)"
 
 clean:
 	@$(COMPOSE) down


### PR DESCRIPTION
The `migration` target now takes a `rev` argument and passes it to Alembic as `--rev-id`. Since Alembic names the file `<rev>_<slug>.py`, a numbered rev drops the file in order


Closes: #634