### PR TITLE
Extraction request and response schemas

### DIFF
--- a/app/api/schemas/extraction.py
+++ b/app/api/schemas/extraction.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.api.schemas.enums import FieldSource
+from app.api.schemas.incident_contract import IncidentContract
+
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+class ExtractionHints(BaseModel):
+    """Optional hints to improve extraction accuracy.
+
+    Extra keys are allowed; the contract marks this object
+    additionalProperties: true.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    incident_type: str | None = None
+    state: str | None = None
+    agency_type: str | None = None
+
+
+class ExtractionDefaults(BaseModel):
+    """Deployment context the extractor falls back on when the narrative is
+    silent: timezone for relative dates, country, and currency for Money."""
+
+    country: str | None = None
+    timezone: str | None = None
+    currency: str | None = None
+
+
+class ExtractionRequest(BaseModel):
+    model_override: str | None = None
+    extraction_hints: ExtractionHints | None = None
+    defaults: ExtractionDefaults | None = None
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+class Correction(BaseModel):
+    """One manual correction applied to the contract via PATCH."""
+
+    field_path: str | None = None
+    original_value: Any = None
+    corrected_value: Any = None
+    corrected_at: datetime | None = None
+    corrected_by: str | None = None
+
+
+class ExtractionCompleted(BaseModel):
+    """A completed extraction. The contract document is embedded here, read
+    from the linked incident row; the extraction itself keeps only job
+    metadata and the corrections audit trail."""
+
+    extract_id: UUID
+    input_id: UUID
+    incident_id: UUID
+    status: Literal["completed"]
+    incident_contract: IncidentContract
+    completed_at: datetime | None = None
+    model_used: str | None = None
+    processing_time_seconds: float | None = None
+    corrections: list[Correction] | None = None
+
+
+class ExtractionProcessing(BaseModel):
+    extract_id: UUID
+    input_id: UUID
+    status: Literal["processing", "failed"]
+    started_at: datetime | None = None
+    retry_after_seconds: int | None = None
+    error_type: str | None = None
+    error_detail: str | None = None
+    partial_result: IncidentContract | None = None
+
+
+# ---------------------------------------------------------------------------
+# Validation and readiness
+# ---------------------------------------------------------------------------
+
+class FieldGap(BaseModel):
+    """One template field with no value yet, with enough context for the UI to
+    explain it and offer the right fix."""
+
+    field_name: str
+    source: FieldSource
+    incident_mapping: str | None = None
+    description: str | None = None
+
+
+class ValidationResult(BaseModel):
+    valid: bool
+    template_id: UUID
+    extract_id: UUID
+    # form_type is an open string, not a closed enum: users register their own
+    # templates and each carries its own label.
+    form_type: str | None = None
+    missing_required: list[FieldGap] | None = None
+    missing_recommended: list[FieldGap] | None = None
+    warnings: list[str] | None = None
+    field_coverage_percent: float | None = None
+
+
+class TemplateReadiness(BaseModel):
+    template_id: UUID
+    form_type: str
+    display_name: str
+    ready: bool
+    missing_required: list[FieldGap] | None = None
+    missing_recommended: list[FieldGap] | None = None
+    field_coverage_percent: float | None = None
+
+
+class ReadinessMatrix(BaseModel):
+    """Per-template fill readiness for one extraction, computed by comparing
+    the contract against every registered template's field list."""
+
+    extract_id: UUID
+    templates: list[TemplateReadiness]
+    computed_at: datetime | None = None

