### PR TITLE
[Pipeline B] Route Controller/FileManipulator through FormService (#641)

### DIFF
--- a/app/services/form.py
+++ b/app/services/form.py
@@ -59,7 +59,16 @@ class FormService:
         self, session: Session, template: Template, input_id: UUID, model: str | None = None
     ) -> FormSubmission:
         transcript = self.input_service.resolve_transcript(session, input_id)
+        return self.fill_and_persist(session, template, transcript, input_id, model)
 
+    def fill_and_persist(
+        self,
+        session: Session,
+        template: Template,
+        transcript: str,
+        input_id: UUID,
+        model: str | None = None,
+    ) -> FormSubmission:
         path = self.controller.fill_form(
             user_input=transcript,
             fields=template.fields,

--- a/app/tasks/fill.py
+++ b/app/tasks/fill.py
@@ -4,9 +4,8 @@ from uuid import UUID
 
 from app.core.celery import celery_app
 from app.db.database import get_session
-from app.db.repositories import get_job_by_celery_id, get_template, update_job, create_form
-from app.models import FormSubmission
-from app.services.controller import Controller
+from app.db.repositories import get_job_by_celery_id, get_template, update_job
+from app.services.form import FormService
 
 logger = logging.getLogger(__name__)
 
@@ -28,21 +27,9 @@ def fill_form_task(self, template_id: int, input_text: str, input_id_str: str, m
         if not template:
             raise ValueError(f"Template {template_id} not found")
 
-        controller = Controller()
-        path = controller.fill_form(
-            user_input=input_text,
-            fields=template.fields,
-            pdf_form_path=template.pdf_path,
-            model=model,
+        submission = FormService().fill_and_persist(
+            session, template, input_text, UUID(input_id_str), model
         )
-
-        submission = FormSubmission(
-            template_id=template_id,
-            input_id=UUID(input_id_str),
-            input_text=input_text,
-            output_pdf_path=path,
-        )
-        create_form(session, submission)
 
         job.status = "completed"
         job.progress_percent = 100


### PR DESCRIPTION
Closes #641.

The async fill task (app/tasks/fill.py) was constructing Controller() directly and building
its own FormSubmission. It now routes through FormService like the sync path does (after
#640), so Controller is constructed in exactly one place (FormService.__init__).

- New FormService.fill_and_persist(session, template, transcript, input_id, model): calls
  Controller and persists the FormSubmission. Both the sync route and the async task use it.
- FormService.fill_form (sync) now resolves the transcript, then delegates to
  fill_and_persist.
- fill_form_task drops its direct Controller() and inline FormSubmission build, and calls
  fill_and_persist with the already-resolved transcript (jobs.py resolves up front per #638
  — no re-resolution). Job-status handling stays in the task.
- weather.py / zipcode.py use Controller for their own purposes and are intentionally
  untouched — #641 is only the form-fill path.

Behavior unchanged — 152 tests pass (no test changes needed; the task is mocked at the
dispatch boundary). ruff check app/ clean. No Controller() construction remains in
app/tasks/fill.py.