### PR TITLE
Extraction repositories promote

### DIFF
--- a/app/db/repositories.py
+++ b/app/db/repositories.py
@@ -2,7 +2,8 @@ from uuid import UUID
 
 from sqlmodel import Session, select
 
-from app.models import Template, FormSubmission, Job, Input
+from app.models import Template, FormSubmission, Job, Input, Extraction, Incident
+from app.api.schemas.enums import ReportStatus
 
 # Templates
 def create_template(session: Session, template: Template) -> Template:
@@ -87,4 +88,57 @@ def update_input(session: Session, input_obj: Input) -> Input:
     session.commit()
     session.refresh(input_obj)
     return input_obj
+
+
+# Extractions
+def create_extraction(session: Session, extraction: Extraction) -> Extraction:
+    session.add(extraction)
+    session.commit()
+    session.refresh(extraction)
+    return extraction
+
+
+def get_extraction(session: Session, extract_id: UUID) -> Extraction | None:
+    return session.get(Extraction, extract_id)
+
+
+def update_extraction(session: Session, extraction: Extraction) -> Extraction:
+    session.add(extraction)
+    session.commit()
+    session.refresh(extraction)
+    return extraction
+
+
+# Incidents
+def create_incident(session: Session, incident: Incident) -> Incident:
+    session.add(incident)
+    session.commit()
+    session.refresh(incident)
+    return incident
+
+
+def get_incident(session: Session, incident_id: UUID) -> Incident | None:
+    return session.get(Incident, incident_id)
+
+
+def get_incident_by_extract(session: Session, extract_id: UUID) -> Incident | None:
+    statement = select(Incident).where(Incident.extract_id == extract_id)
+    return session.exec(statement).first()
+
+
+def update_incident(session: Session, incident: Incident) -> Incident:
+    session.add(incident)
+    session.commit()
+    session.refresh(incident)
+    return incident
+
+
+def create_draft_incident(session: Session, extract_id: UUID) -> Incident:
+    """Create the draft incident row linked to a completed extraction.
+
+    Called when an extraction completes: the new row owns the contract document
+    and starts in draft status. POST /incidents later finalizes this same row.
+    """
+    incident = Incident(extract_id=extract_id, status=ReportStatus.draft)
+    return create_incident(session, incident)
 

