### PR TITLE
Extraction layer: the chunked extraction worker

### DIFF
--- a/app/api/routes/extraction.py
+++ b/app/api/routes/extraction.py
@@ -23,7 +23,7 @@ from app.db.repositories import (
     get_incident_by_extract,
     get_input,
 )
-from app.services.extraction import ExtractionService
+from app.services.extraction.service import ExtractionService
 from app.services.llm import check_ollama_available
 
 router = APIRouter(prefix="/extract", tags=["extraction"])
@@ -67,9 +67,14 @@ def create_extraction(
             error_code="LLM_UNAVAILABLE",
         )
 
-    model_override = body.model_override if body else None
     svc = ExtractionService()
-    extraction, job = svc.start_extraction(db, input_id, model_override=model_override)
+    extraction, job = svc.start_extraction(
+        db,
+        input_id,
+        model_override=body.model_override if body else None,
+        defaults=body.defaults if body else None,
+        hints=body.extraction_hints if body else None,
+    )
 
     return ExtractionJobResponse(
         extract_id=extraction.extract_id,

--- a/app/api/schemas/incident_contract.py
+++ b/app/api/schemas/incident_contract.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import date, time
+from datetime import date as date_type, time as time_type
 from enum import Enum
 from typing import Annotated, Any, Optional
 from uuid import UUID
@@ -1285,7 +1285,7 @@ class ResponderCasualty(BaseModel):
     transported: Optional[bool] = None
     hospital: Optional[str] = None
     hospitalized_overnight: Optional[bool] = None
-    return_to_duty_date: Optional[date] = None
+    return_to_duty_date: Optional[date_type] = None
     osha_recordable: Optional[bool] = None
     exposure_only: Optional[bool] = None
     """
@@ -1447,7 +1447,7 @@ class EMSPatient(BaseModel):
     patient_ref_id: Optional[str] = None
     nemsis_report_id: Optional[str] = None
     age_approx: Optional[int] = None
-    date_of_birth: Optional[date] = None
+    date_of_birth: Optional[date_type] = None
     sex: Optional[str] = None
     chief_complaint: Optional[str] = None
     provider_impression: Optional[str] = None
@@ -1821,7 +1821,7 @@ class InfrastructureItem(BaseModel):
 
 class NearMissEvent(BaseModel):
     description: Optional[str] = None
-    date: Optional[date] = None
+    date: Optional[date_type] = None
     contributing_factors: Optional[list[str]] = None
     lessons_learned: Optional[str] = None
     corrective_action: Optional[str] = None
@@ -1934,8 +1934,8 @@ class SituationStatus(BaseModel):
     critical_resource_needs: Optional[list[str]] = None
     planned_actions: Optional[str] = None
     projected_final_size_ha: Optional[float] = None
-    anticipated_completion_date: Optional[date] = None
-    demobilization_start_date: Optional[date] = None
+    anticipated_completion_date: Optional[date_type] = None
+    demobilization_start_date: Optional[date_type] = None
     costs_to_date: Optional[Money] = None
     projected_final_cost: Optional[Money] = None
 
@@ -1948,7 +1948,7 @@ class LessonsLearned(BaseModel):
 
 class MopUp(BaseModel):
     percent_complete: Optional[int] = None
-    estimated_completion_date: Optional[date] = None
+    estimated_completion_date: Optional[date_type] = None
     personnel_assigned: Optional[int] = None
 
 
@@ -1961,7 +1961,7 @@ class Rehabilitation(BaseModel):
 class FollowUp(BaseModel):
     mop_up: Optional[MopUp] = None
     rehabilitation: Optional[Rehabilitation] = None
-    next_inspection_date: Optional[date] = None
+    next_inspection_date: Optional[date_type] = None
 
 
 class PeriodicReporting(BaseModel):
@@ -2011,9 +2011,7 @@ class SubmissionLogItem(BaseModel):
 
 class ReportMetadata(BaseModel):
     report_id: Annotated[Optional[str], Field(None, examples=["FF-2024-CA-0157"])]
-    incident_number: Annotated[
-        Optional[str], Field(None, examples=["CA-SQF-2024-0421"])
-    ]
+    incident_number: Annotated[Optional[str], Field(None, examples=["CA-SQF-2024-0421"])]
     """
     Department's own incident number
     """
@@ -2021,8 +2019,8 @@ class ReportMetadata(BaseModel):
     """
     Identifiers for this incident in external systems (CAD event, IRWIN, state registry, partner agency)
     """
-    report_date: Optional[date] = None
-    report_time: Optional[time] = None
+    report_date: Optional[date_type] = None
+    report_time: Optional[time_type] = None
     report_status: Optional[ReportStatus] = None
     reporting_unit: Optional[ReportingUnit] = None
     prepared_by: Optional[list[Personnel]] = None
@@ -2130,7 +2128,7 @@ class Fire(BaseModel):
 class CivilianCasualty(BaseModel):
     name: Optional[str] = None
     age: Optional[int] = None
-    date_of_birth: Optional[date] = None
+    date_of_birth: Optional[date_type] = None
     sex: Optional[str] = None
     race_ethnicity: Optional[str] = None
     """

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,6 +35,18 @@ DB_ECHO = os.getenv("FIREFORM_DB_ECHO", "true").lower() == "true"
 # --- External services ----------------------------------------------------
 OLLAMA_HOST = os.getenv("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5:1.5b")
+# Seconds to wait on a single Ollama generate call. One chunk prompt on a small
+# local model is slow, so this is generous by design.
+OLLAMA_TIMEOUT = int(os.getenv("OLLAMA_TIMEOUT", "600"))
+# Ceiling on tokens generated per chunk answer. It stops a small model from
+# echoing the whole field skeleton back and spending the timeout on it.
+#
+# Keep these two in step. A section that runs past OLLAMA_TIMEOUT is lost
+# outright, while one that hits this ceiling still keeps every field it
+# completed before the cut, so the ceiling should be reachable well inside the
+# timeout on the slowest model you run. A small model on CPU manages roughly
+# three tokens a second, which is where these defaults come from.
+OLLAMA_MAX_TOKENS = int(os.getenv("OLLAMA_MAX_TOKENS", "1200"))
 WHISPER_HOST = os.getenv("WHISPER_HOST", "http://localhost:9000").rstrip("/")
 
 # --- Celery / Redis -------------------------------------------------------
@@ -64,6 +76,29 @@ EXTRACTION_POLL_INTERVAL_SECONDS = 5
 
 # Advisory estimate returned in the 202 body of POST /extract/{input_id}.
 ESTIMATED_EXTRACTION_SECONDS = int(os.getenv("ESTIMATED_EXTRACTION_SECONDS", "60"))
+
+# --- Extraction worker ----------------------------------------------------
+# How many chunk prompts run against Ollama at once. Ollama serves
+# OLLAMA_NUM_PARALLEL requests concurrently and queues the rest, so going wider
+# than the server buys nothing but memory pressure.
+EXTRACTION_MAX_PARALLEL = int(os.getenv("OLLAMA_NUM_PARALLEL", "4"))
+
+# Extra attempts after a chunk's first result fails validation. One retry, with
+# the rejected value named in the prompt; a chunk that misses twice is left for
+# manual entry rather than guessed at.
+EXTRACTION_CHUNK_RETRIES = int(os.getenv("EXTRACTION_CHUNK_RETRIES", "1"))
+
+# The contract file the chunk registry reads its tiers and triggers from.
+INCIDENT_CONTRACT_PATH = Path(
+    os.getenv("INCIDENT_CONTRACT_PATH", BASE_DIR / "contracts" / "schemas" / "incident-contract.yaml")
+)
+
+# Deployment context the extractor falls back on when the narrative is silent:
+# timezone for resolving relative dates, country, currency for Money amounts.
+# A request can override any of them through ExtractionRequest.defaults.
+DEFAULT_COUNTRY = os.getenv("FIREFORM_DEFAULT_COUNTRY", "US")
+DEFAULT_TIMEZONE = os.getenv("FIREFORM_DEFAULT_TIMEZONE", "UTC")
+DEFAULT_CURRENCY = os.getenv("FIREFORM_DEFAULT_CURRENCY", "USD")
 
 # --- API Versioning -------------------------------------------------------
 API_PREFIX = "/api/v1"

--- a/app/services/extraction/__init__.py
+++ b/app/services/extraction/__init__.py
@@ -1,0 +1,11 @@
+"""The extraction layer.
+
+Split by job: `service` queues a run, `registry` and `router` decide what to ask
+the model, `prompts` and `client` do the asking, `runner` validates and retries,
+`defaults` covers everything computable without a model, and `worker` stitches
+it all into a contract and a draft incident.
+
+Nothing is re-exported here on purpose. The celery task imports the worker and
+the service imports the task, so a package-level import of either would close
+that loop at import time. Import the submodule you need.
+"""

--- a/app/services/extraction/client.py
+++ b/app/services/extraction/client.py
@@ -1,0 +1,169 @@
+"""The Ollama call behind one chunk.
+
+Thin on purpose: build nothing, decide nothing, just send a prompt and hand
+back parsed JSON. Ollama's JSON mode does most of the work, but small models
+still wrap answers in a code fence or add a sentence, so the parser tolerates
+both rather than failing a chunk over formatting.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+
+from app.core.config import OLLAMA_HOST, OLLAMA_MAX_TOKENS, OLLAMA_MODEL, OLLAMA_TIMEOUT
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class LLMUnavailableError(RuntimeError):
+    """Ollama could not be reached. Nothing is extractable, so the whole run fails."""
+
+
+class ChunkCallError(RuntimeError):
+    """One chunk call failed or came back unparseable. Retryable."""
+
+
+class ChunkTimeoutError(ChunkCallError):
+    """A chunk call ran past the timeout.
+
+    Not worth retrying: the same prompt on the same model takes the same time,
+    so a retry only doubles the wait before the section is left empty anyway.
+    """
+
+
+def _close_truncated(text: str) -> str | None:
+    """Rebuild a JSON object that was cut off mid-answer.
+
+    An answer that hits the token ceiling ends in the middle of a value and
+    parses as nothing, losing a section that was mostly fine. This trims back
+    to the last complete key and value pair and closes the brackets that are
+    still open. Only whole pairs survive, so no half value is ever kept.
+    """
+    depth: list[str] = []
+    in_string = False
+    escaped = False
+    last_complete = None
+
+    for index, char in enumerate(text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "{[":
+            depth.append("}" if char == "{" else "]")
+        elif char in "}]":
+            if depth:
+                depth.pop()
+            last_complete = index + 1
+        elif char == "," and depth:
+            last_complete = index
+
+    if last_complete is None:
+        return None
+
+    # Re-count what is still open at the cut, then close it.
+    head = text[:last_complete]
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    for char in head:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "{[":
+            stack.append("}" if char == "{" else "]")
+        elif char in "}]" and stack:
+            stack.pop()
+
+    return head + "".join(reversed(stack))
+
+
+def _extract_json_object(raw: str) -> dict[str, Any]:
+    """Parse the model's answer, ignoring a code fence or surrounding prose."""
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.split("```")[1] if "```" in text[3:] else text[3:]
+        text = text.removeprefix("json").strip()
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as first_error:
+        start = text.find("{")
+        end = text.rfind("}")
+        candidate = text[start : end + 1] if start != -1 and end > start else None
+        try:
+            parsed = json.loads(candidate) if candidate else None
+        except json.JSONDecodeError:
+            parsed = None
+
+        if parsed is None:
+            repaired = _close_truncated(text[start:] if start != -1 else text)
+            if repaired is None:
+                raise ChunkCallError(
+                    f"no JSON object in the model's answer: {raw[:200]!r}"
+                ) from first_error
+            try:
+                parsed = json.loads(repaired)
+            except json.JSONDecodeError as exc:
+                raise ChunkCallError(f"unparseable JSON from the model: {exc}") from exc
+            logger.warning(
+                "the model's answer was cut off; kept the %d complete field(s) before the cut",
+                len(parsed) if isinstance(parsed, dict) else 0,
+            )
+
+    if not isinstance(parsed, dict):
+        raise ChunkCallError(f"expected a JSON object, got {type(parsed).__name__}")
+    return parsed
+
+
+def call_chunk(prompt: str, model: str | None = None) -> dict[str, Any]:
+    """Send one chunk prompt to Ollama and return the parsed JSON object."""
+    payload = {
+        "model": model or OLLAMA_MODEL,
+        "prompt": prompt,
+        "stream": False,
+        "format": "json",
+        "options": {
+            # Deterministic decoding: extraction should not vary run to run.
+            "temperature": 0,
+            # A section's answer is a small object. Without a cap a small model
+            # will happily echo the whole skeleton back with nulls in it and
+            # spend the timeout doing it.
+            "num_predict": OLLAMA_MAX_TOKENS,
+        },
+    }
+    try:
+        response = requests.post(
+            f"{OLLAMA_HOST}/api/generate", json=payload, timeout=OLLAMA_TIMEOUT
+        )
+        response.raise_for_status()
+    except requests.exceptions.ConnectionError as exc:
+        raise LLMUnavailableError(f"could not reach Ollama at {OLLAMA_HOST}: {exc}") from exc
+    except requests.exceptions.Timeout as exc:
+        raise ChunkTimeoutError(f"Ollama timed out after {OLLAMA_TIMEOUT}s") from exc
+    except requests.exceptions.RequestException as exc:
+        raise ChunkCallError(f"Ollama request failed: {exc}") from exc
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ChunkCallError(f"Ollama returned a non-JSON body: {exc}") from exc
+
+    return _extract_json_object(body.get("response", ""))

--- a/app/services/extraction/defaults.py
+++ b/app/services/extraction/defaults.py
@@ -1,0 +1,181 @@
+"""The parts of extraction that need no model at all.
+
+Deployment context (timezone, country, currency) and anything arithmetic. The
+model is told the context so it can resolve "yesterday evening" itself, and
+these functions then fill what it left blank and compute what is derivable:
+default country and currency, a timezone offset on naive timestamps, and the
+per-unit turnout and travel seconds. Plain code beats a prompt every time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from app.api.schemas.extraction import ExtractionDefaults, ExtractionHints
+from app.core.config import DEFAULT_COUNTRY, DEFAULT_CURRENCY, DEFAULT_TIMEZONE
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ExtractionContext:
+    """Deployment context for one extraction run."""
+
+    country: str
+    timezone: str
+    currency: str
+    now: datetime
+
+    @property
+    def zone(self) -> ZoneInfo:
+        try:
+            return ZoneInfo(self.timezone)
+        except (ZoneInfoNotFoundError, ValueError):
+            logger.warning("unknown timezone %s, falling back to UTC", self.timezone)
+            return ZoneInfo("UTC")
+
+
+def resolve_context(defaults: ExtractionDefaults | dict | None) -> ExtractionContext:
+    """Merge the request's defaults over the server's configured ones."""
+    if isinstance(defaults, ExtractionDefaults):
+        defaults = defaults.model_dump(exclude_none=True)
+    values = defaults or {}
+    timezone_name = values.get("timezone") or DEFAULT_TIMEZONE
+    context = ExtractionContext(
+        country=values.get("country") or DEFAULT_COUNTRY,
+        timezone=timezone_name,
+        currency=values.get("currency") or DEFAULT_CURRENCY,
+        now=datetime.now(),
+    )
+    return ExtractionContext(
+        country=context.country,
+        timezone=context.timezone,
+        currency=context.currency,
+        now=datetime.now(context.zone),
+    )
+
+
+def context_lines(context: ExtractionContext, hints: ExtractionHints | dict | None = None) -> list[str]:
+    """The context block every chunk prompt carries in its dynamic tail."""
+    lines = [
+        f"Right now it is {context.now.isoformat(timespec='seconds')} "
+        f"({context.now.strftime('%A')}), timezone {context.timezone}. "
+        "Resolve relative times like 'yesterday evening' against it.",
+        f"Country when the narrative names none: {context.country}.",
+        f"Currency for money amounts when the narrative names none: {context.currency}.",
+    ]
+    if isinstance(hints, ExtractionHints):
+        hints = hints.model_dump(exclude_none=True)
+    for key, value in (hints or {}).items():
+        if value:
+            lines.append(f"Hint from the responder, {key.replace('_', ' ')}: {value}.")
+    return lines
+
+
+def _localize_datetimes(node: Any, context: ExtractionContext) -> Any:
+    """Attach the deployment offset to any timestamp the model left naive."""
+    if isinstance(node, dict):
+        return {key: _localize_datetimes(value, context) for key, value in node.items()}
+    if isinstance(node, list):
+        return [_localize_datetimes(item, context) for item in node]
+    if isinstance(node, str) and len(node) >= 16 and "T" in node:
+        try:
+            parsed = datetime.fromisoformat(node.replace("Z", "+00:00"))
+        except ValueError:
+            return node
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=context.zone).isoformat()
+    return node
+
+
+def _apply_currency(node: Any, currency: str) -> Any:
+    """Stamp the default currency on Money objects that came back without one."""
+    if isinstance(node, dict):
+        filled = {key: _apply_currency(value, currency) for key, value in node.items()}
+        if isinstance(filled.get("amount"), (int, float)) and not filled.get("currency"):
+            filled["currency"] = currency
+        return filled
+    if isinstance(node, list):
+        return [_apply_currency(item, currency) for item in node]
+    return node
+
+
+def _prune_empty(node: Any) -> Any:
+    """Drop empty strings and empty containers from a contract document.
+
+    Models answer a field they know nothing about with "" or [] rather than
+    leaving it out. In the contract an absent field means unknown, while an
+    empty string is a claim that the value is blank, so these are dropped.
+    Zero is kept: a count of zero is a real answer.
+    """
+    if isinstance(node, dict):
+        cleaned = {}
+        for key, value in node.items():
+            pruned = _prune_empty(value)
+            if pruned is None or pruned == "" or pruned == [] or pruned == {}:
+                continue
+            cleaned[key] = pruned
+        return cleaned
+    if isinstance(node, list):
+        items = [_prune_empty(item) for item in node]
+        return [item for item in items if item not in (None, "", [], {})]
+    return node
+
+
+def _seconds_between(start: Any, end: Any) -> int | None:
+    """Whole seconds between two RFC 3339 strings, or None if that makes no sense."""
+    try:
+        first = datetime.fromisoformat(str(start).replace("Z", "+00:00"))
+        second = datetime.fromisoformat(str(end).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if first.tzinfo is None or second.tzinfo is None:
+        return None
+    delta = (second - first).total_seconds()
+    return int(delta) if delta >= 0 else None
+
+
+def _derive_unit_timings(contract: dict) -> None:
+    """Compute each unit's turnout and travel seconds from its own timestamps.
+
+    Arithmetic is not the model's job. When both timestamps are there the
+    computed value wins, because models do state a duration that contradicts
+    the times they just gave. The model's number is only kept when the
+    timestamps are missing and there is nothing to compute from.
+    """
+    units = contract.get("units")
+    if not isinstance(units, list):
+        return
+    for unit in units:
+        if not isinstance(unit, dict):
+            continue
+        turnout = _seconds_between(unit.get("dispatched_datetime"), unit.get("enroute_datetime"))
+        if turnout is not None:
+            unit["turnout_seconds"] = turnout
+        travel = _seconds_between(unit.get("enroute_datetime"), unit.get("arrived_datetime"))
+        if travel is not None:
+            unit["travel_seconds"] = travel
+
+
+def apply_context(contract: dict, context: ExtractionContext) -> dict:
+    """Run every deterministic post-step over a stitched contract."""
+    filled = _prune_empty(contract)
+    filled = _localize_datetimes(filled, context)
+    filled = _apply_currency(filled, context.currency)
+
+    # Country is deployment truth, not a guess, so it is stamped even when the
+    # narrative said nothing about where it happened.
+    location = filled.setdefault("location", {})
+    if isinstance(location, dict) and not location.get("country"):
+        location["country"] = context.country
+
+    incident = filled.get("incident")
+    if isinstance(incident, dict) and not incident.get("timezone"):
+        incident["timezone"] = context.timezone
+
+    _derive_unit_timings(filled)
+    return filled

--- a/app/services/extraction/prompts.py
+++ b/app/services/extraction/prompts.py
@@ -1,0 +1,154 @@
+"""Chunk prompts.
+
+Every chunk prompt is a static prefix plus a dynamic suffix. The prefix (the
+instructions and the chunk's field skeleton) never changes between incidents,
+so Ollama reuses its KV cache for it; only the tail, which carries the
+deployment context and the narrative, is new each time. Interpolating the
+narrative anywhere but the end would throw that away.
+
+The field skeleton is rendered from the generated Pydantic model rather than
+hand-written, so it cannot drift from the contract. Enum members are spelled
+out because small models invent enum values otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, time
+from enum import Enum
+from functools import lru_cache
+from typing import Any, get_args, get_origin
+from uuid import UUID
+
+from pydantic import AwareDatetime, BaseModel, NaiveDatetime, RootModel
+
+from app.services.extraction.registry import ChunkSpec
+
+# How deep the skeleton goes before it stops describing nested shape. Three
+# levels covers every chunk in the contract without bloating the prompt.
+MAX_DEPTH = 3
+
+# Longest enum spelled out in full. Past this the prompt lists the first few
+# and tells the model to use exactly one of the contract's values.
+MAX_ENUM_MEMBERS = 25
+
+INSTRUCTIONS = """You extract fire and emergency incident data from a responder's narrative.
+
+Rules:
+- Return one JSON object and nothing else. No prose, no markdown, no code fence.
+- Use only facts the narrative states or clearly implies. Never invent a value.
+- Leave out any field the narrative does not support. An absent field is correct; a guess is not.
+- Use exactly the enum values listed. If none fits, leave the field out.
+- Date-times are RFC 3339 with an offset, for example 2026-04-18T21:14:00-07:00.
+- Physical quantities are SI: metres, square metres, hectares, litres, kilometres, Celsius.
+"""
+
+
+def _enum_hint(enum_cls: type[Enum]) -> str:
+    members = [str(member.value) for member in enum_cls]
+    if len(members) > MAX_ENUM_MEMBERS:
+        shown = " | ".join(members[:MAX_ENUM_MEMBERS])
+        return f"<one of: {shown} | ... (use an exact contract value)>"
+    return f"<one of: {' | '.join(members)}>"
+
+
+# Pydantic's date-time markers are plain classes at runtime, not datetime
+# subclasses, so they need naming before the subclass checks below.
+_ALIAS_HINTS: dict[Any, str] = {
+    AwareDatetime: "<date-time, RFC 3339 with offset>",
+    NaiveDatetime: "<date-time, RFC 3339>",
+}
+
+_SCALAR_HINTS: dict[type, str] = {
+    str: "<string>",
+    bool: "<true or false>",
+    int: "<integer>",
+    float: "<number>",
+    datetime: "<date-time, RFC 3339>",
+    date: "<date, YYYY-MM-DD>",
+    time: "<time, HH:MM:SS>",
+    UUID: "<uuid>",
+}
+
+
+def _skeleton(annotation: Any, depth: int) -> Any:
+    """Render one field's expected shape as a placeholder value."""
+    hint = _ALIAS_HINTS.get(annotation)
+    if hint is not None:
+        return hint
+
+    origin = get_origin(annotation)
+
+    if origin is list:
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        item = _skeleton(args[0], depth) if args else "<value>"
+        return [item]
+
+    if origin is not None:
+        # Optional / Union / Annotated: describe the first real member.
+        args = [a for a in get_args(annotation) if a is not type(None)]
+        return _skeleton(args[0], depth) if args else "<value>"
+
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return _enum_hint(annotation)
+
+    if isinstance(annotation, type) and issubclass(annotation, RootModel):
+        # A root model is a wrapper around one value; describe the value.
+        return _skeleton(annotation.model_fields["root"].annotation, depth)
+
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        if depth >= MAX_DEPTH:
+            return "<object>"
+        return model_skeleton(annotation, depth + 1)
+
+    if isinstance(annotation, type):
+        for scalar, hint in _SCALAR_HINTS.items():
+            if issubclass(annotation, scalar):
+                return hint
+
+    return "<value>"
+
+
+def model_skeleton(model: type[BaseModel], depth: int = 0) -> dict[str, Any]:
+    """A JSON-shaped description of every field on a generated contract model."""
+    skeleton: dict[str, Any] = {}
+    for name, info in model.model_fields.items():
+        skeleton[name] = _skeleton(info.annotation, depth)
+    return skeleton
+
+
+@lru_cache(maxsize=None)
+def static_prefix(chunk_name: str, model: type[BaseModel], is_list: bool, description: str) -> str:
+    """The cacheable head of a chunk prompt. Identical for every incident."""
+    shape = model_skeleton(model)
+    body = {chunk_name: [shape] if is_list else shape}
+    lines = [INSTRUCTIONS]
+    if description:
+        lines.append(f"Section: {chunk_name}. {description}")
+    else:
+        lines.append(f"Section: {chunk_name}.")
+    lines.append(
+        f'Return a JSON object with the single key "{chunk_name}", shaped like this. '
+        "The angle-bracket text describes the expected value, it is not a value:"
+    )
+    lines.append(json.dumps(body, indent=2))
+    return "\n\n".join(lines)
+
+
+def build_prompt(
+    spec: ChunkSpec,
+    text: str,
+    context_lines: list[str],
+    retry_note: str | None = None,
+) -> str:
+    """The full prompt for one chunk: cached prefix, then this incident's tail."""
+    prefix = static_prefix(spec.name, spec.model, spec.is_list, spec.description)
+    tail = ["Context for resolving anything the narrative leaves implicit:"]
+    tail.extend(f"- {line}" for line in context_lines)
+    if retry_note:
+        tail.append(
+            "Your previous answer was rejected. Fix it and return the corrected "
+            f"JSON object only. Reason: {retry_note}"
+        )
+    tail.append(f"NARRATIVE:\n{text}")
+    return prefix + "\n\n" + "\n\n".join(tail)

--- a/app/services/extraction/registry.py
+++ b/app/services/extraction/registry.py
@@ -1,0 +1,148 @@
+"""The chunk registry.
+
+The incident contract is the source of truth for how each of its top-level
+chunks is extracted. Every chunk carries `x-extraction` (core, gated,
+background or manual), gated chunks carry `x-triggers`, and any chunk can carry
+`x-extraction-priority`. This module reads those at import time and pairs each
+chunk with the generated Pydantic model that validates it, so the rest of the
+worker never hardcodes a chunk name or a tier.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import lru_cache
+from typing import Any, get_args, get_origin
+
+import yaml
+from pydantic import BaseModel
+
+from app.api.schemas.incident_contract import IncidentContract
+from app.core.config import INCIDENT_CONTRACT_PATH
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class Tier(str, Enum):
+    """What the worker does with a chunk.
+
+    core       always extracted, no gating
+    gated      extracted only when the narrative shows evidence for it
+    background extracted after everything else, never blocks a form
+    manual     never sent to the model (record ids, signatures, reflections)
+    """
+
+    core = "core"
+    gated = "gated"
+    background = "background"
+    manual = "manual"
+
+
+@dataclass(frozen=True)
+class ChunkSpec:
+    """One top-level contract chunk and everything needed to extract it."""
+
+    name: str
+    tier: Tier
+    model: type[BaseModel] | None
+    is_list: bool
+    priority: int = 100
+    triggers: tuple[str, ...] = ()
+    description: str = ""
+    trigger_pattern: re.Pattern[str] | None = field(default=None, compare=False)
+
+    def matches(self, text: str) -> bool:
+        """True when the text carries evidence this chunk applies."""
+        if self.trigger_pattern is None:
+            return False
+        return self.trigger_pattern.search(text) is not None
+
+
+def _build_trigger_pattern(triggers: tuple[str, ...]) -> re.Pattern[str] | None:
+    """One case-insensitive word-boundary pattern for a chunk's trigger list."""
+    if not triggers:
+        return None
+    alternatives = "|".join(re.escape(t) for t in sorted(triggers, key=len, reverse=True))
+    return re.compile(rf"\b(?:{alternatives})\b", re.IGNORECASE)
+
+
+def _unwrap(annotation: Any) -> tuple[type[BaseModel] | None, bool]:
+    """Reduce a generated field annotation to (model, is_list).
+
+    Generated fields are Optional and sometimes list-valued, so this peels off
+    Optional and list wrappers to find the BaseModel underneath. Returns
+    (None, False) for scalar chunks like schema_version.
+    """
+    is_list = False
+    seen: list[Any] = [annotation]
+    while seen:
+        current = seen.pop()
+        if isinstance(current, type) and issubclass(current, BaseModel):
+            return current, is_list
+        origin = get_origin(current)
+        if origin is list:
+            is_list = True
+        args = [arg for arg in get_args(current) if arg is not type(None)]
+        seen.extend(args)
+    return None, is_list
+
+
+@lru_cache(maxsize=1)
+def _contract_properties() -> dict[str, dict]:
+    """The IncidentContract property map, read from the contract file once."""
+    doc = yaml.safe_load(INCIDENT_CONTRACT_PATH.read_text())
+    return doc["IncidentContract"]["properties"]
+
+
+@lru_cache(maxsize=1)
+def chunk_registry() -> dict[str, ChunkSpec]:
+    """Every top-level chunk, keyed by name, in tier and priority order."""
+    specs: list[ChunkSpec] = []
+    for name, spec in _contract_properties().items():
+        tier_value = spec.get("x-extraction")
+        if tier_value is None:
+            # A chunk with no x-extraction is new and unrouted. Treat it as
+            # manual so the worker never silently prompts for something the
+            # contract has not classified.
+            tier_value = Tier.manual.value
+        info = IncidentContract.model_fields.get(name)
+        if info is None:
+            # The contract grew a chunk the committed models do not have yet.
+            # Skip it rather than crash, and say so: the fix is to regenerate.
+            logger.warning(
+                "contract chunk %s has no generated model, skipping it. "
+                "Run `make generate-contract-models`.",
+                name,
+            )
+            continue
+        triggers = tuple(spec.get("x-triggers") or ())
+        model, is_list = _unwrap(info.annotation)
+        specs.append(
+            ChunkSpec(
+                name=name,
+                tier=Tier(tier_value),
+                model=model,
+                is_list=is_list,
+                priority=int(spec.get("x-extraction-priority", 100)),
+                triggers=triggers,
+                description=(spec.get("description") or "").strip(),
+                trigger_pattern=_build_trigger_pattern(triggers),
+            )
+        )
+
+    tier_order = {Tier.core: 0, Tier.gated: 1, Tier.background: 2, Tier.manual: 3}
+    specs.sort(key=lambda s: (tier_order[s.tier], s.priority, s.name))
+    return {spec.name: spec for spec in specs}
+
+
+def extractable_chunks() -> list[ChunkSpec]:
+    """Chunks the model can be asked about: everything but manual, and only
+    those the generated models can validate."""
+    return [
+        spec
+        for spec in chunk_registry().values()
+        if spec.tier is not Tier.manual and spec.model is not None
+    ]

--- a/app/services/extraction/router.py
+++ b/app/services/extraction/router.py
@@ -1,0 +1,39 @@
+"""Chunk routing.
+
+Deciding what not to ask the model is most of the speed. Core chunks apply to
+every incident and always run. Gated chunks only run when their trigger words
+appear in the narrative, so a structure fire never pays for the wildland
+prompt. Background chunks run last. Nothing here calls the model.
+"""
+
+from __future__ import annotations
+
+from app.core.logging import get_logger
+from app.services.extraction.registry import ChunkSpec, Tier, extractable_chunks
+
+logger = get_logger(__name__)
+
+
+def select_chunks(text: str) -> list[ChunkSpec]:
+    """The chunks worth extracting from this text, in the order to run them.
+
+    Order is tier first (core, then gated, then background) and priority
+    within a tier, which the registry already applies.
+    """
+    selected: list[ChunkSpec] = []
+    skipped: list[str] = []
+
+    for spec in extractable_chunks():
+        if spec.tier is Tier.gated and not spec.matches(text):
+            skipped.append(spec.name)
+            continue
+        selected.append(spec)
+
+    logger.info(
+        "chunk router selected %d chunks (%s), skipped %d gated (%s)",
+        len(selected),
+        ", ".join(spec.name for spec in selected),
+        len(skipped),
+        ", ".join(skipped),
+    )
+    return selected

--- a/app/services/extraction/runner.py
+++ b/app/services/extraction/runner.py
@@ -1,0 +1,253 @@
+"""Running the selected chunks.
+
+Each chunk is one focused prompt, validated against its generated model. A
+chunk that comes back malformed gets one retry with the reason named. If it
+misses again, the salvage pass keeps whatever fields do validate and throws
+away only the offending ones, because one invented enum in a sub-field nobody
+mentioned should not cost a whole section. Nothing is ever guessed in the other
+direction: fields only come out. Chunks run in waves by tier so the fields a
+form needs land first, and inside a wave they run in parallel up to the Ollama
+concurrency limit.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from functools import lru_cache
+from itertools import groupby
+from typing import Any, Callable
+
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from app.core.config import EXTRACTION_CHUNK_RETRIES, EXTRACTION_MAX_PARALLEL
+from app.core.logging import get_logger
+from app.services.extraction.client import (
+    ChunkCallError,
+    ChunkTimeoutError,
+    LLMUnavailableError,
+    call_chunk,
+)
+from app.services.extraction.prompts import build_prompt
+from app.services.extraction.registry import ChunkSpec
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ChunkResult:
+    """What one chunk produced: a validated value, or the reason it has none."""
+
+    name: str
+    value: Any = None
+    error: str | None = None
+    attempts: int = 0
+    # Paths thrown away by the salvage pass, so the review screen can show them
+    # as gaps rather than pretending the whole section was extracted.
+    dropped: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+    @property
+    def has_value(self) -> bool:
+        return self.value not in (None, {}, [])
+
+
+@lru_cache(maxsize=None)
+def _list_adapter(model: type[BaseModel]) -> TypeAdapter:
+    """Validator for a list-valued chunk, built once per chunk model."""
+    return TypeAdapter(list[model])
+
+
+def _validate(spec: ChunkSpec, payload: dict[str, Any]) -> Any:
+    """Validate the model's answer against the chunk's contract model.
+
+    The prompt asks for {"chunk_name": {...}}, but models sometimes return the
+    inner object on its own, so both shapes are accepted. Returns plain JSON
+    data with unset fields dropped, ready for the contract document.
+    """
+    raw = payload.get(spec.name, payload)
+
+    if spec.is_list:
+        if isinstance(raw, dict):
+            raw = [raw]
+        if not isinstance(raw, list):
+            raise ValueError(f"expected a list for {spec.name}, got {type(raw).__name__}")
+        # Validated as a whole list, not item by item, so an error's location
+        # carries the index the salvage pass needs to find the offending entry.
+        validated = _list_adapter(spec.model).validate_python(raw)
+        items = [item.model_dump(mode="json", exclude_none=True) for item in validated]
+        return [item for item in items if item]
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"expected an object for {spec.name}, got {type(raw).__name__}")
+    return spec.model.model_validate(raw).model_dump(mode="json", exclude_none=True)
+
+
+def _drop_path(payload: Any, path: tuple) -> str | None:
+    """Delete one validation-error path from the raw answer.
+
+    Returns the path it removed, or None when the path does not resolve (a
+    union tag in the location, an index that moved). Nothing is guessed: only
+    an exact hit is deleted.
+    """
+    node = payload
+    for step in path[:-1]:
+        if isinstance(node, dict) and step in node:
+            node = node[step]
+        elif isinstance(node, list) and isinstance(step, int) and step < len(node):
+            node = node[step]
+        else:
+            return None
+
+    last = path[-1]
+    if isinstance(node, dict) and last in node:
+        del node[last]
+    elif isinstance(node, list) and isinstance(last, int) and last < len(node):
+        del node[last]
+    else:
+        return None
+    return ".".join(str(step) for step in path)
+
+
+def _salvage(spec: ChunkSpec, raw: Any, exc: ValidationError) -> tuple[Any, list[str]]:
+    """Keep the fields that validate by dropping the ones that do not.
+
+    A small model will invent an enum value in some sub-field nobody mentioned,
+    and without this one bad field costs the whole section. Dropping the exact
+    offending paths and validating again keeps the good data. Nothing is
+    invented here; fields only ever come out.
+    """
+    dropped: list[str] = []
+    error = exc
+
+    def deepest_first(path: tuple) -> tuple:
+        """Sort key: remove the longest paths and the highest list indices
+        first, so deleting one entry cannot shift another out from under us."""
+        return tuple((1, step) if isinstance(step, int) else (0, str(step)) for step in path)
+
+    # Each pass can uncover errors the previous one masked, so try a few times.
+    for _ in range(3):
+        removed_any = False
+        paths = sorted({tuple(err["loc"]) for err in error.errors()}, key=deepest_first, reverse=True)
+        for path in paths:
+            removed = _drop_path(raw, path)
+            if removed:
+                dropped.append(removed)
+                removed_any = True
+        if not removed_any:
+            break
+        try:
+            return _validate(spec, {spec.name: raw}), dropped
+        except ValidationError as next_error:
+            error = next_error
+        except ValueError:
+            break
+
+    raise error
+
+
+def _failure_reason(exc: Exception) -> str:
+    """A short, model-readable description of why an answer was rejected."""
+    if isinstance(exc, ValidationError):
+        parts = []
+        for err in exc.errors()[:5]:
+            path = ".".join(str(loc) for loc in err["loc"]) or "value"
+            parts.append(f"{path}: {err['msg']}")
+        return "; ".join(parts)
+    return str(exc)
+
+
+def extract_chunk(
+    spec: ChunkSpec,
+    text: str,
+    context_lines: list[str],
+    model: str | None = None,
+) -> ChunkResult:
+    """Extract one chunk: retry a rejected answer once, then salvage what validates."""
+    result = ChunkResult(name=spec.name)
+    retry_note: str | None = None
+    attempts = 1 + EXTRACTION_CHUNK_RETRIES
+
+    for attempt in range(attempts):
+        result.attempts = attempt + 1
+        last_try = attempt == attempts - 1
+        prompt = build_prompt(spec, text, context_lines, retry_note)
+        try:
+            payload = call_chunk(prompt, model)
+            result.value = _validate(spec, payload)
+            result.error = None
+            return result
+        except LLMUnavailableError:
+            raise
+        except ChunkTimeoutError as exc:
+            result.error = str(exc)
+            logger.warning("chunk %s timed out, not retrying: %s", spec.name, exc)
+            break
+        except ValidationError as exc:
+            retry_note = _failure_reason(exc)
+            result.error = retry_note
+            logger.warning(
+                "chunk %s attempt %d rejected: %s", spec.name, result.attempts, retry_note
+            )
+            if not last_try:
+                continue
+            try:
+                raw = payload.get(spec.name, payload)
+                result.value, result.dropped = _salvage(spec, raw, exc)
+                result.error = None
+                logger.info(
+                    "chunk %s salvaged, dropped %d field(s): %s",
+                    spec.name,
+                    len(result.dropped),
+                    ", ".join(result.dropped),
+                )
+                return result
+            except (ValidationError, ValueError):
+                logger.warning("chunk %s could not be salvaged", spec.name)
+        except (ChunkCallError, ValueError) as exc:
+            retry_note = _failure_reason(exc)
+            result.error = retry_note
+            logger.warning(
+                "chunk %s attempt %d rejected: %s", spec.name, result.attempts, retry_note
+            )
+
+    logger.error(
+        "chunk %s failed after %d attempt(s), left for manual entry: %s",
+        spec.name,
+        result.attempts,
+        result.error,
+    )
+    result.value = None
+    return result
+
+
+def run_chunks(
+    specs: list[ChunkSpec],
+    text: str,
+    context_lines: list[str],
+    model: str | None = None,
+    on_wave: Callable[[list[ChunkResult]], None] | None = None,
+) -> list[ChunkResult]:
+    """Run every selected chunk, one parallel wave per tier.
+
+    `on_wave` is called with the results of each wave as it lands, which is how
+    the worker publishes partial results while the long tail is still running.
+    """
+    results: list[ChunkResult] = []
+    workers = max(1, EXTRACTION_MAX_PARALLEL)
+
+    for tier, group in groupby(specs, key=lambda s: s.tier):
+        wave = list(group)
+        logger.info("extracting %s wave: %s", tier.value, ", ".join(s.name for s in wave))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            wave_results = list(
+                pool.map(lambda spec: extract_chunk(spec, text, context_lines, model), wave)
+            )
+        results.extend(wave_results)
+        if on_wave is not None:
+            on_wave(wave_results)
+
+    return results

--- a/app/services/extraction/service.py
+++ b/app/services/extraction/service.py
@@ -4,8 +4,9 @@ Owns the write path that turns a ready input into a queued extraction: it
 creates the extraction row, creates the async job, and dispatches the worker.
 The route stays a thin HTTP handler and calls straight into here.
 
-The worker itself is stubbed for now (app/tasks/extract.py); the real chunked
-extraction is #630.
+The request's deployment defaults and hints are not stored on the extraction
+row, they only shape this one run, so they travel to the worker as task
+arguments.
 """
 
 from datetime import datetime, timezone
@@ -13,9 +14,15 @@ from datetime import datetime, timezone
 from sqlmodel import Session
 
 from app.api.schemas.enums import ExtractionStatus
+from app.api.schemas.extraction import ExtractionDefaults, ExtractionHints
 from app.db.repositories import create_extraction, create_job, update_job
 from app.models import Extraction, Job
 from app.tasks.extract import extract_task
+
+
+def _as_dict(value: ExtractionDefaults | ExtractionHints | None) -> dict:
+    """Task arguments have to be plain JSON, so models go over as dicts."""
+    return value.model_dump(exclude_none=True) if value is not None else {}
 
 
 class ExtractionService:
@@ -24,6 +31,8 @@ class ExtractionService:
         session: Session,
         input_id,
         model_override: str | None = None,
+        defaults: ExtractionDefaults | None = None,
+        hints: ExtractionHints | None = None,
     ) -> tuple[Extraction, Job]:
         """Create the extraction row and job, then dispatch the worker.
 
@@ -46,7 +55,12 @@ class ExtractionService:
         job = Job(celery_task_id="", job_type="extraction", status="queued", model=model_override)
         job = create_job(session, job)
 
-        result = extract_task.delay(str(extraction.extract_id), job.job_id)
+        result = extract_task.delay(
+            str(extraction.extract_id),
+            job.job_id,
+            _as_dict(defaults),
+            _as_dict(hints),
+        )
         job.celery_task_id = result.id
         job = update_job(session, job)
 

--- a/app/services/extraction/worker.py
+++ b/app/services/extraction/worker.py
@@ -1,0 +1,233 @@
+"""The extraction run.
+
+Takes a queued extraction and turns it into a validated contract and a draft
+incident. Order of business: read the narrative, pick the chunks worth asking
+about, run them in waves, apply the deterministic post-steps, stitch one
+document, then write the incident and close out the extraction and its job.
+
+A chunk that fails does not sink the run. The narrative is the only thing every
+chunk shares, so a chunk missing means those fields stay empty and the review
+screen shows the gap. The run only fails when Ollama is unreachable or when
+nothing at all could be extracted.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from pydantic import ValidationError
+from sqlmodel import Session
+
+from app.api.schemas.enums import ExtractionStatus
+from app.api.schemas.incident_contract import IncidentContract
+from app.core.config import OLLAMA_MODEL
+from app.core.logging import get_logger
+from app.db.repositories import (
+    create_draft_incident,
+    get_extraction,
+    get_input,
+    get_job_by_uuid,
+    update_extraction,
+    update_incident,
+    update_job,
+)
+from app.services.extraction.client import LLMUnavailableError
+from app.services.extraction.defaults import apply_context, context_lines, resolve_context
+from app.services.extraction.router import select_chunks
+from app.services.extraction.runner import ChunkResult, run_chunks
+from app.services.incidents import PROMOTED_COLUMNS, promote
+
+logger = get_logger(__name__)
+
+SCHEMA_VERSION = "1.1.0"
+SCHEMA_NAME = "fireform_incident_contract"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stitch(results: list[ChunkResult]) -> dict[str, Any]:
+    """Merge the chunk results into one contract document.
+
+    Chunks own disjoint sub-objects, so merging is a plain assignment per chunk.
+    Chunks with nothing in them are left out: an absent field means unknown.
+    """
+    contract: dict[str, Any] = {"schema_version": SCHEMA_VERSION, "schema_name": SCHEMA_NAME}
+    for result in results:
+        if result.has_value:
+            contract[result.name] = result.value
+    return contract
+
+
+def _completeness(results: list[ChunkResult]) -> dict[str, Any]:
+    """Extraction-quality summary for extraction_metadata."""
+    filled = [r for r in results if r.has_value]
+    failed = [r.name for r in results if not r.ok]
+    empty = [r.name for r in results if r.ok and not r.has_value]
+    # A salvaged chunk kept its good fields; the ones thrown away are gaps too.
+    dropped = [f"{r.name}.{path}" for r in results for path in r.dropped]
+    percent = round(100 * len(filled) / len(results)) if results else 0
+    return {
+        "overall_percent": percent,
+        "missing_fields": sorted(failed + empty + dropped),
+    }
+
+
+def _metadata(extraction, input_record, model_used: str, results: list[ChunkResult]) -> dict[str, Any]:
+    return {
+        "extract_id": str(extraction.extract_id),
+        "input_id": str(extraction.input_id),
+        "input_type": input_record.input_type.value
+        if hasattr(input_record.input_type, "value")
+        else str(input_record.input_type),
+        "extracted_at": _now().isoformat(),
+        "llm_model": model_used,
+        "completeness": _completeness(results),
+    }
+
+
+def _fail(session: Session, extraction, job, error_type: str, detail: str) -> None:
+    now = _now()
+    extraction.status = ExtractionStatus.failed
+    extraction.error_type = error_type
+    extraction.error_detail = detail
+    extraction.updated_at = now
+    update_extraction(session, extraction)
+    if job:
+        job.status = "failed"
+        job.error = {"error_code": error_type, "message": detail}
+        job.updated_at = now
+        update_job(session, job)
+    logger.error("extraction %s failed (%s): %s", extraction.extract_id, error_type, detail)
+
+
+def _write_incident(session: Session, extraction, contract: dict[str, Any]):
+    """Create the draft incident that owns the contract from here on."""
+    incident = create_draft_incident(session, extraction.extract_id)
+    incident.incident_contract = contract
+    promoted = promote(contract)
+    for column in PROMOTED_COLUMNS:
+        setattr(incident, column, promoted[column])
+    incident_section = contract.get("incident") or {}
+    incident.incident_name = incident_section.get("name")
+    incident.updated_at = _now()
+    return update_incident(session, incident)
+
+
+def run_extraction(
+    session: Session,
+    extract_id: UUID,
+    job_id: str,
+    defaults: dict | None = None,
+    hints: dict | None = None,
+) -> dict[str, Any]:
+    """Run one queued extraction to completion. Returns a small result summary."""
+    started = time.monotonic()
+    extraction = get_extraction(session, extract_id)
+    if extraction is None:
+        logger.error("extraction %s no longer exists, nothing to run", extract_id)
+        return {"extract_id": str(extract_id), "status": "missing"}
+
+    job = get_job_by_uuid(session, job_id)
+    input_record = get_input(session, extraction.input_id)
+
+    now = _now()
+    extraction.status = ExtractionStatus.processing
+    extraction.started_at = extraction.started_at or now
+    extraction.updated_at = now
+    update_extraction(session, extraction)
+    if job:
+        job.status = "processing"
+        job.updated_at = now
+        update_job(session, job)
+
+    text = (input_record.transcript if input_record else "") or ""
+    if not text.strip():
+        _fail(session, extraction, job, "EMPTY_INPUT", "The input has no transcript to extract from.")
+        return {"extract_id": str(extract_id), "status": "failed"}
+
+    model_used = extraction.model_used or OLLAMA_MODEL
+    context = resolve_context(defaults)
+    prompt_context = context_lines(context, hints)
+    specs = select_chunks(text)
+
+    collected: list[ChunkResult] = []
+
+    def publish(wave: list[ChunkResult]) -> None:
+        """Show what has landed so far while the remaining waves run."""
+        collected.extend(wave)
+        extraction.partial_result = _stitch(collected)
+        extraction.updated_at = _now()
+        update_extraction(session, extraction)
+        if job:
+            job.progress_percent = round(100 * len(collected) / len(specs)) if specs else 100
+            job.updated_at = _now()
+            update_job(session, job)
+
+    try:
+        results = run_chunks(specs, text, prompt_context, extraction.model_used, on_wave=publish)
+    except LLMUnavailableError as exc:
+        _fail(session, extraction, job, "LLM_UNAVAILABLE", str(exc))
+        raise
+
+    if results and not any(result.ok for result in results):
+        _fail(
+            session,
+            extraction,
+            job,
+            "EXTRACTION_FAILED",
+            "Every chunk was rejected by validation. Nothing could be extracted.",
+        )
+        return {"extract_id": str(extract_id), "status": "failed"}
+
+    contract = apply_context(_stitch(results), context)
+    contract["extraction_metadata"] = _metadata(extraction, input_record, model_used, results)
+
+    try:
+        IncidentContract.model_validate(contract)
+    except ValidationError as exc:
+        _fail(session, extraction, job, "EXTRACTION_FAILED", f"stitched contract is invalid: {exc}")
+        raise
+
+    incident = _write_incident(session, extraction, contract)
+
+    now = _now()
+    extraction.status = ExtractionStatus.completed
+    extraction.completed_at = now
+    extraction.processing_time_seconds = round(time.monotonic() - started, 2)
+    extraction.model_used = model_used
+    # The incident row owns the document now; the working copy goes away.
+    extraction.partial_result = None
+    extraction.error_type = None
+    extraction.error_detail = None
+    extraction.updated_at = now
+    update_extraction(session, extraction)
+
+    if job:
+        job.status = "completed"
+        job.progress_percent = 100
+        job.result_url = f"/api/v1/extract/{extract_id}"
+        job.updated_at = now
+        update_job(session, job)
+
+    failed = [result.name for result in results if not result.ok]
+    logger.info(
+        "extraction %s completed in %.2fs: %d/%d chunks filled, %d failed, incident %s",
+        extract_id,
+        extraction.processing_time_seconds,
+        sum(1 for r in results if r.has_value),
+        len(results),
+        len(failed),
+        incident.incident_id,
+    )
+    return {
+        "extract_id": str(extract_id),
+        "job_id": job_id,
+        "incident_id": str(incident.incident_id),
+        "status": "completed",
+        "failed_chunks": failed,
+    }

--- a/app/tasks/extract.py
+++ b/app/tasks/extract.py
@@ -1,47 +1,29 @@
+"""Celery glue for the extraction worker.
+
+All the work lives in app/services/extraction/worker.py. This is only the
+broker entry point: open a session, run the extraction, close the session.
+"""
+
 import logging
-from datetime import datetime, timezone
 from uuid import UUID
 
-from app.api.schemas.enums import ExtractionStatus
 from app.core.celery import celery_app
 from app.db.database import get_session
-from app.db.repositories import get_extraction, get_job_by_uuid, update_extraction, update_job
+from app.services.extraction.worker import run_extraction
 
 logger = logging.getLogger(__name__)
 
 
 @celery_app.task(name="extract_incident")
-def extract_task(extract_id_str: str, job_id_str: str) -> dict:
-    """Stub extraction worker.
-
-    #629 ships the queue slice: the extraction row and job exist and the task
-    runs, but the real chunked extraction (split the narrative into field
-    groups, call the model, validate, stitch a contract, create the draft
-    incident) lands in #630. For now the task only marks the job in-flight and
-    leaves the extraction in its ``processing`` state, which is what
-    GET /extract/{id} reports back to pollers.
-    """
+def extract_task(
+    extract_id_str: str,
+    job_id_str: str,
+    defaults: dict | None = None,
+    hints: dict | None = None,
+) -> dict:
+    """Run the chunked extraction for one queued extraction row."""
     session = next(get_session())
-    extract_id = UUID(extract_id_str)
     try:
-        extraction = get_extraction(session, extract_id)
-        job = get_job_by_uuid(session, job_id_str)
-
-        now = datetime.now(timezone.utc)
-        if extraction:
-            extraction.status = ExtractionStatus.processing
-            extraction.started_at = extraction.started_at or now
-            extraction.updated_at = now
-            update_extraction(session, extraction)
-        if job:
-            job.status = "processing"
-            job.updated_at = now
-            update_job(session, job)
-
-        logger.info(
-            "extract_task stub ran for extraction %s; real worker is #630",
-            extract_id_str,
-        )
-        return {"extract_id": extract_id_str, "job_id": job_id_str}
+        return run_extraction(session, UUID(extract_id_str), job_id_str, defaults, hints)
     finally:
         session.close()

--- a/contracts/schemas/incident-contract.yaml
+++ b/contracts/schemas/incident-contract.yaml
@@ -24,6 +24,13 @@
 #   grows over time (including non-English terms) without schema changes.
 # - All date-times are RFC 3339 with UTC offset; incident.timezone holds the
 #   IANA zone for local wall-clock rendering.
+# - Each top-level chunk carries x-extraction, telling the extraction worker
+#   how to treat it: core runs on every incident, gated runs only when the
+#   narrative shows evidence for it, background runs after the rest, manual is
+#   never sent to the model (signatures, record ids, authored reflections).
+#   Gated chunks list the evidence words in x-triggers, and x-extraction-priority
+#   orders chunks inside a tier. The worker reads all three from this file at
+#   startup, so retuning the router means editing the contract, not the code.
 
 IncidentContract:
   type: object
@@ -35,102 +42,414 @@ IncidentContract:
     IncidentRecord columns server-side.
   properties:
     schema_version:
+      x-extraction: manual
       type: string
       description: Schema version identifier
       example: "1.1.0"
     schema_name:
+      x-extraction: manual
       type: string
       description: Schema name identifier
       enum:
         - fireform_incident_contract
 
     extraction_metadata:
+      x-extraction: manual
       $ref: "#/ExtractionMetadata"
     report_metadata:
+      x-extraction: manual
       $ref: "#/ReportMetadata"
     incident:
+      x-extraction: core
+      x-extraction-priority: 1
       $ref: "#/Incident"
     dispatch:
+      x-extraction: core
+      x-extraction-priority: 2
       $ref: "#/Dispatch"
     location:
+      x-extraction: core
+      x-extraction-priority: 3
       $ref: "#/Location"
     actions_taken:
+      x-extraction: core
+      x-extraction-priority: 5
       $ref: "#/ActionsTaken"
     responding_agencies:
+      x-extraction: core
+      x-extraction-priority: 6
       $ref: "#/RespondingAgencies"
     units:
+      x-extraction: core
+      x-extraction-priority: 4
       type: array
       description: Per-unit (apparatus/resource) response records with timestamps
       items:
         $ref: "#/UnitResponse"
     resources_summary:
+      x-extraction: background
       $ref: "#/ResourcesSummary"
     fire:
+      x-extraction: gated
+      x-triggers:
+        - fire
+        - fires
+        - flame
+        - flames
+        - smoke
+        - burn
+        - burning
+        - burned
+        - blaze
+        - arson
+        - ignition
+        - ignited
+        - ember
+        - embers
+        - smoldering
       $ref: "#/Fire"
     explosion:
+      x-extraction: gated
+      x-triggers:
+        - explosion
+        - explosive
+        - exploded
+        - blast
+        - detonation
+        - detonated
+        - bleve
+        - ruptured
+        - backdraft
       $ref: "#/Explosion"
     risk_reduction:
+      x-extraction: background
       $ref: "#/RiskReduction"
     structure:
+      x-extraction: gated
+      x-triggers:
+        - structure
+        - building
+        - house
+        - home
+        - apartment
+        - residence
+        - roof
+        - floor
+        - basement
+        - attic
+        - warehouse
+        - garage
+        - unit
+        - storey
+        - story
+        - wall
+        - ceiling
       $ref: "#/Structure"
     wildland:
+      x-extraction: gated
+      x-triggers:
+        - wildland
+        - wildfire
+        - brush
+        - grass
+        - grassland
+        - forest
+        - woods
+        - vegetation
+        - acre
+        - acres
+        - hectare
+        - hectares
+        - timber
+        - canopy
+        - crown
+        - fireline
+        - containment
       $ref: "#/Wildland"
     exposures:
+      x-extraction: gated
+      x-triggers:
+        - exposure
+        - exposures
+        - spread
+        - spreading
+        - adjacent
+        - neighboring
+        - neighbouring
+        - next door
+        - nearby structure
       type: array
       description: Properties beyond the origin affected by spread of the incident
       items:
         $ref: "#/Exposure"
     casualties:
+      x-extraction: gated
+      x-triggers:
+        - injured
+        - injury
+        - injuries
+        - victim
+        - victims
+        - fatality
+        - fatalities
+        - deceased
+        - died
+        - killed
+        - dead
+        - transported
+        - burns
+        - inhalation
+        - casualty
+        - casualties
+        - hurt
+        - unconscious
       $ref: "#/Casualties"
     rescues:
+      x-extraction: gated
+      x-triggers:
+        - rescue
+        - rescued
+        - trapped
+        - extricate
+        - extrication
+        - extricated
+        - pulled out
+        - carried out
+        - ladder rescue
+        - confined space
       type: array
       description: Rescues and assisted evacuations, with or without injury
       items:
         $ref: "#/Rescue"
     evacuation_displacement:
+      x-extraction: gated
+      x-triggers:
+        - evacuate
+        - evacuated
+        - evacuation
+        - displaced
+        - displacement
+        - shelter
+        - sheltered
+        - relocated
+        - red cross
+        - self-evacuated
       $ref: "#/EvacuationDisplacement"
     ems:
+      x-extraction: gated
+      x-triggers:
+        - ems
+        - ambulance
+        - medic
+        - medics
+        - paramedic
+        - patient
+        - patients
+        - cpr
+        - triage
+        - hospital
+        - vitals
+        - oxygen
+        - defibrillator
+        - als
+        - bls
+        - treated
       $ref: "#/EMS"
     hazmat:
+      x-extraction: gated
+      x-triggers:
+        - hazmat
+        - chemical
+        - chemicals
+        - spill
+        - spilled
+        - leak
+        - leaking
+        - fumes
+        - placard
+        - decon
+        - decontamination
+        - vapor
+        - vapour
+        - propane
+        - cylinder
+        - tanker
+        - corrosive
+        - toxic
       $ref: "#/Hazmat"
     emerging_hazards:
+      x-extraction: gated
+      x-triggers:
+        - battery
+        - batteries
+        - lithium
+        - ev
+        - electric vehicle
+        - solar
+        - solar panel
+        - energy storage
+        - charger
+        - charging
+        - thermal runaway
       type: array
       description: Battery, EV, solar and other stored-energy hazards (NERIS)
       items:
         $ref: "#/EmergingHazard"
     investigation:
+      x-extraction: gated
+      x-triggers:
+        - investigation
+        - investigator
+        - investigated
+        - cause
+        - origin
+        - arson
+        - fire marshal
+        - evidence
+        - police
+        - suspicious
+        - incendiary
       $ref: "#/Investigation"
     persons_involved:
+      x-extraction: gated
+      x-triggers:
+        - owner
+        - occupant
+        - occupants
+        - resident
+        - residents
+        - tenant
+        - witness
+        - witnesses
+        - driver
+        - landlord
+        - homeowner
       type: array
       description: Owners, occupants and other parties connected to the incident
       items:
         $ref: "#/PersonInvolved"
     mobile_property:
+      x-extraction: gated
+      x-triggers:
+        - vehicle
+        - vehicles
+        - car
+        - cars
+        - truck
+        - van
+        - suv
+        - motorcycle
+        - boat
+        - vessel
+        - trailer
+        - bus
+        - license plate
+        - tractor
       type: array
       description: Vehicles, vessels and other mobile property involved
       items:
         $ref: "#/MobileProperty"
     losses:
+      x-extraction: gated
+      x-triggers:
+        - loss
+        - losses
+        - damage
+        - damages
+        - destroyed
+        - cost
+        - estimated
+        - insured
+        - insurance
+        - value
+        - worth
+        - dollars
+        - total loss
       $ref: "#/Losses"
     weather:
+      x-extraction: gated
+      x-triggers:
+        - weather
+        - wind
+        - windy
+        - gust
+        - rain
+        - raining
+        - snow
+        - storm
+        - temperature
+        - humidity
+        - dry
+        - fog
+        - heat
+        - freezing
       $ref: "#/Weather"
     environmental_impact:
+      x-extraction: gated
+      x-triggers:
+        - runoff
+        - contamination
+        - contaminated
+        - waterway
+        - river
+        - creek
+        - stream
+        - soil
+        - pollution
+        - wildlife
+        - groundwater
+        - drain
       $ref: "#/EnvironmentalImpact"
     infrastructure_impact:
+      x-extraction: gated
+      x-triggers:
+        - power
+        - powerline
+        - electric
+        - utility
+        - utilities
+        - outage
+        - road closed
+        - road closure
+        - water main
+        - gas line
+        - bridge
+        - rail
+        - traffic
+        - telecom
       $ref: "#/InfrastructureImpact"
     near_miss_and_safety:
+      x-extraction: gated
+      x-triggers:
+        - near miss
+        - mayday
+        - close call
+        - ppe
+        - scba
+        - rit
+        - collapse
+        - safety officer
+        - firefighter injured
+        - accountability
       $ref: "#/NearMissAndSafety"
     situation_status:
+      x-extraction: core
+      x-extraction-priority: 7
       $ref: "#/SituationStatus"
     lessons_learned:
+      x-extraction: manual
       $ref: "#/LessonsLearned"
     follow_up:
+      x-extraction: manual
       $ref: "#/FollowUp"
     periodic_reporting:
+      x-extraction: background
       $ref: "#/PeriodicReporting"
     attachments:
+      x-extraction: manual
       $ref: "#/Attachments"
     custom_fields:
+      x-extraction: manual
       type: object
       description: |
         Agency-local fields with no contract home (NFIRS special studies,

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,7 +12,24 @@ DATABASE_URL=postgresql://fireform:fireform@localhost:5432/fireform
 # Override to point at an external Ollama instance (e.g. a GPU server).
 OLLAMA_HOST=http://ollama:11434
 OLLAMA_MODEL=qwen2.5:1.5b
-OLLAMA_TIMEOUT=300
+OLLAMA_TIMEOUT=600
+# How many chunk prompts the extraction worker sends at once. Keep it in step
+# with the Ollama server's own parallelism; going wider only queues requests.
+OLLAMA_NUM_PARALLEL=4
+# Ceiling on tokens per section answer. Keep it in step with OLLAMA_TIMEOUT: a
+# section that runs past the timeout is lost, while one that hits this ceiling
+# keeps every field it finished before the cut. A small model on CPU manages
+# about three tokens a second.
+OLLAMA_MAX_TOKENS=1200
+
+# --- Extraction -----------------------------------------------------------
+# Extra tries after a chunk's first answer fails validation.
+EXTRACTION_CHUNK_RETRIES=1
+# Deployment context the extractor falls back on when the narrative is silent.
+# A request can override any of these through the extraction body's "defaults".
+FIREFORM_DEFAULT_COUNTRY=US
+FIREFORM_DEFAULT_TIMEZONE=UTC
+FIREFORM_DEFAULT_CURRENCY=USD
 
 # --- Whisper --------------------------------------------------------------
 # Whisper runs in Docker with port mapped to host. App runs on host.

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -23,6 +23,10 @@ services:
   ollama:
     image: ollama/ollama:latest
     container_name: fireform-ollama
+    environment:
+      # The server side of the extraction worker's parallelism. Both read the
+      # same variable so they cannot drift apart.
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-4}
     ports:
       - "127.0.0.1:11434:11434"
     volumes:
@@ -102,8 +106,10 @@ services:
       - PYTHONPATH=/app
       - DATABASE_URL=postgresql://fireform:fireform@postgres:5432/fireform
       - OLLAMA_HOST=${OLLAMA_HOST:-http://ollama:11434}
-      - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-300}
+      - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-600}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:1.5b}
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-4}
+      - OLLAMA_MAX_TOKENS=${OLLAMA_MAX_TOKENS:-1200}
       - WHISPER_HOST=${WHISPER_HOST:-http://whisper:9000}
       - FIREFORM_DATA_DIR=/data/uploads
       - FIREFORM_TEMPLATE_DIR=/data/uploads
@@ -135,8 +141,10 @@ services:
       - PYTHONPATH=/app
       - DATABASE_URL=postgresql://fireform:fireform@postgres:5432/fireform
       - OLLAMA_HOST=${OLLAMA_HOST:-http://ollama:11434}
-      - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-300}
+      - OLLAMA_TIMEOUT=${OLLAMA_TIMEOUT:-600}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:1.5b}
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-4}
+      - OLLAMA_MAX_TOKENS=${OLLAMA_MAX_TOKENS:-1200}
       - FIREFORM_DATA_DIR=/data/uploads
       - FIREFORM_TEMPLATE_DIR=/data/uploads
       - CELERY_BROKER_URL=redis://redis:6379/0

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -31,6 +31,9 @@ COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/pytho
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 COPY app/ ./app/
+# The extraction worker reads the incident contract at startup for its chunk
+# tiers and triggers, so the schemas ship with the image.
+COPY contracts/schemas/ ./contracts/schemas/
 COPY requirements.txt .
 COPY docker/entrypoint.sh /entrypoint.sh
 

