### PR TITLE
[Pipeline B] Fix positional PDF field-matching in Filler (#642)

### DIFF
--- a/app/services/filler.py
+++ b/app/services/filler.py
@@ -3,6 +3,23 @@ from app.services.llm import LLM
 from datetime import datetime
 
 
+def _pdf_text(value) -> str:
+    """Decode a pdfrw string (field name / tooltip) to plain text.
+
+    Duplicated from app.services.template._pdf_text — importing it directly
+    would create a circular import (template -> controller ->
+    file_manipulator -> filler -> template). Keep these in sync: this must
+    normalize a widget name exactly the way template.py normalizes it when
+    it names the widget, so textbox_answers keys and widget names compare
+    equal.
+    """
+    if value is None:
+        return ""
+    if hasattr(value, "to_unicode"):
+        return value.to_unicode().strip()
+    return str(value).strip()
+
+
 class Filler:
     def __init__(self):
         pass
@@ -10,7 +27,10 @@ class Filler:
     def fill_form(self, pdf_form: str, llm: LLM):
         """
         Fill a PDF form with values from user_input using LLM.
-        Fields are filled in the visual order (top-to-bottom, left-to-right).
+        Each widget is matched to its answer by name (widget name == field-dict
+        key, since prepare_fillable names widgets after their field and the LLM
+        keys its answers by field name) — not by position, since the field-dict
+        order and the PDF's physical widget order aren't guaranteed to match.
         """
         output_pdf = (
             pdf_form[:-4]
@@ -23,28 +43,18 @@ class Filler:
         t2j = llm.main_loop()
         textbox_answers = t2j.get_data()  # This is a dictionary
 
-        answers_list = list(textbox_answers.values())
-
         # Read PDF
         pdf = PdfReader(pdf_form)
 
         # Loop through pages
-        i = 0
         for page in pdf.pages:
             if page.Annots:
-                sorted_annots = sorted(
-                    page.Annots, key=lambda a: (-float(a.Rect[1]), float(a.Rect[0]))
-                )
-
-                for annot in sorted_annots:
+                for annot in page.Annots:
                     if annot.Subtype == "/Widget" and annot.T:
-                        if i < len(answers_list):
-                            annot.V = f"{answers_list[i]}"
+                        name = _pdf_text(annot.T)
+                        if name in textbox_answers:
+                            annot.V = f"{textbox_answers[name]}"
                             annot.AP = None
-                            i += 1
-                        else:
-                            # Stop if we run out of answers
-                            break
 
         PdfWriter().write(output_pdf, pdf)
 

--- a/tests/test_filler.py
+++ b/tests/test_filler.py
@@ -1,0 +1,90 @@
+"""Tests for Filler.fill_form's value-to-widget matching (issue #642).
+
+Widgets are matched to LLM answers by field NAME, not by position — the
+field-dict order and the PDF's physical widget order aren't guaranteed to
+align.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.services.filler import Filler
+
+
+class _FakeAnnot:
+    """Stand-in for a pdfrw widget annotation."""
+
+    def __init__(self, name, rect):
+        self.Subtype = "/Widget"
+        self.T = name
+        self.Rect = rect
+        self.V = None
+        self.AP = "placeholder-appearance"
+
+
+class _FakePage:
+    def __init__(self, annots):
+        self.Annots = annots
+
+
+class _FakePdf:
+    def __init__(self, pages):
+        self.pages = pages
+
+
+class _FakeLLM:
+    """Stand-in for app.services.llm.LLM — main_loop() returns self, like the real one."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def main_loop(self):
+        return self
+
+    def get_data(self):
+        return self._data
+
+
+class TestFillerNameMatching:
+
+    def _run(self, annots, answers):
+        fake_pdf = _FakePdf(pages=[_FakePage(annots)])
+        with patch("app.services.filler.PdfReader", return_value=fake_pdf), \
+             patch("app.services.filler.PdfWriter") as mock_writer_cls:
+            mock_writer_cls.return_value = MagicMock()
+            Filler().fill_form(pdf_form="src/inputs/template.pdf", llm=_FakeLLM(answers))
+
+    def test_values_match_by_name_when_widget_order_diverges_from_field_order(self):
+        """Field dict is keyed a, b, c (insertion order) but the widgets sit on
+        the page in physical order c, b, a (top-to-bottom). Positional matching
+        would zip answers_list[0]="AAA" onto the first-visited widget (c's box)
+        and answers_list[2]="CCC" onto the last (a's box) — wrong. Name matching
+        must put each value in its own-named box regardless of page order."""
+        annot_c = _FakeAnnot("c", rect=[0, 300, 100, 320])  # topmost
+        annot_b = _FakeAnnot("b", rect=[0, 200, 100, 220])  # middle
+        annot_a = _FakeAnnot("a", rect=[0, 100, 100, 120])  # bottommost
+
+        # Physical/traversal order on the page: c, b, a.
+        # Field-dict / answer order: a, b, c.
+        answers = {"a": "AAA", "b": "BBB", "c": "CCC"}
+        self._run([annot_c, annot_b, annot_a], answers)
+
+        assert annot_a.V == "AAA"
+        assert annot_b.V == "BBB"
+        assert annot_c.V == "CCC"
+
+    def test_widget_with_no_matching_answer_is_left_unfilled(self):
+        annot_a = _FakeAnnot("a", rect=[0, 100, 100, 120])
+        annot_d = _FakeAnnot("d", rect=[0, 200, 100, 220])
+
+        self._run([annot_a, annot_d], {"a": "AAA"})
+
+        assert annot_a.V == "AAA"
+        assert annot_d.V is None
+
+    def test_answer_with_no_matching_widget_does_not_crash(self):
+        annot_a = _FakeAnnot("a", rect=[0, 100, 100, 120])
+
+        # "extra" has no corresponding widget on the page.
+        self._run([annot_a], {"a": "AAA", "extra": "unused"})
+
+        assert annot_a.V == "AAA"


### PR DESCRIPTION
Closes #642.

Filler.fill_form matched extracted values to PDF widgets by positional index (values in
field-dict order zipped to widgets sorted by physical position). This worked only because
the field-dict order coincidentally matched the widget order — if they ever diverged, values
landed in the wrong boxes on emergency reports.

Now matches by field NAME: for each widget, its name (_pdf_text(annot.T)) is looked up in
the extracted answers. The widget name, the template field name, and the answer-dict key are
the same string (prepare_fillable names widgets after fields; the LLM keys answers by field
name), so name-matching is exact. Unmatched widgets are left unfilled; unmatched answers
aren't drawn. The positional sort is removed — order no longer affects correctness.

New tests (tests/test_filler.py): the key one places widgets in a different physical order
than the field-dict order and asserts each value lands in its correctly-named box — this
fails under the old positional code and passes now. Plus unmatched-widget and
unmatched-answer robustness tests.

155 tests pass (152 + 3 new). ruff clean.

Note: _pdf_text is duplicated into filler.py (with a sync comment) to avoid a circular
import (template → controller → file_manipulator → filler → template) — same pattern as
_resolve_project_file. Worth folding into the path/helper consolidation follow-up.