--- a/app/services/incidents.py
+++ b/app/services/incidents.py
@@ -1,0 +1,182 @@
+"""Incident analytics recompute.
+
+`promote` is the single function that derives the promoted analytics columns
+from the incident contract. The routes and the async worker both call it after
+any change to the contract, so the columns can never drift from the document
+they are derived from. It takes a plain contract dict and returns a plain dict
+of column values; it never touches the database.
+"""
+
+from datetime import datetime
+from typing import Any
+
+# Keys of the value dict returned by ``promote``. Kept explicit so callers can
+# apply the result to an Incident row without guessing field names.
+PROMOTED_COLUMNS = (
+    "incident_category",
+    "incident_datetime",
+    "city",
+    "state",
+    "country",
+    "civilian_injuries",
+    "civilian_fatalities",
+    "responder_injuries",
+    "responder_fatalities",
+    "people_rescued",
+    "people_evacuated",
+    "structures_destroyed",
+    "area_burned_ha",
+    "total_loss_amount",
+    "total_loss_currency",
+    "call_to_arrival_seconds",
+    "turnout_seconds_first_unit",
+    "travel_seconds_first_unit",
+    "on_scene_duration_seconds",
+)
+
+
+def _obj(contract: dict, key: str) -> dict:
+    """Return contract[key] if it is a dict, else an empty dict."""
+    value = contract.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    """Parse an RFC 3339 date-time string; return None if absent or unparseable."""
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        # fromisoformat handles the 'Z' suffix from Python 3.11 onwards.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _seconds_between(start: Any, end: Any) -> int | None:
+    """Whole seconds from start to end; None unless both parse and end >= start."""
+    a = _parse_dt(start)
+    b = _parse_dt(end)
+    if a is None or b is None:
+        return None
+    delta = (b - a).total_seconds()
+    if delta < 0:
+        return None
+    return int(delta)
+
+
+def _primary_category(incident: dict) -> str | None:
+    """Category of the incident type flagged primary, else the first type's."""
+    types = incident.get("types")
+    if not isinstance(types, list) or not types:
+        return None
+    entries = [t for t in types if isinstance(t, dict)]
+    for entry in entries:
+        if entry.get("primary"):
+            return entry.get("category")
+    return entries[0].get("category") if entries else None
+
+
+def _incident_datetime(incident: dict, dispatch: dict) -> datetime | None:
+    """Alarm, else start, else dispatch call-received, parsed to a datetime."""
+    raw = (
+        incident.get("alarm_datetime")
+        or incident.get("start_datetime")
+        or dispatch.get("call_received_datetime")
+    )
+    return _parse_dt(raw)
+
+
+def _total_loss(losses: dict) -> tuple[float | None, str | None]:
+    """Sum property and contents loss; currency from whichever is present first."""
+    prop = losses.get("property_loss") if isinstance(losses.get("property_loss"), dict) else {}
+    contents = losses.get("contents_loss") if isinstance(losses.get("contents_loss"), dict) else {}
+    amounts = [v for v in (prop.get("amount"), contents.get("amount")) if isinstance(v, (int, float))]
+    total = sum(amounts) if amounts else None
+    currency = prop.get("currency") or contents.get("currency")
+    return total, currency
+
+
+def _first_unit(contract: dict) -> dict:
+    """The unit that arrived first (earliest arrived_datetime), else empty."""
+    units = contract.get("units")
+    if not isinstance(units, list):
+        return {}
+    arrived = []
+    for unit in units:
+        if not isinstance(unit, dict):
+            continue
+        at = _parse_dt(unit.get("arrived_datetime"))
+        if at is not None:
+            arrived.append((at, unit))
+    if not arrived:
+        return {}
+    arrived.sort(key=lambda pair: pair[0])
+    return arrived[0][1]
+
+
+def _unit_turnout(unit: dict) -> int | None:
+    """Precomputed turnout_seconds, else dispatched to enroute."""
+    precomputed = unit.get("turnout_seconds")
+    if isinstance(precomputed, int):
+        return precomputed
+    return _seconds_between(unit.get("dispatched_datetime"), unit.get("enroute_datetime"))
+
+
+def _unit_travel(unit: dict) -> int | None:
+    """Precomputed travel_seconds, else enroute to arrived."""
+    precomputed = unit.get("travel_seconds")
+    if isinstance(precomputed, int):
+        return precomputed
+    return _seconds_between(unit.get("enroute_datetime"), unit.get("arrived_datetime"))
+
+
+def _count(rescues: Any) -> int | None:
+    """Number of entries in a list field, or None when it is absent."""
+    return len(rescues) if isinstance(rescues, list) else None
+
+
+def promote(contract: dict | None) -> dict[str, Any]:
+    """Derive the promoted analytics columns from the incident contract.
+
+    Every value is nullable; an empty or partial contract yields None for the
+    fields it does not cover. This is the only place these columns are computed.
+    """
+    contract = contract or {}
+    incident = _obj(contract, "incident")
+    dispatch = _obj(contract, "dispatch")
+    location = _obj(contract, "location")
+    casualties = _obj(contract, "casualties")
+    evacuation = _obj(contract, "evacuation_displacement")
+    structure = _obj(contract, "structure")
+    wildland = _obj(contract, "wildland")
+    losses = _obj(contract, "losses")
+
+    total_loss_amount, total_loss_currency = _total_loss(losses)
+
+    call_received = dispatch.get("call_received_datetime") or incident.get("alarm_datetime")
+    first_arrival = incident.get("first_arrival_datetime")
+    first_unit = _first_unit(contract)
+
+    return {
+        "incident_category": _primary_category(incident),
+        "incident_datetime": _incident_datetime(incident, dispatch),
+        "city": location.get("city"),
+        "state": location.get("state"),
+        "country": location.get("country"),
+        "civilian_injuries": casualties.get("total_civilian_injuries"),
+        "civilian_fatalities": casualties.get("total_civilian_fatalities"),
+        "responder_injuries": casualties.get("total_responder_injuries"),
+        "responder_fatalities": casualties.get("total_responder_fatalities"),
+        "people_rescued": _count(contract.get("rescues")),
+        "people_evacuated": evacuation.get("total_people_evacuated"),
+        "structures_destroyed": structure.get("structures_destroyed"),
+        "area_burned_ha": wildland.get("area_burned_ha"),
+        "total_loss_amount": total_loss_amount,
+        "total_loss_currency": total_loss_currency,
+        "call_to_arrival_seconds": _seconds_between(call_received, first_arrival),
+        "turnout_seconds_first_unit": _unit_turnout(first_unit),
+        "travel_seconds_first_unit": _unit_travel(first_unit),
+        "on_scene_duration_seconds": _seconds_between(first_arrival, incident.get("cleared_datetime")),
+    }

