### PR TITLE
[Pipeline B] Wire fill flow to accept input_id and use stored transcript

### DIFF
--- a/app/api/routes/forms.py
+++ b/app/api/routes/forms.py
@@ -17,6 +17,7 @@ from app.core.errors.base import AppError
 from app.db.repositories import create_form, get_template, get_form_submission, delete_form_submission
 from app.models import FormSubmission, Template
 from app.services.controller import Controller
+from app.services.input import InputService
 
 PROJECT_ROOT = BASE_DIR
 
@@ -46,18 +47,19 @@ def fill_form(form: FormFill, db: Session = Depends(get_db)):
     if not fetched_template:
         raise AppError("Template not found", status_code=404, error_code="TEMPLATE_NOT_FOUND")
 
+    transcript = InputService().resolve_transcript(db, form.input_id)
+
     controller = Controller()
     try:
         path = controller.fill_form(
-            user_input=form.input_text,
+            user_input=transcript,
             fields=fetched_template.fields,
             pdf_form_path=fetched_template.pdf_path,
             model=form.model,
         )
 
-        # `model` is a runtime override, not a column — keep it out of the DB row.
         submission = FormSubmission(
-            **form.model_dump(exclude={"model"}), output_pdf_path=path
+            template_id=form.template_id, input_text=transcript, output_pdf_path=path
         )
         return create_form(db, submission)
     except Exception as e:

--- a/app/api/routes/jobs.py
+++ b/app/api/routes/jobs.py
@@ -11,6 +11,7 @@ from app.api.schemas.forms import (
 from app.core.errors.base import AppError
 from app.db.repositories import create_job, get_job_by_uuid, get_template
 from app.models import Job
+from app.services.input import InputService
 from app.tasks.fill import fill_form_task
 
 router = APIRouter(tags=["jobs"])
@@ -39,14 +40,16 @@ def submit_async_form_fill(form: AsyncFormFill, db: Session = Depends(get_db)):
         if not get_template(db, tid):
             raise AppError(f"Template {tid} not found", status_code=404)
 
+    transcript = InputService().resolve_transcript(db, form.input_id)
+
     jobs: list[AsyncJobSubmitResponse] = []
     for tid in form.template_ids:
-        result = fill_form_task.delay(tid, form.input_text, form.model)
+        result = fill_form_task.delay(tid, transcript, form.model)
         job = Job(
             celery_task_id=result.id,
             job_type="form_generation",
             template_id=tid,
-            input_text=form.input_text,
+            input_text=transcript,
             status="queued",
             model=form.model,
         )

--- a/app/api/schemas/forms.py
+++ b/app/api/schemas/forms.py
@@ -1,16 +1,12 @@
+from uuid import UUID
+
 from pydantic import BaseModel, field_validator
 
 
 class FormFill(BaseModel):
     template_id: int
-    input_text: str
+    input_id: UUID
     model: str | None = None
-
-    @field_validator("input_text")
-    def validate_input_text(cls, value):
-        if not value or not value.strip():
-            raise ValueError("Input text cannot be empty")
-        return value
 
 
 class FormFillResponse(BaseModel):
@@ -34,14 +30,8 @@ class ModelsResponse(BaseModel):
 
 class AsyncFormFill(BaseModel):
     template_ids: list[int]
-    input_text: str
+    input_id: UUID
     model: str | None = None
-
-    @field_validator("input_text")
-    def validate_input_text(cls, value):
-        if not value or not value.strip():
-            raise ValueError("Input text cannot be empty")
-        return value
 
     @field_validator("template_ids")
     def validate_template_ids(cls, value):

--- a/app/services/input.py
+++ b/app/services/input.py
@@ -1,10 +1,12 @@
 from datetime import date, datetime, timezone
+from uuid import UUID
 
 from sqlmodel import Session
 
 from app.api.schemas.enums import InputStatus, InputType
 from app.core.config import AUDIO_DIR
-from app.db.repositories import create_input, create_job, update_job
+from app.core.errors.base import AppError
+from app.db.repositories import create_input, create_job, get_input, update_job
 from app.models import Input, Job
 from app.tasks.transcribe import transcribe_audio_task
 
@@ -65,6 +67,28 @@ class InputService:
             raise
 
         return record, job
+
+    def resolve_transcript(self, session: Session, input_id: UUID) -> str:
+        """Look up a stored Input and return its transcript, for form-fill callers.
+
+        Shared by the sync and async fill paths so the input_id -> transcript
+        resolution (and its 404/409 rules) live in exactly one place.
+        """
+        record = get_input(session, input_id)
+        if record is None:
+            raise AppError(
+                f"Input with ID {input_id} not found",
+                status_code=404,
+                error_code="INPUT_NOT_FOUND",
+            )
+        if record.status != InputStatus.ready:
+            raise AppError(
+                f"Input {input_id} is not ready (status: {record.status})",
+                status_code=409,
+                error_code="INPUT_NOT_READY",
+                detail={"status": record.status},
+            )
+        return record.transcript
 
     def build_text_input(
         self,

--- a/contracts/path/forms.yaml
+++ b/contracts/path/forms.yaml
@@ -7,9 +7,11 @@ fill:
     operationId: fillForm
     summary: Fill a single template from a stored transcript
     description: |
-      Takes a transcript plus one template's field dictionary, sends them to the
-      local Ollama LLM to get values back field-by-field, then draws those values
-      into the template's PDF boxes. Runs synchronously: one LLM pass per call.
+      Takes the transcript stored on a prior input (see POST /input/text or
+      POST /input/voice) plus one template's field dictionary, sends them to
+      the local Ollama LLM to get values back field-by-field, then draws those
+      values into the template's PDF boxes. Runs synchronously: one LLM pass
+      per call. The referenced input must have status "ready".
     tags:
       - forms
     requestBody:
@@ -20,7 +22,7 @@ fill:
             $ref: "../schemas/form-record.yaml#/FormFillRequest"
           example:
             template_id: 3
-            input_text: "62 year old male, chest pain, transported to St. Mary's."
+            input_id: "550e8400-e29b-41d4-a716-446655440001"
             model: "llama3.1"
     responses:
       "200":
@@ -35,7 +37,7 @@ fill:
               input_text: "62 year old male, chest pain, transported to St. Mary's."
               output_pdf_path: "output/forms/3_12.pdf"
       "404":
-        description: Template not found
+        description: Template or input not found
         content:
           application/json:
             schema:
@@ -43,6 +45,17 @@ fill:
             example:
               error_code: "TEMPLATE_NOT_FOUND"
               message: "Template not found"
+      "409":
+        description: Input exists but is not ready (still queued/transcribing, or failed)
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+            example:
+              error_code: "INPUT_NOT_READY"
+              message: "Input 550e8400-e29b-41d4-a716-446655440001 is not ready (status: transcribing)"
+              detail:
+                status: "transcribing"
       "500":
         description: Form fill failed (LLM or PDF generation error)
         content:
@@ -58,7 +71,9 @@ async_fill:
     operationId: submitAsyncFormFill
     summary: Queue form fill jobs for one or more templates
     description: |
-      Queues one Celery job per template_id, each running the same transcript
+      Resolves input_id to its stored transcript up front (so a missing or
+      not-ready input fails synchronously, before any job is queued), then
+      queues one Celery job per template_id, each running that transcript
       against that template's field dictionary. Poll GET /api/v1/jobs/{job_id}
       on each returned poll_url for status.
     tags:
@@ -71,7 +86,7 @@ async_fill:
             $ref: "../schemas/form-record.yaml#/AsyncFormFillRequest"
           example:
             template_ids: [3, 7]
-            input_text: "62 year old male, chest pain, transported to St. Mary's."
+            input_id: "550e8400-e29b-41d4-a716-446655440001"
             model: "llama3.1"
     responses:
       "200":
@@ -89,7 +104,7 @@ async_fill:
                   status: "queued"
                   poll_url: "/api/v1/jobs/550e8400-e29b-41d4-a716-446655440099"
       "404":
-        description: One of the requested template_ids was not found
+        description: One of the requested template_ids, or the input_id, was not found
         content:
           application/json:
             schema:
@@ -97,3 +112,14 @@ async_fill:
             example:
               error_code: "NOT_FOUND"
               message: "Template 7 not found"
+      "409":
+        description: Input exists but is not ready (still queued/transcribing, or failed)
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+            example:
+              error_code: "INPUT_NOT_READY"
+              message: "Input 550e8400-e29b-41d4-a716-446655440001 is not ready (status: transcribing)"
+              detail:
+                status: "transcribing"

--- a/contracts/schemas/form-record.yaml
+++ b/contracts/schemas/form-record.yaml
@@ -4,14 +4,17 @@ FormFillRequest:
   type: object
   required:
     - template_id
-    - input_text
+    - input_id
   properties:
     template_id:
       type: integer
       description: ID of the template to fill
-    input_text:
+    input_id:
       type: string
-      description: Transcript text the LLM extracts this template's field values from
+      format: uuid
+      description: ID of a stored input (see POST /input/text, POST /input/voice)
+        whose transcript is used to fill this template. The input must have
+        status "ready".
     model:
       type: string
       nullable: true
@@ -39,7 +42,7 @@ AsyncFormFillRequest:
   type: object
   required:
     - template_ids
-    - input_text
+    - input_id
   properties:
     template_ids:
       type: array
@@ -47,9 +50,12 @@ AsyncFormFillRequest:
         type: integer
       description: IDs of the templates to fill. One job is queued per template,
         each running the same transcript against that template's field dictionary.
-    input_text:
+    input_id:
       type: string
-      description: Transcript text the LLM extracts each template's field values from
+      format: uuid
+      description: ID of a stored input (see POST /input/text, POST /input/voice)
+        whose transcript is used to fill each template. The input must have
+        status "ready".
     model:
       type: string
       nullable: true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,9 +4,12 @@ Covers every endpoint and the full upload → template → fill pipeline.
 All heavy dependencies (LLM, commonforms, filesystem) are mocked via conftest.
 """
 
+from uuid import uuid4
+
 from sqlmodel import select
 
-from app.models import Template, FormSubmission
+from app.api.schemas.enums import InputStatus, InputType
+from app.models import Template, FormSubmission, Input
 from app.core.config import API_PREFIX
 
 
@@ -180,35 +183,84 @@ class TestFormEndpoints:
         })
         return resp.json()["id"]
 
-    def test_fill_form_success(self, client, mock_controller):
+    def _seed_input(self, db, status=InputStatus.ready, transcript="The employee is John Doe, email jdoe@ucsc.edu"):
+        """Helper: create an Input row directly and return its UUID."""
+        record = Input(input_type=InputType.text, status=status, transcript=transcript)
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        return record.input_id
+
+    def test_fill_form_success(self, client, mock_controller, db):
         tpl_id = self._seed_template(client, mock_controller)
+        input_id = self._seed_input(db)
 
         resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": tpl_id,
-            "input_text": "The employee is John Doe, email jdoe@ucsc.edu",
+            "input_id": str(input_id),
         })
         assert resp.status_code == 200
 
         data = resp.json()
         assert data["id"] is not None
         assert data["template_id"] == tpl_id
+        assert data["input_text"] == "The employee is John Doe, email jdoe@ucsc.edu"
         assert data["output_pdf_path"] == "src/outputs/filled_output.pdf"
         mock_controller["form_ctrl"].fill_form.assert_called_once()
 
     def test_fill_form_missing_template(self, client, mock_controller):
         resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": 9999,
-            "input_text": "some text",
+            "input_id": str(uuid4()),
         })
         assert resp.status_code == 404
 
-    def test_fill_form_template_file_not_found(self, client, mock_controller):
+    def test_fill_form_missing_input(self, client, mock_controller):
         tpl_id = self._seed_template(client, mock_controller)
+
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
+            "template_id": tpl_id,
+            "input_id": str(uuid4()),
+        })
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "INPUT_NOT_FOUND"
+
+    def test_fill_form_input_transcribing(self, client, mock_controller, db):
+        """An input still being transcribed is not usable yet → 409."""
+        tpl_id = self._seed_template(client, mock_controller)
+        input_id = self._seed_input(db, status=InputStatus.transcribing, transcript=None)
+
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
+            "template_id": tpl_id,
+            "input_id": str(input_id),
+        })
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error_code"] == "INPUT_NOT_READY"
+        assert body["detail"]["status"] == "transcribing"
+
+    def test_fill_form_input_failed(self, client, mock_controller, db):
+        """An input whose transcription failed is never usable → 409."""
+        tpl_id = self._seed_template(client, mock_controller)
+        input_id = self._seed_input(db, status=InputStatus.failed, transcript=None)
+
+        resp = client.post(f"{API_PREFIX}/forms/fill", json={
+            "template_id": tpl_id,
+            "input_id": str(input_id),
+        })
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error_code"] == "INPUT_NOT_READY"
+        assert body["detail"]["status"] == "failed"
+
+    def test_fill_form_template_file_not_found(self, client, mock_controller, db):
+        tpl_id = self._seed_template(client, mock_controller)
+        input_id = self._seed_input(db)
         mock_controller["form_ctrl"].fill_form.side_effect = FileNotFoundError("PDF template not found")
 
         resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": tpl_id,
-            "input_text": "some text",
+            "input_id": str(input_id),
         })
         assert resp.status_code == 500
         assert resp.json()["error_code"] == "FORM_FILL_ERROR"
@@ -283,12 +335,13 @@ class TestFormEndpoints:
         assert resp.status_code == 200
         assert resp.json()["models"] == ["qwen2.5:1.5b"]
 
-    def test_fill_form_passes_model_override(self, client, mock_controller):
+    def test_fill_form_passes_model_override(self, client, mock_controller, db):
         """A `model` in the request reaches Controller.fill_form but isn't persisted."""
         tpl_id = self._seed_template(client, mock_controller)
+        input_id = self._seed_input(db, transcript="John Doe")
         resp = client.post(f"{API_PREFIX}/forms/fill", json={
             "template_id": tpl_id,
-            "input_text": "John Doe",
+            "input_id": str(input_id),
             "model": "qwen2.5:3b",
         })
         assert resp.status_code == 200
@@ -355,13 +408,22 @@ class TestE2EPipeline:
         assert any(t["id"] == template_id for t in templates)
 
         # -- Step 4: Fill the form --
-        fill_resp = client.post(f"{API_PREFIX}/forms/fill", json={
-            "template_id": template_id,
-            "input_text": (
+        input_record = Input(
+            input_type=InputType.text,
+            status=InputStatus.ready,
+            transcript=(
                 "Officer Jane Smith, badge 4521. On January 15 2025 at "
                 "123 Main St, a structure fire was reported. Two engines "
                 "responded, fire contained within 45 minutes."
             ),
+        )
+        db.add(input_record)
+        db.commit()
+        db.refresh(input_record)
+
+        fill_resp = client.post(f"{API_PREFIX}/forms/fill", json={
+            "template_id": template_id,
+            "input_id": str(input_record.input_id),
         })
         assert fill_resp.status_code == 200
         fill_data = fill_resp.json()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,7 +1,11 @@
 """Tests for async job submission and status endpoints."""
 
 from unittest.mock import patch, MagicMock
+from uuid import uuid4
+
+from app.api.schemas.enums import InputStatus, InputType
 from app.core.config import API_PREFIX
+from app.models import Input
 
 
 class TestJobEndpoints:
@@ -14,16 +18,24 @@ class TestJobEndpoints:
         })
         return resp.json()["id"]
 
+    def _seed_input(self, db, status=InputStatus.ready, transcript="John Doe firefighter"):
+        record = Input(input_type=InputType.text, status=status, transcript=transcript)
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        return record.input_id
+
     @patch("app.api.routes.jobs.fill_form_task")
-    def test_submit_async_single(self, mock_task, client):
+    def test_submit_async_single(self, mock_task, client, db):
         mock_result = MagicMock()
         mock_result.id = "celery-task-id-1"
         mock_task.delay.return_value = mock_result
 
         tpl_id = self._seed_template(client)
+        input_id = self._seed_input(db)
         resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [tpl_id],
-            "input_text": "John Doe firefighter",
+            "input_id": str(input_id),
         })
         assert resp.status_code == 200
         data = resp.json()
@@ -34,7 +46,7 @@ class TestJobEndpoints:
         mock_task.delay.assert_called_once_with(tpl_id, "John Doe firefighter", None)
 
     @patch("app.api.routes.jobs.fill_form_task")
-    def test_submit_async_batch(self, mock_task, client):
+    def test_submit_async_batch(self, mock_task, client, db):
         mock_task.delay.side_effect = [
             MagicMock(id="task-1"),
             MagicMock(id="task-2"),
@@ -42,9 +54,10 @@ class TestJobEndpoints:
 
         t1 = self._seed_template(client)
         t2 = self._seed_template(client)
+        input_id = self._seed_input(db, transcript="batch input")
         resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [t1, t2],
-            "input_text": "batch input",
+            "input_id": str(input_id),
         })
         assert resp.status_code == 200
         jobs = resp.json()["jobs"]
