### PR TITLE
Feat/extraction corrections

### DIFF
--- a/app/api/routes/extraction.py
+++ b/app/api/routes/extraction.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Body, Depends
 from sqlmodel import Session
 
 from app.api.deps import get_db
@@ -23,10 +23,43 @@ from app.db.repositories import (
     get_incident_by_extract,
     get_input,
 )
+from app.models import Extraction, Incident
 from app.services.extraction.service import ExtractionService
+from app.services.extraction_review import ExtractionReviewService, load_for_review
 from app.services.llm import check_ollama_available
 
 router = APIRouter(prefix="/extract", tags=["extraction"])
+
+MERGE_PATCH_MEDIA_TYPE = "application/merge-patch+json"
+
+
+def _completed_response(extraction: Extraction, incident: Incident | None) -> ExtractionCompleted:
+    """The completed shape, with the contract read from the incident row."""
+    contract = IncidentContract.model_validate(
+        (incident.incident_contract if incident else None) or {}
+    )
+    return ExtractionCompleted(
+        extract_id=extraction.extract_id,
+        input_id=extraction.input_id,
+        incident_id=incident.incident_id if incident else None,
+        status="completed",
+        incident_contract=contract,
+        completed_at=extraction.completed_at,
+        model_used=extraction.model_used,
+        processing_time_seconds=extraction.processing_time_seconds,
+        corrections=extraction.corrections,
+    )
+
+
+def _load_extraction(db: Session, extract_id: UUID) -> Extraction:
+    extraction = get_extraction(db, extract_id)
+    if extraction is None:
+        raise AppError(
+            f"Extraction with ID {extract_id} not found",
+            status_code=404,
+            error_code="EXTRACT_NOT_FOUND",
+        )
+    return extraction
 
 
 @router.post("/{input_id}", response_model=ExtractionJobResponse, status_code=202)