--- a/tests/test_repositories_promote.py
+++ b/tests/test_repositories_promote.py
@@ -1,0 +1,258 @@
+"""Tests for the extraction/incident repositories and the analytics recompute.
+
+Repositories run against the shared in-memory SQLite engine from conftest.py.
+`promote` is a pure function and is tested directly over an empty and a full
+contract.
+"""
+
+from app.db import repositories as repo
+from app.models import Input, Extraction
+from app.api.schemas.enums import InputType, ExtractionStatus, ReportStatus
+from app.services.incidents import promote, PROMOTED_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# Repository paths
+# ---------------------------------------------------------------------------
+
+def _make_input(db):
+    return repo.create_input(db, Input(input_type=InputType.text, transcript="x"))
+
+
+def _make_extraction(db, input_id):
+    return repo.create_extraction(db, Extraction(input_id=input_id))
+
+
+class TestExtractionRepository:
+
+    def test_create_and_get_extraction(self, db):
+        inp = _make_input(db)
+        created = _make_extraction(db, inp.input_id)
+        assert created.extract_id is not None
+
+        fetched = repo.get_extraction(db, created.extract_id)
+        assert fetched is not None
+        assert fetched.extract_id == created.extract_id
+        assert fetched.input_id == inp.input_id
+        assert fetched.status == ExtractionStatus.processing
+
+    def test_get_extraction_unknown_returns_none(self, db):
+        from uuid import uuid4
+        assert repo.get_extraction(db, uuid4()) is None
+
+    def test_update_extraction_persists_changes(self, db):
+        inp = _make_input(db)
+        extraction = _make_extraction(db, inp.input_id)
+
+        extraction.status = ExtractionStatus.completed
+        extraction.model_used = "llama3:8b"
+        repo.update_extraction(db, extraction)
+
+        reloaded = repo.get_extraction(db, extraction.extract_id)
+        assert reloaded.status == ExtractionStatus.completed
+        assert reloaded.model_used == "llama3:8b"
+
+
+class TestIncidentRepository:
+
+    def test_create_draft_incident_links_to_extraction(self, db):
+        inp = _make_input(db)
+        extraction = _make_extraction(db, inp.input_id)
+
+        incident = repo.create_draft_incident(db, extraction.extract_id)
+        assert incident.incident_id is not None
+        assert incident.extract_id == extraction.extract_id
+        assert incident.status == ReportStatus.draft
+
+    def test_get_incident_and_by_extract(self, db):
+        inp = _make_input(db)
+        extraction = _make_extraction(db, inp.input_id)
+        incident = repo.create_draft_incident(db, extraction.extract_id)
+
+        assert repo.get_incident(db, incident.incident_id).incident_id == incident.incident_id
+        by_extract = repo.get_incident_by_extract(db, extraction.extract_id)
+        assert by_extract.incident_id == incident.incident_id
+
+    def test_get_incident_unknown_returns_none(self, db):
+        from uuid import uuid4
+        assert repo.get_incident(db, uuid4()) is None
+
+    def test_update_incident_persists_promoted_columns(self, db):
+        inp = _make_input(db)
+        extraction = _make_extraction(db, inp.input_id)
+        incident = repo.create_draft_incident(db, extraction.extract_id)
+
+        incident.incident_number = "CA-SQF-2024-0421"
+        incident.city = "Springfield"
+        incident.civilian_injuries = 3
+        repo.update_incident(db, incident)
+
+        reloaded = repo.get_incident(db, incident.incident_id)
+        assert reloaded.incident_number == "CA-SQF-2024-0421"
+        assert reloaded.city == "Springfield"
+        assert reloaded.civilian_injuries == 3
+
+
+# ---------------------------------------------------------------------------
+# promote
+# ---------------------------------------------------------------------------
+
+class TestPromoteEmptyContract:
+
+    def test_empty_dict_yields_all_none(self):
+        result = promote({})
+        assert set(result) == set(PROMOTED_COLUMNS)
+        assert all(value is None for value in result.values())
+
+    def test_none_contract_yields_all_none(self):
+        assert all(value is None for value in promote(None).values())
+
+    def test_partial_contract_only_fills_present_fields(self):
+        result = promote({"location": {"city": "Reno", "state": "NV"}})
+        assert result["city"] == "Reno"
+        assert result["state"] == "NV"
+        assert result["country"] is None
+        assert result["incident_datetime"] is None
+
+
+FULL_CONTRACT = {
+    "incident": {
+        "types": [
+            {"primary": False, "category": "ems"},
+            {"primary": True, "category": "fire"},
+        ],
+        "alarm_datetime": "2024-07-10T13:50:00-07:00",
+        "start_datetime": "2024-07-10T13:40:00-07:00",
+        "first_arrival_datetime": "2024-07-10T13:56:00-07:00",
+        "cleared_datetime": "2024-07-10T15:56:00-07:00",
+    },
+    "dispatch": {"call_received_datetime": "2024-07-10T13:52:00-07:00"},
+    "location": {"city": "Reno", "state": "NV", "country": "US"},
+    "casualties": {
+        "total_civilian_injuries": 2,
+        "total_civilian_fatalities": 1,
+        "total_responder_injuries": 3,
+        "total_responder_fatalities": 0,
+    },
+    "rescues": [{"person_type": "civilian"}, {"person_type": "civilian"}],
+    "evacuation_displacement": {"total_people_evacuated": 40},
+    "structure": {"structures_destroyed": 2},
+    "wildland": {"area_burned_ha": 12.5},
+    "losses": {
+        "property_loss": {"amount": 100000, "currency": "USD"},
+        "contents_loss": {"amount": 25000, "currency": "USD"},
+    },
+    "units": [
+        {
+            "unit_id": "E2",
+            "arrived_datetime": "2024-07-10T13:58:00-07:00",
+            "dispatched_datetime": "2024-07-10T13:52:00-07:00",
+            "enroute_datetime": "2024-07-10T13:53:00-07:00",
+        },
+        {
+            "unit_id": "E1",
+            "arrived_datetime": "2024-07-10T13:56:00-07:00",
+            "turnout_seconds": 60,
+            "travel_seconds": 180,
+        },
+    ],
+}
+
+
+class TestPromoteFullContract:
+
+    def setup_method(self):
+        self.result = promote(FULL_CONTRACT)
+
+    def test_category_from_primary_type(self):
+        assert self.result["incident_category"] == "fire"
+
+    def test_incident_datetime_prefers_alarm(self):
+        # Alarm wins over start and dispatch call-received.
+        assert self.result["incident_datetime"].isoformat() == "2024-07-10T13:50:00-07:00"
+
+    def test_location_promoted(self):
+        assert self.result["city"] == "Reno"
+        assert self.result["state"] == "NV"
+        assert self.result["country"] == "US"
+
+    def test_casualty_counts_from_totals(self):
+        assert self.result["civilian_injuries"] == 2
+        assert self.result["civilian_fatalities"] == 1
+        assert self.result["responder_injuries"] == 3
+        assert self.result["responder_fatalities"] == 0
+
+    def test_people_rescued_is_array_length(self):
+        assert self.result["people_rescued"] == 2
+
+    def test_people_evacuated_from_total(self):
+        assert self.result["people_evacuated"] == 40
+
+    def test_structures_and_area(self):
+        assert self.result["structures_destroyed"] == 2
+        assert self.result["area_burned_ha"] == 12.5
+
+    def test_total_loss_is_property_plus_contents(self):
+        assert self.result["total_loss_amount"] == 125000
+        assert self.result["total_loss_currency"] == "USD"
+
+    def test_call_to_arrival_uses_call_received(self):
+        # 13:52 call received -> 13:56 first arrival = 4 minutes.
+        assert self.result["call_to_arrival_seconds"] == 240
+
+    def test_on_scene_duration(self):
+        # 13:56 first arrival -> 15:56 cleared = 2 hours.
+        assert self.result["on_scene_duration_seconds"] == 7200
+
+    def test_first_unit_is_earliest_arrival_with_precomputed_timing(self):
+        # E1 arrived first (13:56) and carries precomputed turnout/travel.
+        assert self.result["turnout_seconds_first_unit"] == 60
+        assert self.result["travel_seconds_first_unit"] == 180
+
+
+class TestPromoteFallbacks:
+
+    def test_incident_datetime_falls_back_to_start_then_call_received(self):
+        start_only = promote({"incident": {"start_datetime": "2024-07-10T13:40:00-07:00"}})
+        assert start_only["incident_datetime"].isoformat() == "2024-07-10T13:40:00-07:00"
+
+        dispatch_only = promote({"dispatch": {"call_received_datetime": "2024-07-10T13:52:00-07:00"}})
+        assert dispatch_only["incident_datetime"].isoformat() == "2024-07-10T13:52:00-07:00"
+
+    def test_call_to_arrival_falls_back_to_alarm_when_no_call_received(self):
+        result = promote({
+            "incident": {
+                "alarm_datetime": "2024-07-10T13:50:00-07:00",
+                "first_arrival_datetime": "2024-07-10T13:56:00-07:00",
+            },
+        })
+        assert result["call_to_arrival_seconds"] == 360
+
+    def test_first_unit_turnout_travel_computed_from_timestamps(self):
+        result = promote({
+            "units": [{
+                "unit_id": "E7",
+                "arrived_datetime": "2024-07-10T13:58:00-07:00",
+                "dispatched_datetime": "2024-07-10T13:52:00-07:00",
+                "enroute_datetime": "2024-07-10T13:53:00-07:00",
+            }],
+        })
+        assert result["turnout_seconds_first_unit"] == 60   # 13:52 -> 13:53
+        assert result["travel_seconds_first_unit"] == 300   # 13:53 -> 13:58
+
+    def test_negative_interval_is_none(self):
+        result = promote({
+            "incident": {
+                "first_arrival_datetime": "2024-07-10T14:00:00-07:00",
+                "cleared_datetime": "2024-07-10T13:00:00-07:00",
+            },
+        })
+        assert result["on_scene_duration_seconds"] is None
+
+    def test_single_loss_side_still_totals(self):
+        result = promote({"losses": {"property_loss": {"amount": 5000, "currency": "GBP"}}})
+        assert result["total_loss_amount"] == 5000
+        assert result["total_loss_currency"] == "GBP"
+
+    def test_unparseable_datetime_is_none(self):
+        assert promote({"incident": {"alarm_datetime": "not a date"}})["incident_datetime"] is None


### PR DESCRIPTION
# Repositories and the analytics recompute

The incident row keeps a set of scalar columns (dates, counts, loss totals, response times) next to the full contract document. Those columns exist so long period queries run on indexes instead of digging through JSON. The risk is they drift from the contract they came from. This PR makes sure they can't, by deriving them in one place.

## What is in here

**Repositories** for the extraction and incident rows: create, get, and update, plus a helper that creates the draft incident linked to an extraction. These stay dumb. Plain data in, plain data out, no business logic.

**`promote(contract)`** in the services layer. It takes a contract dict and returns the promoted column values. It is the only code that derives them, so the routes and the worker both call it after any contract change and get the same result. The rules follow the contract:

- incident datetime falls back alarm, then start, then dispatch call received
- total loss is property loss plus contents loss
- casualty and evacuee counts come from their totals
- response times come from the derived timestamps

An empty or partial contract just yields nulls for the fields it does not cover.

Closes Issue:  #628