@@ -53,22 +66,66 @@ class TestJobEndpoints:
         assert mock_task.delay.call_count == 2
 
     @patch("app.api.routes.jobs.fill_form_task")
-    def test_submit_async_missing_template(self, mock_task, client):
+    def test_submit_async_missing_template(self, mock_task, client, db):
+        input_id = self._seed_input(db, transcript="some text")
         resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [9999],
-            "input_text": "some text",
+            "input_id": str(input_id),
         })
         assert resp.status_code == 404
         mock_task.delay.assert_not_called()
 
     @patch("app.api.routes.jobs.fill_form_task")
-    def test_get_job_status(self, mock_task, client):
+    def test_submit_async_missing_input(self, mock_task, client):
+        tpl_id = self._seed_template(client)
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
+            "template_ids": [tpl_id],
+            "input_id": str(uuid4()),
+        })
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "INPUT_NOT_FOUND"
+        mock_task.delay.assert_not_called()
+
+    @patch("app.api.routes.jobs.fill_form_task")
+    def test_submit_async_input_transcribing(self, mock_task, client, db):
+        """A not-yet-ready input is rejected up front — no job should be queued."""
+        tpl_id = self._seed_template(client)
+        input_id = self._seed_input(db, status=InputStatus.transcribing, transcript=None)
+
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
+            "template_ids": [tpl_id],
+            "input_id": str(input_id),
+        })
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error_code"] == "INPUT_NOT_READY"
+        assert body["detail"]["status"] == "transcribing"
+        mock_task.delay.assert_not_called()
+
+    @patch("app.api.routes.jobs.fill_form_task")
+    def test_submit_async_input_failed(self, mock_task, client, db):
+        tpl_id = self._seed_template(client)
+        input_id = self._seed_input(db, status=InputStatus.failed, transcript=None)
+
+        resp = client.post(f"{API_PREFIX}/forms/jobs", json={
+            "template_ids": [tpl_id],
+            "input_id": str(input_id),
+        })
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error_code"] == "INPUT_NOT_READY"
+        assert body["detail"]["status"] == "failed"
+        mock_task.delay.assert_not_called()
+
+    @patch("app.api.routes.jobs.fill_form_task")
+    def test_get_job_status(self, mock_task, client, db):
         mock_task.delay.return_value = MagicMock(id="celery-abc")
 
         tpl_id = self._seed_template(client)