--- a/scripts/generate_contract_models.py
+++ b/scripts/generate_contract_models.py
@@ -180,6 +180,22 @@ def strip_shared_enums(source: str, shared: set[str]) -> str:
     return "\n".join(kept) + "\n"
 
 
+# Types a contract field can share a name with. A field called `date` binds
+# `date = None` in its class body, which shadows the imported type and leaves
+# pydantic resolving the annotation to NoneType, so the field silently rejects
+# every value. Importing these under a distinct name removes the collision.
+SHADOWABLE_TYPES = {"date": "date_type", "time": "time_type"}
+
+
+def alias_shadowed_types(source: str) -> str:
+    """Import date and time under names no contract field can shadow."""
+    imported = ", ".join(f"{name} as {alias}" for name, alias in SHADOWABLE_TYPES.items())
+    out = source.replace("from datetime import date, time", f"from datetime import {imported}", 1)
+    for name, alias in SHADOWABLE_TYPES.items():
+        out = out.replace(f"Optional[{name}]", f"Optional[{alias}]")
+    return out
+
+
 def main() -> None:
     shared = shared_enum_names()
     with tempfile.TemporaryDirectory() as tmp:
@@ -191,7 +207,7 @@ def main() -> None:
             run_codegen(wrapped, raw)
         finally:
             wrapped.unlink(missing_ok=True)