@@ -89,30 +122,10 @@ def create_extraction(
 
 @router.get("/{extract_id}", response_model=ExtractionCompleted | ExtractionProcessing)
 def get_extraction_result(extract_id: UUID, db: Session = Depends(get_db)):
-    extraction = get_extraction(db, extract_id)
-    if extraction is None:
-        raise AppError(
-            f"Extraction with ID {extract_id} not found",
-            status_code=404,
-            error_code="EXTRACT_NOT_FOUND",
-        )
+    extraction = _load_extraction(db, extract_id)
 
     if extraction.status == ExtractionStatus.completed:
-        incident = get_incident_by_extract(db, extract_id)
-        contract = IncidentContract.model_validate(
-            (incident.incident_contract if incident else None) or {}
-        )
-        return ExtractionCompleted(
-            extract_id=extraction.extract_id,
-            input_id=extraction.input_id,
-            incident_id=incident.incident_id if incident else None,
-            status="completed",
-            incident_contract=contract,
-            completed_at=extraction.completed_at,
-            model_used=extraction.model_used,
-            processing_time_seconds=extraction.processing_time_seconds,
-            corrections=extraction.corrections,
-        )
+        return _completed_response(extraction, get_incident_by_extract(db, extract_id))
 
     retry_after = (
         EXTRACTION_POLL_INTERVAL_SECONDS
@@ -134,3 +147,23 @@ def get_extraction_result(extract_id: UUID, db: Session = Depends(get_db)):
         error_detail=extraction.error_detail,
         partial_result=partial,
     )
+
+
+@router.patch("/{extract_id}", response_model=ExtractionCompleted)
+def update_extraction(
+    extract_id: UUID,
+    patch: dict = Body(
+        ...,
+        media_type=MERGE_PATCH_MEDIA_TYPE,
+        description="JSON Merge Patch (RFC 7396) shaped like the incident contract. "
+        "Only send the fields that changed; a null deletes a field.",
+    ),
+    db: Session = Depends(get_db),
+):
+    extraction = _load_extraction(db, extract_id)
+    incident = load_for_review(extraction, get_incident_by_extract(db, extract_id))
+
+    extraction, incident = ExtractionReviewService().apply_patch(
+        db, extraction, incident, patch
+    )
+    return _completed_response(extraction, incident)

--- a/app/core/errors/base.py
+++ b/app/core/errors/base.py
@@ -21,3 +21,23 @@ class AppError(Exception):
         self.status_code = status_code
         self.error_code = error_code or _default_error_code(status_code)
         self.detail = detail
+
+
+class ValidationAppError(AppError):
+    """A 422 raised by a service with field-level issues attached.
+
+    Request-shape problems are caught by FastAPI and rendered from
+    RequestValidationError. This is for the ones only the service can see, such
+    as a correction whose merged document no longer matches the contract, and
+    it renders the same validation_errors list so clients read one shape.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        validation_errors: list[dict] | None = None,
+        error_code: str = "VALIDATION_ERROR",
+        detail: dict | None = None,
+    ):
+        super().__init__(message, status_code=422, error_code=error_code, detail=detail)
+        self.validation_errors = validation_errors or []

--- a/app/core/errors/handlers.py
+++ b/app/core/errors/handlers.py
@@ -5,7 +5,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
 from app.core.config import RETRY_AFTER_SECONDS
-from app.core.errors.base import AppError
+from app.core.errors.base import AppError, ValidationAppError
 
 
 def _jsonable(value):
@@ -33,6 +33,18 @@ def register_exception_handlers(app):
             body["detail"] = exc.detail
         if exc.status_code == 503:
             body["retry_after_seconds"] = RETRY_AFTER_SECONDS
+        return JSONResponse(status_code=exc.status_code, content=body)
+
+    @app.exception_handler(ValidationAppError)
+    async def validation_app_error_handler(request: Request, exc: ValidationAppError):
+        body: dict = {"error_code": exc.error_code, "message": exc.message}
+        if exc.detail is not None:
+            body["detail"] = exc.detail
+        if exc.validation_errors:
+            body["validation_errors"] = [
+                {**error, "value": _jsonable(error.get("value"))}
+                for error in exc.validation_errors
+            ]
         return JSONResponse(status_code=exc.status_code, content=body)
 
     @app.exception_handler(RequestValidationError)

--- a/app/services/extraction_review.py
+++ b/app/services/extraction_review.py
@@ -1,0 +1,297 @@
+"""Review-screen write path for an extraction.
+
+A responder fixes a wrong value, adds a missing one or drops one the model
+invented. The correction arrives as a JSON Merge Patch (RFC 7396) shaped like
+the incident contract, and this module applies it to the contract document on
+the linked incident row, which is the single store of incident data.
+
+Everything here works on plain dicts and repository calls, no FastAPI. The
+route stays a thin handler.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import UnionType
+from typing import Any, Union, get_args, get_origin
+
+from pydantic import BaseModel, ValidationError
+from sqlmodel import Session
+
+from app.api.schemas.enums import ExtractionStatus, ReportStatus
+from app.api.schemas.incident_contract import IncidentContract
+from app.core.errors.base import AppError, ValidationAppError
+from app.db.repositories import update_extraction, update_incident
+from app.models import Extraction, Incident
+from app.services.incidents import promote
+
+# Deleting a key is the whole point of RFC 7396, so a null in the patch is a
+# delete, never a value. Kept as a name so the intent reads at the call sites.
+DELETE = None
+
+
+# ---------------------------------------------------------------------------
+# RFC 7396 merge patch
+# ---------------------------------------------------------------------------
+
+def merge_patch(target: Any, patch: Any) -> Any:
+    """Apply a JSON Merge Patch to a document (RFC 7396).
+
+    A non-object patch replaces the target outright. Inside an object, a null
+    removes the key, a nested object merges recursively, anything else
+    replaces.
+    """
+    if not isinstance(patch, dict):
+        return patch
+
+    result = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is DELETE:
+            result.pop(key, None)
+        else:
+            result[key] = merge_patch(result.get(key), value)
+    return result
+
+
+def patch_paths(patch: dict, prefix: str = "") -> list[tuple[str, Any]]:
+    """Every leaf of the patch as a (dotted path, value) pair.
+
+    Nested objects are walked so a patch that only touches
+    ``losses.property_loss.amount`` records that one path and not its parents.
+    A list, a scalar and an empty object are leaves: the merge replaces them
+    whole, so that is the level a correction is recorded at.
+    """
+    leaves: list[tuple[str, Any]] = []
+    for key, value in patch.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict) and value:
+            leaves.extend(patch_paths(value, path))
+        else:
+            leaves.append((path, value))
+    return leaves
+
+
+def value_at(document: Any, path: str) -> Any:
+    """Value at a dotted path, or None when any step is missing."""
+    current = document
+    for key in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Field path checking
+# ---------------------------------------------------------------------------
+
+def _model_of(annotation: Any) -> type[BaseModel] | None:
+    """The contract submodel behind an annotation, or None.
+
+    Generated fields are Optional and sometimes list-valued. A list is not
+    walked into (a patch replaces the whole list), so only a plain object
+    annotation yields a model.
+    """
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        for arg in get_args(annotation):
+            if arg is type(None):
+                continue
+            return _model_of(arg)
+        return None
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    return None
+
+
+def _is_open_mapping(annotation: Any) -> bool:
+    """True for a free-form object like custom_fields, whose keys are open."""
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        return any(
+            _is_open_mapping(arg) for arg in get_args(annotation) if arg is not type(None)
+        )
+    return origin is dict
+
+
+def unknown_paths(patch: dict, model: type[BaseModel], prefix: str = "") -> list[str]:
+    """Dotted paths in the patch that the contract has no field for.
+
+    The generated models ignore unknown keys, so without this check a typo
+    would be accepted and then silently dropped on the way to the database.
+    Open mappings such as custom_fields accept any key by design.
+    """
+    unknown: list[str] = []
+    for key, value in patch.items():
+        path = f"{prefix}.{key}" if prefix else key
+        field = model.model_fields.get(key)
+        if field is None:
+            unknown.append(path)
+            continue
+        if not isinstance(value, dict) or not value:
+            continue
+        if _is_open_mapping(field.annotation):
+            continue
+        submodel = _model_of(field.annotation)
+        if submodel is not None:
+            unknown.extend(unknown_paths(value, submodel, path))
+    return unknown
+
+
+def _validation_errors(exc: ValidationError) -> list[dict]:
+    """Pydantic errors as the contract's validation_errors entries."""
+    errors = []
+    for error in exc.errors():
+        path = ".".join(str(part) for part in error.get("loc", ()))
+        errors.append({
+            "field": path or None,
+            "issue": error.get("msg"),
+            "value": error.get("input"),
+        })
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Corrections
+# ---------------------------------------------------------------------------
+
+def correction_entries(
+    patch: dict,
+    before: dict,
+    after: dict,
+    corrected_at: datetime,
+    corrected_by: str | None = None,
+) -> list[dict]:
+    """Audit entries for the paths the patch actually changed.
+
+    A path whose value is the same before and after is a no-op and is not
+    recorded, so the trail stays a history of real edits.
+    """
+    entries = []
+    for path, _ in patch_paths(patch):
+        original = value_at(before, path)
+        corrected = value_at(after, path)
+        if original == corrected:
+            continue
+        entries.append({
+            "field_path": path,
+            "original_value": original,
+            "corrected_value": corrected,
+            "corrected_at": corrected_at.isoformat(),
+            "corrected_by": corrected_by,
+        })
+    return entries
+
+
+class ExtractionReviewService:
+    """Applies manual corrections to a completed extraction."""
+
+    def apply_patch(
+        self,
+        session: Session,
+        extraction: Extraction,
+        incident: Incident,
+        patch: dict,
+        corrected_by: str | None = None,
+    ) -> tuple[Extraction, Incident]:
+        """Merge the patch into the contract, then rewrite everything derived.
+
+        The document, the promoted analytics columns and the corrections trail
+        all move together in one call so they can never disagree.
+        """
+        self._reject_locked(incident)
+        self._reject_unknown_paths(patch)
+
+        before = incident.incident_contract or {}
+        merged = merge_patch(before, patch)
+        after = self._validated(merged)
+
+        now = datetime.now(timezone.utc)
+        entries = correction_entries(patch, before, after, now, corrected_by)
+
+        incident.incident_contract = after
+        for column, value in promote(after).items():
+            setattr(incident, column, value)
+        incident.updated_at = now
+        incident = update_incident(session, incident)
+
+        if entries:
+            # Reassign rather than append: SQLModel tracks JSON columns by
+            # identity, so mutating the list in place would not be persisted.
+            extraction.corrections = (extraction.corrections or []) + entries
+            extraction.updated_at = now
+            extraction = update_extraction(session, extraction)
+
+        return extraction, incident
+
+    def _reject_locked(self, incident: Incident) -> None:
+        if incident.status == ReportStatus.submitted:
+            raise AppError(
+                "Cannot modify extraction incident report has been submitted",
+                status_code=409,
+                error_code="EXTRACT_LOCKED",
+                detail={
+                    "report_status": incident.status,
+                    "submitted_at": incident.updated_at.isoformat()
+                    if incident.updated_at
+                    else None,
+                },
+            )
+
+    def _reject_unknown_paths(self, patch: dict) -> None:
+        unknown = unknown_paths(patch, IncidentContract)
+        if unknown:
+            raise ValidationAppError(
+                "Invalid field path or value in patch",
+                validation_errors=[
+                    {
+                        "field": path,
+                        "issue": "Unknown field path in the incident contract",
+                        "value": value_at(patch, path),
+                    }
+                    for path in unknown
+                ],
+            )
+
+    def _validated(self, merged: dict) -> dict:
+        """Validate the merged document and return it normalized.
+
+        Dumping the validated model back out is what strips the keys a delete
+        removed and settles types (dates, enums) into their JSON form, so the
+        stored document always matches the contract.
+        """
+        try:
+            model = IncidentContract.model_validate(merged)
+        except ValidationError as exc:
+            raise ValidationAppError(
+                "Invalid field path or value in patch",
+                validation_errors=_validation_errors(exc),
+            ) from exc
+        return model.model_dump(mode="json", exclude_none=True)
+
+
+def load_for_review(extraction: Extraction, incident: Incident | None) -> Incident:
+    """The incident row a correction writes to, or the reason there is none.
+
+    An extraction that has not completed has no contract document yet, so
+    there is nothing to correct.
+    """
+    if extraction.status != ExtractionStatus.completed or incident is None:
+        raise AppError(
+            f"Extraction is in '{extraction.status}' state. Wait until status is 'completed'.",
+            status_code=409,
+            error_code="EXTRACT_NOT_COMPLETED",
+            detail={"current_status": extraction.status},
+        )
+    return incident
+
+
+__all__ = [
+    "ExtractionReviewService",
+    "correction_entries",
+    "load_for_review",
+    "merge_patch",
+    "patch_paths",
+    "unknown_paths",
+    "value_at",
+]