+        input_id = self._seed_input(db, transcript="test input")
         submit_resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [tpl_id],
-            "input_text": "test input",
+            "input_id": str(input_id),
         })
         job_id = submit_resp.json()["jobs"][0]["job_id"]
 
@@ -85,28 +142,30 @@ class TestJobEndpoints:
         assert resp.status_code == 404
 
     @patch("app.api.routes.jobs.fill_form_task")
-    def test_submit_with_model_override(self, mock_task, client):
+    def test_submit_with_model_override(self, mock_task, client, db):
         mock_task.delay.return_value = MagicMock(id="celery-xyz")
 
         tpl_id = self._seed_template(client)
+        input_id = self._seed_input(db, transcript="test")
         resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [tpl_id],
-            "input_text": "test",
+            "input_id": str(input_id),
             "model": "mistral:latest",
         })
         assert resp.status_code == 200
         mock_task.delay.assert_called_once_with(tpl_id, "test", "mistral:latest")
 
-    def test_submit_empty_template_ids(self, client):
+    def test_submit_empty_template_ids(self, client, db):
+        input_id = self._seed_input(db, transcript="test")
         resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [],
-            "input_text": "test",
+            "input_id": str(input_id),
         })
         assert resp.status_code == 422
 
-    def test_submit_empty_input_text(self, client):
+    def test_submit_invalid_input_id(self, client):
         resp = client.post(f"{API_PREFIX}/forms/jobs", json={
             "template_ids": [1],
-            "input_text": "",
+            "input_id": "not-a-uuid",
         })
         assert resp.status_code == 422


### PR DESCRIPTION
Closes #638.

Changes the fill endpoints to accept input_id and use the stored Input.transcript instead
of a raw input_text in the request — the core of Pipeline B's "store the transcript once,
reuse it" model.

- FormFill / AsyncFormFill now take input_id (UUID) instead of input_text.
- Shared InputService.resolve_transcript(session, input_id): looks up the Input via
  get_input, raises 404 INPUT_NOT_FOUND if missing, 409 INPUT_NOT_READY (with the actual
  status in the detail) if status != ready, else returns the transcript. Both routes use it,
  so the rule lives in one place.
- Sync (/forms/fill) resolves after the template check; async (/forms/jobs) resolves up
  front, before the Celery dispatch, so 404/409 return synchronously and no job is queued
  on a bad input_id.
- Contract (form-record.yaml, forms.yaml) updated to input_id (uuid) with 409 examples —
  this is the input_text → input_id switch deferred from the contract-reshape PR, now done
  with the code together.
- FormSubmission still stores the resolved transcript (the FormSubmission → Input FK is a
  separate follow-up issue).

Note: input_id is a UUID (matching the Input model / input-record.yaml), not int as the
issue text said - corrected here.

Please Review @marcvergees @vharkins1 @chetanr25 .