-        body = strip_shared_enums(raw.read_text(), shared)
+        body = alias_shadowed_types(strip_shared_enums(raw.read_text(), shared))
 
     # Drop codegen's own header; it names the temporary wrapped file.
     body = "\n".join(

--- a/tests/test_v1_extraction.py
+++ b/tests/test_v1_extraction.py
@@ -82,7 +82,7 @@ class TestCreateExtraction:
         mock_result = MagicMock()
         mock_result.id = celery_id
         with patch("app.api.routes.extraction.check_ollama_available", return_value=ollama_up), \
-             patch("app.services.extraction.extract_task") as mock_task:
+             patch("app.services.extraction.service.extract_task") as mock_task:
             mock_task.delay.return_value = mock_result
             resp = client.post(f"{POST_URL}/{input_id}", json=body)
             return resp, mock_task

--- a/tests/test_v1_extraction_worker.py
+++ b/tests/test_v1_extraction_worker.py
@@ -1,0 +1,527 @@
+"""Tests for the chunked extraction worker (#630).
+
+The model is mocked everywhere: a fake Ollama reads the chunk name out of the
+prompt and answers from a canned table, so these cover routing, validation,
+retry, failure handling and the deterministic post-steps without a running
+Ollama.
+"""
+
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from app.api.schemas.enums import ExtractionStatus, InputStatus, InputType
+from app.db.repositories import (
+    create_extraction,
+    create_input,
+    create_job,
+    get_incident_by_extract,
+    get_job_by_uuid,
+)
+from app.models import Extraction, Input, Job
+from app.services.extraction import runner as runner_module
+from app.services.extraction.client import (
+    ChunkCallError,
+    ChunkTimeoutError,
+    LLMUnavailableError,
+    _extract_json_object,
+)
+from app.services.extraction.defaults import ExtractionContext, apply_context, resolve_context
+from app.services.extraction.prompts import build_prompt, static_prefix
+from app.services.extraction.registry import Tier, chunk_registry, extractable_chunks
+from app.services.extraction.router import select_chunks
+from app.services.extraction.worker import run_extraction
+
+NARRATIVE = (
+    "Structure fire at 42 Oak Street in Reno. Engine 12 dispatched, two civilians "
+    "injured and transported to hospital. Property loss estimated at 50000. "
+    "Investigation points to an electrical cause."
+)
+
+# What the fake model answers per chunk. Anything not listed comes back empty,
+# which is the honest answer for a chunk the narrative does not support.
+ANSWERS = {
+    "incident": {
+        "name": "Oak Street structure fire",
+        "types": [{"category": "fire", "primary": True}],
+        "alarm_datetime": "2026-04-18T21:14:00-07:00",
+        "first_arrival_datetime": "2026-04-18T21:19:00-07:00",
+        "cleared_datetime": "2026-04-18T23:19:00-07:00",
+    },
+    "location": {"address": "42 Oak Street", "city": "Reno", "state": "NV"},
+    "casualties": {"total_civilian_injuries": 2},
+    "units": [
+        {
+            "unit_id": "E12",
+            "dispatched_datetime": "2026-04-18T21:14:00-07:00",
+            "enroute_datetime": "2026-04-18T21:16:00-07:00",
+            "arrived_datetime": "2026-04-18T21:19:00-07:00",
+        }
+    ],
+    "losses": {"property_loss": {"amount": 50000}},
+}
+
+_SECTION = re.compile(r"^Section: ([a-z_]+)\.", re.MULTILINE)
+
+
+def chunk_of(prompt: str) -> str:
+    """The chunk a prompt is asking about."""
+    match = _SECTION.search(prompt)
+    assert match, "every chunk prompt names its section"
+    return match.group(1)
+
+
+def fake_ollama(answers=None, calls=None):
+    """A stand-in for client.call_chunk that answers from a table."""
+    table = ANSWERS if answers is None else answers
+
+    def _call(prompt: str, model: str | None = None):
+        name = chunk_of(prompt)
+        if calls is not None:
+            calls.append((name, prompt))
+        value = table.get(name, {})
+        return {name: value() if callable(value) else value}
+
+    return _call
+
+
+@pytest.fixture
+def mock_llm(monkeypatch):
+    """Patch the Ollama call the runner uses. Yields a setter for the answers."""
+
+    def _install(answers=None, calls=None, side_effect=None):
+        target = side_effect or fake_ollama(answers, calls)
+        monkeypatch.setattr(runner_module, "call_chunk", target)
+        return target
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+def seed(db, transcript: str = NARRATIVE) -> tuple[Extraction, Job]:
+    now = datetime.now(timezone.utc)
+    record = create_input(
+        db,
+        Input(
+            input_type=InputType.text,
+            status=InputStatus.ready,
+            transcript=transcript,
+            created_at=now,
+            updated_at=now,
+        ),
+    )
+    extraction = create_extraction(
+        db,
+        Extraction(
+            input_id=record.input_id,
+            status=ExtractionStatus.processing,
+            started_at=now,
+            created_at=now,
+            updated_at=now,
+        ),
+    )
+    job = create_job(db, Job(celery_task_id="task-1", job_type="extraction", status="queued"))
+    return extraction, job
+
+
+# ---------------------------------------------------------------------------
+# Registry and routing
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    def test_every_chunk_carries_a_tier(self):
+        registry = chunk_registry()
+        assert registry, "the contract should yield chunks"
+        assert all(isinstance(spec.tier, Tier) for spec in registry.values())
+
+    def test_manual_chunks_are_never_extracted(self):
+        names = {spec.name for spec in extractable_chunks()}
+        assert "attachments" not in names
+        assert "report_metadata" not in names
+        assert "custom_fields" not in names
+
+    def test_gated_chunks_declare_triggers(self):
+        gated = [s for s in chunk_registry().values() if s.tier is Tier.gated]
+        assert gated
+        assert all(spec.triggers for spec in gated)
+
+    def test_list_chunks_are_flagged(self):
+        assert chunk_registry()["units"].is_list is True
+        assert chunk_registry()["incident"].is_list is False
+
+
+class TestRouter:
+    def test_core_chunks_always_run(self):
+        selected = {spec.name for spec in select_chunks("nothing much happened")}
+        assert {"incident", "dispatch", "location", "units"} <= selected
+
+    def test_gated_chunk_runs_only_on_evidence(self):
+        without = {spec.name for spec in select_chunks("Assisted a resident with a lift.")}
+        with_evidence = {spec.name for spec in select_chunks("Brush fire burned four hectares.")}
+        assert "wildland" not in without
+        assert "wildland" in with_evidence
+
+    def test_core_chunks_come_before_gated(self):
+        tiers = [spec.tier for spec in select_chunks(NARRATIVE)]
+        assert tiers == sorted(tiers, key=lambda t: [Tier.core, Tier.gated, Tier.background].index(t))
+
+
+class TestAnswerParsing:
+    def test_a_code_fence_is_ignored(self):
+        assert _extract_json_object('```json\n{"incident": {"name": "x"}}\n```') == {
+            "incident": {"name": "x"}
+        }
+
+    def test_an_answer_cut_off_mid_value_keeps_what_came_before(self):
+        # Verbatim shape of a real qwen2.5 answer that hit the token ceiling.
+        truncated = (
+            '{\n  "incident": {\n    "name": "Oak Street fire",\n'
+            '    "alarm_datetime": "2026-04-18T21:14:00-07:00",\n'
+            '    "cleared_datetime": "2026-04-18T21:19'
+        )
+        parsed = _extract_json_object(truncated)
+        assert parsed["incident"]["name"] == "Oak Street fire"
+        assert parsed["incident"]["alarm_datetime"] == "2026-04-18T21:14:00-07:00"
+        # The half-written value is gone rather than kept as a broken timestamp.
+        assert "cleared_datetime" not in parsed["incident"]
+
+    def test_a_cut_off_list_keeps_its_complete_entries(self):
+        truncated = '{"units": [{"unit_id": "E12"}, {"unit_id": "E13"}, {"unit_id": "E1'
+        assert _extract_json_object(truncated) == {
+            "units": [{"unit_id": "E12"}, {"unit_id": "E13"}]
+        }
+
+    def test_an_answer_with_no_object_is_rejected(self):
+        with pytest.raises(ChunkCallError):
+            _extract_json_object("I could not find anything in that narrative.")
+
+
+class TestPrompts:
+    def test_prefix_is_identical_across_incidents(self):
+        spec = chunk_registry()["casualties"]
+        first = build_prompt(spec, "one narrative", ["context"])
+        second = build_prompt(spec, "a different narrative", ["context"])
+        prefix = static_prefix(spec.name, spec.model, spec.is_list, spec.description)
+        assert first.startswith(prefix) and second.startswith(prefix)
+
+    def test_narrative_sits_at_the_end(self):
+        spec = chunk_registry()["incident"]
+        prompt = build_prompt(spec, NARRATIVE, ["context line"])
+        assert prompt.rstrip().endswith(NARRATIVE)
+
+    def test_enum_values_are_spelled_out(self):
+        spec = chunk_registry()["incident"]
+        prompt = build_prompt(spec, NARRATIVE, [])
+        assert "hazardous_conditions" in prompt
+
+
+# ---------------------------------------------------------------------------
+# The run
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    def test_extraction_completes_and_writes_a_draft_incident(self, db, mock_llm):
+        mock_llm()
+        extraction, job = seed(db)
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert result["status"] == "completed"
+        assert extraction.status == ExtractionStatus.completed
+        assert extraction.completed_at is not None
+        assert extraction.processing_time_seconds is not None
+        # The incident row owns the document, so the working copy is cleared.
+        assert extraction.partial_result is None
+
+        incident = get_incident_by_extract(db, extraction.extract_id)
+        assert incident is not None
+        contract = incident.incident_contract
+        assert contract["location"]["city"] == "Reno"
+        assert contract["incident"]["name"] == "Oak Street structure fire"
+        assert contract["schema_name"] == "fireform_incident_contract"
+
+    def test_promoted_columns_are_recomputed_from_the_contract(self, db, mock_llm):
+        mock_llm()
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        incident = get_incident_by_extract(db, extraction.extract_id)
+        assert incident.city == "Reno"
+        assert incident.state == "NV"
+        assert incident.civilian_injuries == 2
+        assert incident.incident_category == "fire"
+        assert incident.total_loss_amount == 50000
+        assert incident.call_to_arrival_seconds == 300
+        assert incident.on_scene_duration_seconds == 7200
+
+    def test_job_finishes(self, db, mock_llm):
+        mock_llm()
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        stored = get_job_by_uuid(db, job.job_id)
+        assert stored.status == "completed"
+        assert stored.progress_percent == 100
+        assert stored.result_url.endswith(str(extraction.extract_id))
+
+    def test_only_routed_chunks_are_asked_about(self, db, mock_llm):
+        calls: list[tuple[str, str]] = []
+        mock_llm(calls=calls)
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        asked = {name for name, _ in calls}
+        assert "casualties" in asked
+        assert "wildland" not in asked
+
+    def test_metadata_records_the_run(self, db, mock_llm):
+        mock_llm()
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        contract = get_incident_by_extract(db, extraction.extract_id).incident_contract
+        metadata = contract["extraction_metadata"]
+        assert metadata["extract_id"] == str(extraction.extract_id)
+        assert metadata["llm_model"]
+        assert 0 <= metadata["completeness"]["overall_percent"] <= 100
+
+
+class TestRetryAndFailure:
+    def test_a_rejected_answer_is_retried_once(self, db, mock_llm):
+        attempts = {"casualties": 0}
+
+        def answers_with_one_miss():
+            attempts["casualties"] += 1
+            if attempts["casualties"] == 1:
+                return {"total_civilian_injuries": "two civilians"}
+            return {"total_civilian_injuries": 2}
+
+        calls: list[tuple[str, str]] = []
+        mock_llm({**ANSWERS, "casualties": answers_with_one_miss}, calls=calls)
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert attempts["casualties"] == 2
+        retry_prompt = [p for name, p in calls if name == "casualties"][1]
+        assert "previous answer was rejected" in retry_prompt
+        contract = get_incident_by_extract(db, extraction.extract_id).incident_contract
+        assert contract["casualties"]["total_civilian_injuries"] == 2
+
+    def test_a_bad_field_is_dropped_and_the_rest_of_the_chunk_kept(self, db, mock_llm):
+        # One invented enum in a sub-field used to cost the whole section.
+        broken = {
+            **ANSWERS,
+            "losses": {
+                "property_loss": {"amount": 50000, "currency": "USD"},
+                "estimate_method": "a wild guess",
+            },
+        }
+        mock_llm(broken)
+        extraction, job = seed(db)
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert result["status"] == "completed"
+        assert "losses" not in result["failed_chunks"]
+        contract = get_incident_by_extract(db, extraction.extract_id).incident_contract
+        assert contract["losses"]["property_loss"]["amount"] == 50000
+        assert "estimate_method" not in contract["losses"]
+        assert "losses.estimate_method" in contract["extraction_metadata"]["completeness"]["missing_fields"]
+
+    def test_salvage_keeps_the_right_list_entries(self, db, mock_llm):
+        # Two bad entries in one list: deleting them must not shift the good one.
+        units = {
+            **ANSWERS,
+            "units": [
+                {"unit_id": "E12", "response_mode": "warp_speed"},
+                {"unit_id": "E13"},
+                {"unit_id": "E14", "response_mode": "teleport"},
+            ],
+        }
+        mock_llm(units)
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        stored = get_incident_by_extract(db, extraction.extract_id).incident_contract["units"]
+        assert [unit["unit_id"] for unit in stored] == ["E12", "E13", "E14"]
+        assert all("response_mode" not in unit for unit in stored)
+
+    def test_a_chunk_with_nothing_salvageable_is_left_empty(self, db, mock_llm):
+        # Its only field is unusable, so what survives the salvage pass is empty.
+        mock_llm({**ANSWERS, "casualties": {"total_civilian_injuries": "loads"}})
+        extraction, job = seed(db)
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert result["status"] == "completed"
+        contract = get_incident_by_extract(db, extraction.extract_id).incident_contract
+        assert "casualties" not in contract
+        missing = contract["extraction_metadata"]["completeness"]["missing_fields"]
+        assert "casualties" in missing
+        assert "casualties.total_civilian_injuries" in missing
+
+    def test_an_unusable_chunk_shape_is_reported_as_failed(self, db, mock_llm):
+        # A scalar where the section's object belongs: there is nothing to keep.
+        def scalar_casualties(prompt, model=None):
+            name = chunk_of(prompt)
+            return {name: "two people hurt" if name == "casualties" else ANSWERS.get(name, {})}
+
+        mock_llm(side_effect=scalar_casualties)
+        extraction, job = seed(db)
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert result["status"] == "completed"
+        assert "casualties" in result["failed_chunks"]
+        assert "casualties" not in get_incident_by_extract(db, extraction.extract_id).incident_contract
+
+    def test_a_timed_out_chunk_is_not_retried(self, db, mock_llm):
+        calls: list[str] = []
+
+        def slow_casualties(prompt, model=None):
+            name = chunk_of(prompt)
+            calls.append(name)
+            if name == "casualties":
+                raise ChunkTimeoutError("Ollama timed out after 300s")
+            return {name: ANSWERS.get(name, {})}
+
+        mock_llm(side_effect=slow_casualties)
+        extraction, job = seed(db)
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        # One attempt only: the same prompt on the same model takes the same time.
+        assert calls.count("casualties") == 1
+        assert "casualties" in result["failed_chunks"]
+        assert extraction.status == ExtractionStatus.completed
+
+    def test_run_fails_when_every_chunk_is_rejected(self, db, mock_llm):
+        def always_broken(prompt, model=None):
+            # A scalar where the chunk's object belongs: rejected every time.
+            return {chunk_of(prompt): "not an object"}
+
+        mock_llm(side_effect=always_broken)
+        extraction, job = seed(db)
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert result["status"] == "failed"
+        assert extraction.status == ExtractionStatus.failed
+        assert extraction.error_type == "EXTRACTION_FAILED"
+        assert get_incident_by_extract(db, extraction.extract_id) is None
+        assert get_job_by_uuid(db, job.job_id).status == "failed"
+
+    def test_ollama_down_fails_the_run(self, db, mock_llm):
+        def unreachable(prompt, model=None):
+            raise LLMUnavailableError("could not reach Ollama at http://ollama:11434")
+
+        mock_llm(side_effect=unreachable)
+        extraction, job = seed(db)
+
+        with pytest.raises(LLMUnavailableError):
+            run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert extraction.status == ExtractionStatus.failed
+        assert extraction.error_type == "LLM_UNAVAILABLE"
+        assert "could not reach Ollama" in extraction.error_detail
+        assert get_job_by_uuid(db, job.job_id).error["error_code"] == "LLM_UNAVAILABLE"
+
+    def test_empty_transcript_fails_before_any_call(self, db, mock_llm):
+        calls: list[tuple[str, str]] = []
+        mock_llm(calls=calls)
+        extraction, job = seed(db, transcript="   ")
+
+        result = run_extraction(db, extraction.extract_id, job.job_id)
+
+        assert result["status"] == "failed"
+        assert extraction.error_type == "EMPTY_INPUT"
+        assert calls == []
+
+    def test_a_missing_extraction_is_a_no_op(self, db, mock_llm):
+        from uuid import uuid4
+
+        mock_llm()
+        assert run_extraction(db, uuid4(), "job-does-not-exist")["status"] == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic post-steps
+# ---------------------------------------------------------------------------
+
+class TestDeterministicSteps:
+    def test_request_defaults_win_over_config(self):
+        context = resolve_context({"country": "IN", "timezone": "Asia/Kolkata", "currency": "INR"})
+        assert (context.country, context.timezone, context.currency) == ("IN", "Asia/Kolkata", "INR")
+
+    def test_unknown_timezone_falls_back_to_utc(self):
+        context = resolve_context({"timezone": "Mars/Olympus"})
+        assert str(context.zone) == "UTC"
+
+    def test_defaults_fill_country_currency_and_offset(self):
+        context = ExtractionContext(
+            country="IN",
+            timezone="Asia/Kolkata",
+            currency="INR",
+            now=datetime.now(timezone.utc),
+        )
+        filled = apply_context(
+            {
+                "location": {"city": "Pune"},
+                "losses": {"property_loss": {"amount": 1200}},
+                "incident": {"alarm_datetime": "2026-04-18T21:14:00"},
+            },
+            context,
+        )
+        assert filled["location"]["country"] == "IN"
+        assert filled["losses"]["property_loss"]["currency"] == "INR"
+        assert filled["incident"]["alarm_datetime"].endswith("+05:30")
+        assert filled["incident"]["timezone"] == "Asia/Kolkata"
+
+    def test_blank_answers_are_dropped_but_zero_is_kept(self):
+        context = ExtractionContext("US", "UTC", "USD", datetime.now(timezone.utc))
+        filled = apply_context(
+            {
+                "incident": {"name": "", "special_modifiers": [], "chimney_fire": False},
+                "casualties": {"total_civilian_injuries": 0},
+                "structure": {"floors": {"above_grade": ""}},
+            },
+            context,
+        )
+        assert "name" not in filled["incident"]
+        assert "special_modifiers" not in filled["incident"]
+        assert filled["incident"]["chimney_fire"] is False
+        assert filled["casualties"]["total_civilian_injuries"] == 0
+        assert "structure" not in filled
+
+    def test_currency_already_stated_is_left_alone(self):
+        context = ExtractionContext("US", "UTC", "USD", datetime.now(timezone.utc))
+        filled = apply_context({"losses": {"property_loss": {"amount": 10, "currency": "GBP"}}}, context)
+        assert filled["losses"]["property_loss"]["currency"] == "GBP"
+
+    def test_unit_turnout_and_travel_are_computed(self, db, mock_llm):
+        mock_llm()
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        unit = get_incident_by_extract(db, extraction.extract_id).incident_contract["units"][0]
+        assert unit["turnout_seconds"] == 120
+        assert unit["travel_seconds"] == 180
+
+    def test_computed_timings_beat_a_stated_duration(self, db, mock_llm):
+        # Models do state a duration that contradicts the times they just gave.
+        stated = {**ANSWERS, "units": [{**ANSWERS["units"][0], "turnout_seconds": 570}]}
+        mock_llm(stated)
+        extraction, job = seed(db)
+        run_extraction(db, extraction.extract_id, job.job_id)
+
+        unit = get_incident_by_extract(db, extraction.extract_id).incident_contract["units"][0]
+        assert unit["turnout_seconds"] == 120
+
+    def test_a_stated_duration_survives_when_there_is_nothing_to_compute(self):
+        context = ExtractionContext("US", "UTC", "USD", datetime.now(timezone.utc))
+        filled = apply_context({"units": [{"unit_id": "E12", "turnout_seconds": 95}]}, context)
+        assert filled["units"][0]["turnout_seconds"] == 95


### PR DESCRIPTION
# Extraction layer: the chunked extraction worker (#630)

#629 created the rows and dispatched a job, then left a stub. This makes the run real: a narrative goes in, a validated incident contract and a draft incident come out.

## Why chunked

The contract has 37 sections and about 600 fields. One incident fills a few of them. A structure fire never fills wildland or vehicle sections. One big prompt is slow, too large for a small local model, and pushes it to fill sections nobody spoke about. So the run asks one section at a time, in parallel, and only the sections the narrative supports. On the test narrative it asked 15 and skipped 14.

---

## How a run goes

**Routing lives in the contract, not in code.** Each section says whether it always runs, runs only on evidence words, runs last, or never goes to the model at all. Changing the routing means editing the contract.

The worker then:

- picks the sections, runs them in waves, core ones first, a few at a time
- validates each answer against that section's model and retries once with the reason named (more validation comes later)
- if the retry fails too, keeps the fields that pass and drops the rest, so one bad field does not cost a whole section. **This checks shape, not truth.** Fields only come out, never in, and every drop is recorded as a gap
- does the parts that need no model: strips blanks, fills default country and currency, adds the timezone offset to bare timestamps, computes each unit's turnout and travel time
- stitches the document, validates it, writes the draft incident that owns it from here on, recomputes the analytics columns, closes the job

Partial results are saved after each wave, so a poll mid run shows what has landed. A failed section does not sink the run, its fields just stay empty for review. The run fails only if the model server is down, the transcript is empty, or every section was rejected.

Each prompt is a fixed head plus a changing tail. The head holds the instructions and the section's field list and never changes, so the model server reuses its cache. The narrative goes last, because anywhere else kills that reuse. The field list is generated from the contract, so it cannot drift.

## Also in here

- The request's defaults and hints were accepted and then thrown away. They now reach the worker.
- A bug in the model generator: a field named after a date type shadowed that type, so the field rejected every value it was given.
- The production image did not ship the contract files the worker reads at startup. It does now.

---

## Tried on a real model and the observations

A 1.5b model on CPU, short structure fire narrative. 15 sections routed, contract and draft incident written, about **16 minutes**. That is the model at three tokens a second, not the pipeline.

Four fixes came out of it:

- a timed out section is not retried, the same prompt takes the same time
- answers are length capped, an unbounded small model repeats the whole field list back filled with nulls
- an answer cut off mid value used to parse as nothing. It is now trimmed to the last complete field and closed. Half written values never survive
- the model said a unit took 570 seconds when its own timestamps said 120. Arithmetic is not its job, so it is computed

The cap and the timeout go together. Past the timeout a section is lost, at the cap it keeps what it finished.

---

## What the output actually looks like

**The pipeline works end to end. The output is not trustworthy yet.** From that same run, things the model wrote that nobody said:

- a dispatch system event id, which can never be spoken
- a postal code and county, close to right, never mentioned (Thinking of using the already existing postal code - address service)
- coordinates 27 miles from the address (Thinking of building a new service which can translate address to lat/long. We must never rely on the AI for lat/long and even just by narration. This fix should be addressed in some point later)
- a casualty with a name, date of birth, race and insurance policy number (Hallicunation)

**Nothing here catches it.** A made up name is a valid string, so it passes every check and lands in the incident row looking like something a responder said.

Why:

1. The model is too small. It fills slots because it is shown slots.
2. The prompt shows every field of a section, which reads as a form to fill in.
3. Decoding only asks for valid JSON, not for the section's schema.
4. Nothing compares the answer to the narrative.
5. Some fields have no answer in a narrative. Coordinates and a postal code come from an address, not from speech.

---

### Few issues which i encountered and should be worked on anytime layer

1. Make the model swappable by env, local or hosted, so accuracy is not tied to what runs on a laptop CPU.
2. Mark the fields that are derived and keep them out of the prompt.
3. Check every value against the narrative before keeping it. Making the validation layer more robust.
4. Drop the completeness percentage. A run that invents half the contract scores well on it, which is worse than no number.
5. Geocode the address instead of asking the model for coordinates.

**Parent:** #550
**Closes:** #630