--- a/contracts/path/extraction.yaml
+++ b/contracts/path/extraction.yaml
@@ -238,17 +238,27 @@ extract_by_id:
             schema:
               $ref: "../schemas/common.yaml#/ErrorResponse"
       "409":
-        description: Extraction is locked (already submitted)
+        description: Conflict extraction locked or not yet completed
         content:
           application/json:
             schema:
               $ref: "../schemas/common.yaml#/ErrorResponse"
-            example:
-              error_code: "EXTRACT_LOCKED"
-              message: "Cannot modify extraction incident report has been submitted"
-              detail:
-                report_status: "submitted"
-                submitted_at: "2024-07-15T18:00:00Z"
+            examples:
+              locked:
+                summary: Report already submitted
+                value:
+                  error_code: "EXTRACT_LOCKED"
+                  message: "Cannot modify extraction incident report has been submitted"
+                  detail:
+                    report_status: "submitted"
+                    submitted_at: "2024-07-15T18:00:00Z"
+              not_completed:
+                summary: Extraction still running, no document to correct yet
+                value:
+                  error_code: "EXTRACT_NOT_COMPLETED"
+                  message: "Extraction is in 'processing' state. Wait until status is 'completed'."
+                  detail:
+                    current_status: "processing"
       "422":
         description: Invalid field path or value
         content:

--- a/tests/test_v1_extraction_corrections.py
+++ b/tests/test_v1_extraction_corrections.py
@@ -1,0 +1,302 @@
+"""Tests for PATCH /api/v1/extract/{extract_id}.
+
+The review-screen write path: a merge patch lands on the contract document
+held by the incident row, the promoted analytics columns are recomputed from
+it, and every real change is appended to the corrections trail.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.api.schemas.enums import ExtractionStatus, InputStatus, InputType, ReportStatus
+from app.db.repositories import (
+    create_extraction,
+    create_incident,
+    create_input,
+    get_extraction,
+    get_incident,
+)
+from app.api.schemas.incident_contract import IncidentContract
+from app.models import Extraction, Incident, Input
+from app.services.extraction_review import merge_patch, patch_paths, unknown_paths
+
+URL = "/api/v1/extract"
+MERGE_PATCH = {"Content-Type": "application/merge-patch+json"}
+
+_CONTRACT = {
+    "schema_version": "1.1.0",
+    "schema_name": "fireform_incident_contract",
+    "incident": {"name": "Bear Creek Wildfire"},
+    "location": {"city": "Reno", "state": "NV", "country": "US"},
+    "casualties": {"total_civilian_injuries": 1, "total_responder_injuries": 0},
+    "losses": {"property_loss": {"amount": 10000, "currency": "USD"}},
+    "fire": {"cause_certainty": "suspected"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+def _seed(
+    db,
+    contract=None,
+    extraction_status=ExtractionStatus.completed,
+    report_status=ReportStatus.draft,
+) -> tuple[Extraction, Incident]:
+    now = datetime.now(timezone.utc)
+    inp = create_input(
+        db,
+        Input(
+            input_type=InputType.text,
+            status=InputStatus.ready,
+            transcript="Structure fire at 42 Oak St, one civilian injury.",
+            created_at=now,
+            updated_at=now,
+        ),
+    )
+    extraction = create_extraction(
+        db,
+        Extraction(
+            input_id=inp.input_id,
+            status=extraction_status,
+            started_at=now,
+            completed_at=now if extraction_status == ExtractionStatus.completed else None,
+            model_used="qwen2.5:1.5b",
+        ),
+    )
+    incident = create_incident(
+        db,
+        Incident(
+            extract_id=extraction.extract_id,
+            status=report_status,
+            incident_contract=_CONTRACT if contract is None else contract,
+        ),
+    )
+    return extraction, incident
+
+
+def _patch(client, extract_id, body):
+    return client.patch(f"{URL}/{extract_id}", json=body, headers=MERGE_PATCH)
+
+
+# ---------------------------------------------------------------------------
+# The merge itself
+# ---------------------------------------------------------------------------
+
+class TestMergePatch:
+
+    def test_nested_keys_merge_not_replace(self):
+        target = {"losses": {"property_loss": {"amount": 1, "currency": "USD"}}}
+        merged = merge_patch(target, {"losses": {"property_loss": {"amount": 2}}})
+        assert merged["losses"]["property_loss"] == {"amount": 2, "currency": "USD"}
+
+    def test_null_deletes_the_key(self):
+        merged = merge_patch({"a": 1, "b": 2}, {"b": None})
+        assert merged == {"a": 1}
+
+    def test_null_for_absent_key_is_a_no_op(self):
+        assert merge_patch({"a": 1}, {"b": None}) == {"a": 1}
+
+    def test_list_is_replaced_whole(self):
+        merged = merge_patch({"units": [{"id": "E1"}, {"id": "E2"}]}, {"units": [{"id": "E3"}]})
+        assert merged["units"] == [{"id": "E3"}]
+
+    def test_target_is_not_mutated(self):
+        target = {"incident": {"name": "old"}}
+        merge_patch(target, {"incident": {"name": "new"}})
+        assert target["incident"]["name"] == "old"
+
+    def test_patch_paths_walks_to_leaves(self):
+        paths = dict(patch_paths({"losses": {"property_loss": {"amount": 250000}}, "a": None}))
+        assert paths == {"losses.property_loss.amount": 250000, "a": None}
+
+    def test_unknown_paths_reports_dotted_path(self):
+        assert unknown_paths({"losses": {"nope": 1}}, IncidentContract) == ["losses.nope"]
+
+    def test_custom_fields_keys_are_open(self):
+        patch = {"custom_fields": {"state_texas.marshal_signature_name": "A. Ruiz"}}
+        assert unknown_paths(patch, IncidentContract) == []
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/v1/extract/{extract_id}
+# ---------------------------------------------------------------------------
+
+class TestUpdateExtraction:
+
+    def test_200_applies_the_correction(self, client, db):
+        extraction, incident = _seed(db)
+        resp = _patch(
+            client,
+            extraction.extract_id,
+            {"losses": {"property_loss": {"amount": 250000}}},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "completed"
+        assert body["incident_id"] == str(incident.incident_id)
+        loss = body["incident_contract"]["losses"]["property_loss"]
+        # The untouched sibling survives the merge.
+        assert loss == {"amount": 250000, "currency": "USD"}
+
+    def test_200_writes_the_document_to_the_incident_row(self, client, db):
+        extraction, incident = _seed(db)
+        _patch(client, extraction.extract_id, {"incident": {"name": "Bear Creek Fire"}})
+        db.expire_all()
+        stored = get_incident(db, incident.incident_id)
+        assert stored.incident_contract["incident"]["name"] == "Bear Creek Fire"
+
+    def test_200_recomputes_promoted_columns(self, client, db):
+        extraction, incident = _seed(db)
+        _patch(
+            client,
+            extraction.extract_id,
+            {
+                "casualties": {"total_responder_injuries": 2},
+                "losses": {"property_loss": {"amount": 250000}},
+                "location": {"city": "Sparks"},
+            },
+        )
+        db.expire_all()
+        stored = get_incident(db, incident.incident_id)
+        assert stored.responder_injuries == 2
+        assert stored.total_loss_amount == 250000
+        assert stored.total_loss_currency == "USD"
+        assert stored.city == "Sparks"
+
+    def test_200_null_deletes_a_field(self, client, db):
+        extraction, incident = _seed(db)
+        resp = _patch(client, extraction.extract_id, {"fire": {"cause_certainty": None}})
+        assert resp.status_code == 200
+        assert resp.json()["incident_contract"]["fire"]["cause_certainty"] is None
+        # The stored document drops the key outright, per RFC 7396. The response
+        # still carries it as null because the contract model serializes every
+        # field, the same way GET does.
+        db.expire_all()
+        stored = get_incident(db, incident.incident_id)
+        assert "cause_certainty" not in stored.incident_contract.get("fire", {})
+
+    def test_200_delete_clears_the_promoted_column(self, client, db):
+        extraction, incident = _seed(db)
+        _patch(client, extraction.extract_id, {"losses": {"property_loss": None}})
+        db.expire_all()
+        stored = get_incident(db, incident.incident_id)
+        assert stored.total_loss_amount is None
+        assert stored.total_loss_currency is None
+
+    def test_200_records_the_audit_trail(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(
+            client,
+            extraction.extract_id,
+            {"casualties": {"total_responder_injuries": 2}},
+        )
+        corrections = resp.json()["corrections"]
+        assert len(corrections) == 1
+        entry = corrections[0]
+        assert entry["field_path"] == "casualties.total_responder_injuries"
+        assert entry["original_value"] == 0
+        assert entry["corrected_value"] == 2
+        assert entry["corrected_at"] is not None
+
+    def test_200_audit_trail_records_a_delete(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(client, extraction.extract_id, {"fire": {"cause_certainty": None}})
+        entry = resp.json()["corrections"][0]
+        assert entry["field_path"] == "fire.cause_certainty"
+        assert entry["original_value"] == "suspected"
+        assert entry["corrected_value"] is None
+
+    def test_200_audit_trail_appends_across_calls(self, client, db):
+        extraction, _ = _seed(db)
+        _patch(client, extraction.extract_id, {"incident": {"name": "First"}})
+        resp = _patch(client, extraction.extract_id, {"incident": {"name": "Second"}})
+        db.expire_all()
+        stored = get_extraction(db, extraction.extract_id)
+        assert len(stored.corrections) == 2
+        assert [c["corrected_value"] for c in resp.json()["corrections"]] == ["First", "Second"]
+
+    def test_200_unchanged_value_is_not_recorded(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(client, extraction.extract_id, {"incident": {"name": "Bear Creek Wildfire"}})
+        assert resp.status_code == 200
+        assert not resp.json()["corrections"]
+
+    def test_200_adds_a_custom_field(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(
+            client,
+            extraction.extract_id,
+            {"custom_fields": {"state_texas.marshal_signature_name": "A. Ruiz"}},
+        )
+        assert resp.status_code == 200
+        custom = resp.json()["incident_contract"]["custom_fields"]
+        assert custom["state_texas.marshal_signature_name"] == "A. Ruiz"
+
+    def test_404_extraction_not_found(self, client, db):
+        resp = _patch(client, uuid4(), {"incident": {"name": "x"}})
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "EXTRACT_NOT_FOUND"
+
+    def test_409_extraction_still_processing(self, client, db):
+        extraction, _ = _seed(db, extraction_status=ExtractionStatus.processing)
+        resp = _patch(client, extraction.extract_id, {"incident": {"name": "x"}})
+        assert resp.status_code == 409
+        assert resp.json()["error_code"] == "EXTRACT_NOT_COMPLETED"
+
+    def test_409_locked_after_submission(self, client, db):
+        extraction, incident = _seed(db, report_status=ReportStatus.submitted)
+        resp = _patch(client, extraction.extract_id, {"incident": {"name": "x"}})
+        assert resp.status_code == 409
+        body = resp.json()
+        assert body["error_code"] == "EXTRACT_LOCKED"
+        assert body["detail"]["report_status"] == "submitted"
+        db.expire_all()
+        stored = get_incident(db, incident.incident_id)
+        assert stored.incident_contract["incident"]["name"] == "Bear Creek Wildfire"
+
+    def test_422_invalid_enum_value(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(client, extraction.extract_id, {"fire": {"cause_certainty": "maybe"}})
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["error_code"] == "VALIDATION_ERROR"
+        assert body["validation_errors"][0]["field"] == "fire.cause_certainty"
+        assert body["validation_errors"][0]["value"] == "maybe"
+
+    def test_422_unknown_field_path(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(client, extraction.extract_id, {"losses": {"imaginary_loss": 5}})
+        assert resp.status_code == 422
+        assert resp.json()["validation_errors"][0]["field"] == "losses.imaginary_loss"
+
+    def test_422_wrong_type_for_a_field(self, client, db):
+        extraction, _ = _seed(db)
+        resp = _patch(
+            client,
+            extraction.extract_id,
+            {"casualties": {"total_responder_injuries": "two"}},
+        )
+        assert resp.status_code == 422
+        assert resp.json()["validation_errors"][0]["field"] == (
+            "casualties.total_responder_injuries"
+        )
+
+    def test_422_leaves_the_document_untouched(self, client, db):
+        extraction, incident = _seed(db)
+        _patch(client, extraction.extract_id, {"fire": {"cause_certainty": "maybe"}})
+        db.expire_all()
+        stored = get_incident(db, incident.incident_id)
+        assert stored.incident_contract["fire"]["cause_certainty"] == "suspected"
+        assert get_extraction(db, extraction.extract_id).corrections is None
+
+    def test_422_non_json_body_does_not_500(self, client, db):
+        extraction, _ = _seed(db)
+        resp = client.patch(
+            f"{URL}/{extraction.extract_id}",
+            content=b"not json",
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.status_code == 422
+        assert resp.json()["error_code"] == "VALIDATION_ERROR"


### PR DESCRIPTION
# Extraction layer: manual corrections on an extraction (#631)

## Why

Extraction gets some things wrong. The review screen needs a way to fix a bad value, add a missed one, and drop one the model invented. Until now an extraction was read only once the job finished.

## What this adds

`PATCH /api/v1/extract/{extract_id}`, a JSON merge patch (RFC 7396) shaped like the incident contract:

- Send only what changed. Nested objects merge, so a sibling field is not wiped.
- `null` deletes a field. Lists are replaced whole.
- The merged document is validated, written to the incident row, and the promoted analytics columns are recomputed by the same `promote` the worker uses.
- Every path that really changed is appended to the corrections trail with the value before, the value after and a timestamp. A patch that sets a field to what it already held records nothing.
- Returns the same completed shape as `GET`, so the screen renders straight from it.

## Errors

- 404 `EXTRACT_NOT_FOUND`
- 409 `EXTRACT_LOCKED` when the report is submitted
- 409 `EXTRACT_NOT_COMPLETED` when the job is still running
- 422 `VALIDATION_ERROR` with the field, the reason and the value

Unknown field paths are worth a note. The generated contract models ignore keys they do not know, so a typo like `losses.imaginary_loss` used to be accepted and then dropped on the way to the database. The patch is now checked against the contract field tree first and a typo comes back as a 422 naming the path. Keys under `custom_fields` stay open.

## Contract change

PATCH listed only the locked case under 409. Patching an extraction that has not finished is the same class of problem, so the 409 now carries both examples.

 **Closes:** #631