--- a/tests/test_v1_extraction_schemas.py
+++ b/tests/test_v1_extraction_schemas.py
@@ -1,0 +1,192 @@
+"""Validate the extraction schemas against the examples in the contract.
+
+Each example below is copied from contracts/path/extraction.yaml. The point is
+to catch drift: if the contract example changes shape, the matching model must
+still accept it (and vice versa). No routes are exercised here, only the
+Pydantic models from app/api/schemas/extraction.py.
+"""
+
+from app.api.schemas.enums import FieldSource
+from app.api.schemas.extraction import (
+    ExtractionCompleted,
+    ExtractionProcessing,
+    ExtractionRequest,
+    ReadinessMatrix,
+    ValidationResult,
+)
+from app.api.schemas.incident_contract import IncidentContract
+
+
+# ---------------------------------------------------------------------------
+# ExtractionRequest — POST /extract/{input_id} request body
+# ---------------------------------------------------------------------------
+
+def test_extraction_request_example():
+    example = {
+        "model_override": "llama3:8b",
+        "extraction_hints": {
+            "incident_type": "wildland_fire",
+            "state": "CA",
+        },
+        "defaults": {
+            "country": "US",
+            "timezone": "America/Los_Angeles",
+            "currency": "USD",
+        },
+    }
+    model = ExtractionRequest.model_validate(example)
+    assert model.model_dump(exclude_none=True) == example
+
+
+def test_extraction_request_hints_allow_extra_keys():
+    # extraction_hints is additionalProperties: true in the contract.
+    model = ExtractionRequest.model_validate(
+        {"extraction_hints": {"incident_type": "structure_fire", "battalion": "3"}}
+    )
+    assert model.extraction_hints.incident_type == "structure_fire"
+    dumped = model.model_dump(exclude_none=True)
+    assert dumped["extraction_hints"]["battalion"] == "3"
+
+
+def test_extraction_request_all_fields_optional():
+    assert ExtractionRequest.model_validate({}).model_dump(exclude_none=True) == {}
+
+
+# ---------------------------------------------------------------------------
+# ExtractionCompleted / ExtractionProcessing — GET /extract/{extract_id}
+# ---------------------------------------------------------------------------
+
+def test_extraction_completed_example():
+    example = {
+        "extract_id": "550e8400-e29b-41d4-a716-446655440020",
+        "input_id": "550e8400-e29b-41d4-a716-446655440001",
+        "incident_id": "550e8400-e29b-41d4-a716-446655440050",
+        "status": "completed",
+        "completed_at": "2024-07-15T14:31:05Z",
+        "incident_contract": {
+            "schema_version": "1.1.0",
+            "schema_name": "fireform_incident_contract",
+            "extraction_metadata": {
+                "extract_id": "550e8400-e29b-41d4-a716-446655440020",
+                "confidence_score": 0.91,
+            },
+            "incident": {"name": "Bear Creek Wildfire"},
+        },
+    }
+    model = ExtractionCompleted.model_validate(example)
+    assert model.status == "completed"
+    assert isinstance(model.incident_contract, IncidentContract)
+    assert model.incident_contract.incident.name == "Bear Creek Wildfire"
+
+
+def test_extraction_processing_example():
+    example = {
+        "extract_id": "550e8400-e29b-41d4-a716-446655440020",
+        "input_id": "550e8400-e29b-41d4-a716-446655440001",
+        "status": "processing",
+        "started_at": "2024-07-15T14:30:00Z",
+        "retry_after_seconds": 5,
+    }
+    model = ExtractionProcessing.model_validate(example)
+    assert model.status == "processing"
+    assert model.retry_after_seconds == 5
+
+
+def test_extraction_processing_failed_status_allowed():
+    model = ExtractionProcessing.model_validate({
+        "extract_id": "550e8400-e29b-41d4-a716-446655440020",
+        "input_id": "550e8400-e29b-41d4-a716-446655440001",
+        "status": "failed",
+        "error_type": "LLM_TIMEOUT",
+        "error_detail": "Ollama did not respond within the timeout",
+    })
+    assert model.status == "failed"
+    assert model.error_type == "LLM_TIMEOUT"
+
+
+# ---------------------------------------------------------------------------
+# ReadinessMatrix — GET /extract/{extract_id}/readiness
+# ---------------------------------------------------------------------------
+
+def test_readiness_matrix_example():
+    example = {
+        "extract_id": "550e8400-e29b-41d4-a716-446655440020",
+        "computed_at": "2026-07-15T14:35:00Z",
+        "templates": [
+            {
+                "template_id": "550e8400-e29b-41d4-a716-446655440070",
+                "form_type": "neris",
+                "display_name": "NERIS Incident Report",
+                "ready": True,
+                "missing_required": [],
+                "missing_recommended": [
+                    {
+                        "field_name": "smoke_alarm_presence",
+                        "source": "schema",
+                        "incident_mapping": "risk_reduction.smoke_alarm.presence",
+                    }
+                ],
+                "field_coverage_percent": 94,
+            },
+            {
+                "template_id": "550e8400-e29b-41d4-a716-446655440073",
+                "form_type": "state_texas",
+                "display_name": "Texas State Fire Marshal Incident Report",
+                "ready": False,
+                "missing_required": [
+                    {
+                        "field_name": "marshal_signature_name",
+                        "source": "manual",
+                        "incident_mapping": "custom_fields.state_texas.marshal_signature_name",
+                        "description": "Reviewing marshal's printed name, entered per incident",
+                    },
+                    {
+                        "field_name": "fire_cause",
+                        "source": "schema",
+                        "incident_mapping": "fire.cause_category",
+                    },
+                ],
+                "missing_recommended": [],
+                "field_coverage_percent": 78,
+            },
+        ],
+    }
+    model = ReadinessMatrix.model_validate(example)
+    assert len(model.templates) == 2
+    # form_type is an open string: state_texas is not in the built-in list.
+    assert model.templates[1].form_type == "state_texas"
+    assert model.templates[1].missing_required[0].source is FieldSource.manual
+
+
+# ---------------------------------------------------------------------------
+# ValidationResult — POST /extract/{extract_id}/validate
+# ---------------------------------------------------------------------------
+
+def test_validation_result_example():
+    example = {
+        "valid": True,
+        "template_id": "550e8400-e29b-41d4-a716-446655440070",
+        "form_type": "neris",
+        "extract_id": "550e8400-e29b-41d4-a716-446655440020",
+        "missing_required": [],
+        "missing_recommended": [
+            {
+                "field_name": "smoke_alarm_presence",
+                "source": "schema",
+                "incident_mapping": "risk_reduction.smoke_alarm.presence",
+            },
+            {
+                "field_name": "smoke_alarm_operation",
+                "source": "schema",
+                "incident_mapping": "risk_reduction.smoke_alarm.operation",
+            },
+        ],
+        "warnings": [
+            "losses.property_loss is null. NERIS recommends providing damage estimates"
+        ],
+        "field_coverage_percent": 94,
+    }
+    model = ValidationResult.model_validate(example)
+    assert model.valid is True
+    assert len(model.missing_recommended) == 2
+    assert model.missing_recommended[0].source is FieldSource.schema


### PR DESCRIPTION
# Extraction request and response schemas



All of it lives in one new file, `app/api/schemas/extraction.py`:

- The request model, covering the model override, extraction hints, and the deployment defaults (country, timezone, currency). Hints allow extra keys, matching the contract.
- The processing and completed responses. The completed one embeds the generated `IncidentContract` from  #626 rather than redefining it, and carries the corrections audit trail.
- The validation result and the field gap.
- The readiness matrix and its per-template entry.

The field gap reuses the `FieldSource` enum from #624.

Closes Issue - #627