### PR TITLE
Consolidate duplicated path/PDF helpers into shared leaf modules (#654)

### DIFF
--- a/app/api/routes/forms.py
+++ b/app/api/routes/forms.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import requests
 from fastapi import APIRouter, Depends, File, UploadFile, Query
 from sqlmodel import Session
@@ -10,29 +9,12 @@ from app.api.schemas.forms import (
     ModelsResponse,
     TranscriptionResponse,
 )
-from app.core.config import OLLAMA_HOST, OLLAMA_MODEL, BASE_DIR, RETENTION_PERIOD_DAYS
+from app.core import paths
+from app.core.config import OLLAMA_HOST, OLLAMA_MODEL, RETENTION_PERIOD_DAYS
 from app.services.whisper import call_whisper_asr
 from app.core.errors.base import AppError
 from app.db.repositories import get_template, get_form_submission, delete_form_submission
 from app.services.form import FormService
-
-PROJECT_ROOT = BASE_DIR
-
-def _resolve_project_file(file_path: str) -> Path:
-    raw_path = (file_path or "").strip()
-    if not raw_path:
-        raise AppError("Path is required", status_code=400)
-
-    candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = (PROJECT_ROOT / candidate).resolve()
-    else:
-        candidate = candidate.resolve()
-
-    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
-        raise AppError("Path must be inside the project", status_code=400)
-
-    return candidate
 
 router = APIRouter(prefix="/forms", tags=["forms"])
 
@@ -106,7 +88,7 @@ def delete_submission_endpoint(submission_id: int, db: Session = Depends(get_db)
 
     if sub.output_pdf_path:
         try:
-            resolved_out = _resolve_project_file(sub.output_pdf_path)
+            resolved_out = paths._resolve_project_file(sub.output_pdf_path)
             if resolved_out.exists() and resolved_out.is_file():
                 resolved_out.unlink()
         except Exception:

--- a/app/core/paths.py
+++ b/app/core/paths.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from app.core.config import BASE_DIR, DEFAULT_TEMPLATE_DIR
+
+PROJECT_ROOT = BASE_DIR
+
+
+def _resolve_target_directory(directory: str) -> Path:
+    dir_value = (directory or DEFAULT_TEMPLATE_DIR).strip()
+    if not dir_value:
+        raise HTTPException(status_code=400, detail="Directory is required.")
+
+    candidate = Path(dir_value)
+    if not candidate.is_absolute():
+        candidate = (PROJECT_ROOT / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
+        raise HTTPException(status_code=400, detail="Directory must be inside the project.")
+
+    return candidate
+
+
+def _resolve_project_file(file_path: str) -> Path:
+    raw_path = (file_path or "").strip()
+    if not raw_path:
+        raise HTTPException(status_code=400, detail="Path is required.")
+
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = (PROJECT_ROOT / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
+        raise HTTPException(status_code=400, detail="Path must be inside the project.")
+
+    return candidate

--- a/app/core/pdf_utils.py
+++ b/app/core/pdf_utils.py
@@ -1,0 +1,55 @@
+import re
+from pathlib import Path
+
+from app.core import paths
+
+# PDF field-type codes -> the type values the frontend field builder uses.
+_FIELD_TYPE_BY_FT = {"/Tx": "string", "/Btn": "checkbox", "/Ch": "list", "/Sig": "signature"}
+
+
+def _pdf_text(value) -> str:
+    """Decode a pdfrw string (field name / tooltip) to plain text."""
+    if value is None:
+        return ""
+    if hasattr(value, "to_unicode"):
+        return value.to_unicode().strip()
+    return str(value).strip()
+
+
+def _humanize(name: str) -> str:
+    """Turn a raw field name into a readable description (JobTitle -> Job Title)."""
+    text = re.sub(r"_+", " ", name)
+    text = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _extract_pdf_fields(pdf_path: str) -> list[dict] | None:
+    """Fillable widgets in the same order Filler.fill_form writes them
+    (top-to-bottom, left-to-right per page), so seeded rows line up with the
+    fill order. Returns None if the PDF can't be read."""
+    try:
+        from pdfrw import PdfReader
+        candidate = Path(pdf_path)
+        if not candidate.is_absolute():
+            candidate = (paths.PROJECT_ROOT / candidate).resolve()
+        pdf = PdfReader(str(candidate))
+        fields: list[dict] = []
+        for page in pdf.pages:
+            widgets = [a for a in (page.Annots or []) if a.Subtype == "/Widget" and a.T]
+            widgets.sort(key=lambda a: (-float(a.Rect[1]), float(a.Rect[0])))
+            for annot in widgets:
+                name = _pdf_text(annot.T)
+                fields.append({
+                    "name": name,
+                    "description": _pdf_text(annot.TU) or _humanize(name),
+                    "type": _FIELD_TYPE_BY_FT.get(str(annot.FT), "string"),
+                })
+        return fields
+    except Exception:
+        return None
+
+
+def _count_pdf_widgets(pdf_path: str) -> int | None:
+    """Number of fillable widgets in a PDF, or None if unreadable."""
+    fields = _extract_pdf_fields(pdf_path)
+    return None if fields is None else len(fields)

--- a/app/services/filler.py
+++ b/app/services/filler.py
@@ -1,23 +1,7 @@
 from pdfrw import PdfReader, PdfWriter
+from app.core.pdf_utils import _pdf_text
 from app.services.llm import LLM
 from datetime import datetime
-
-
-def _pdf_text(value) -> str:
-    """Decode a pdfrw string (field name / tooltip) to plain text.
-
-    Duplicated from app.services.template._pdf_text — importing it directly
-    would create a circular import (template -> controller ->
-    file_manipulator -> filler -> template). Keep these in sync: this must
-    normalize a widget name exactly the way template.py normalizes it when
-    it names the widget, so textbox_answers keys and widget names compare
-    equal.
-    """
-    if value is None:
-        return ""
-    if hasattr(value, "to_unicode"):
-        return value.to_unicode().strip()
-    return str(value).strip()
 
 
 class Filler:

--- a/app/services/form.py
+++ b/app/services/form.py
@@ -1,13 +1,11 @@
 import re
 from collections import Counter
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from uuid import UUID
 
 from sqlmodel import Session
 
-from app.core.config import BASE_DIR
-from app.core.errors.base import AppError
+from app.core import paths
 from app.db.repositories import (
     create_form,
     delete_form_submission,
@@ -19,8 +17,6 @@ from app.models import FormSubmission, Template
 from app.services.controller import Controller
 from app.services.input import InputService
 
-PROJECT_ROOT = BASE_DIR
-
 _STOPWORDS = {
     "the", "and", "a", "of", "to", "in", "is", "that", "it", "was", "for", "on",
     "as", "with", "by", "at", "an", "be", "this", "are", "from", "or", "have",
@@ -31,23 +27,6 @@ _STOPWORDS = {
     "left", "right", "pain", "due", "after", "before", "emergency", "department",
     "medical", "clinical"
 }
-
-
-def _resolve_project_file(file_path: str) -> Path:
-    raw_path = (file_path or "").strip()
-    if not raw_path:
-        raise AppError("Path is required", status_code=400)
-
-    candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = (PROJECT_ROOT / candidate).resolve()
-    else:
-        candidate = candidate.resolve()
-
-    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
-        raise AppError("Path must be inside the project", status_code=400)
-
-    return candidate
 
 
 class FormService:
@@ -140,7 +119,7 @@ class FormService:
         for sub in submissions:
             if sub.output_pdf_path:
                 try:
-                    resolved_out = _resolve_project_file(sub.output_pdf_path)
+                    resolved_out = paths._resolve_project_file(sub.output_pdf_path)
                     if resolved_out.exists() and resolved_out.is_file():
                         resolved_out.unlink()
                 except Exception:

--- a/app/services/template.py
+++ b/app/services/template.py
@@ -1,8 +1,6 @@
-import re
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import HTTPException
 from sqlmodel import Session
 
 from app.api.schemas.templates import (
@@ -11,7 +9,8 @@ from app.api.schemas.templates import (
     TemplateResponse,
     TemplateUploadResponse,
 )
-from app.core.config import BASE_DIR, DEFAULT_TEMPLATE_DIR
+from app.core import paths
+from app.core.pdf_utils import _count_pdf_widgets, _extract_pdf_fields
 from app.db.repositories import (
     create_template,
     delete_template,
@@ -22,94 +21,6 @@ from app.db.repositories import (
 from app.models import Template
 from app.services.controller import Controller
 
-PROJECT_ROOT = BASE_DIR
-
-
-def _resolve_target_directory(directory: str) -> Path:
-    dir_value = (directory or DEFAULT_TEMPLATE_DIR).strip()
-    if not dir_value:
-        raise HTTPException(status_code=400, detail="Directory is required.")
-
-    candidate = Path(dir_value)
-    if not candidate.is_absolute():
-        candidate = (PROJECT_ROOT / candidate).resolve()
-    else:
-        candidate = candidate.resolve()
-
-    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
-        raise HTTPException(status_code=400, detail="Directory must be inside the project.")
-
-    return candidate
-
-
-def _resolve_project_file(file_path: str) -> Path:
-    raw_path = (file_path or "").strip()
-    if not raw_path:
-        raise HTTPException(status_code=400, detail="Path is required.")
-
-    candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = (PROJECT_ROOT / candidate).resolve()
-    else:
-        candidate = candidate.resolve()
-
-    if candidate != PROJECT_ROOT and PROJECT_ROOT not in candidate.parents:
-        raise HTTPException(status_code=400, detail="Path must be inside the project.")
-
-    return candidate
-
-
-# PDF field-type codes -> the type values the frontend field builder uses.
-_FIELD_TYPE_BY_FT = {"/Tx": "string", "/Btn": "checkbox", "/Ch": "list", "/Sig": "signature"}
-
-
-def _pdf_text(value) -> str:
-    """Decode a pdfrw string (field name / tooltip) to plain text."""
-    if value is None:
-        return ""
-    if hasattr(value, "to_unicode"):
-        return value.to_unicode().strip()
-    return str(value).strip()
-
-
-def _humanize(name: str) -> str:
-    """Turn a raw field name into a readable description (JobTitle -> Job Title)."""
-    text = re.sub(r"_+", " ", name)
-    text = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
-    return re.sub(r"\s+", " ", text).strip()
-
-
-def _extract_pdf_fields(pdf_path: str) -> list[dict] | None:
-    """Fillable widgets in the same order Filler.fill_form writes them
-    (top-to-bottom, left-to-right per page), so seeded rows line up with the
-    fill order. Returns None if the PDF can't be read."""
-    try:
-        from pdfrw import PdfReader
-        candidate = Path(pdf_path)
-        if not candidate.is_absolute():
-            candidate = (PROJECT_ROOT / candidate).resolve()
-        pdf = PdfReader(str(candidate))
-        fields: list[dict] = []
-        for page in pdf.pages:
-            widgets = [a for a in (page.Annots or []) if a.Subtype == "/Widget" and a.T]
-            widgets.sort(key=lambda a: (-float(a.Rect[1]), float(a.Rect[0])))
-            for annot in widgets:
-                name = _pdf_text(annot.T)
-                fields.append({
-                    "name": name,
-                    "description": _pdf_text(annot.TU) or _humanize(name),
-                    "type": _FIELD_TYPE_BY_FT.get(str(annot.FT), "string"),
-                })
-        return fields
-    except Exception:
-        return None
-
-
-def _count_pdf_widgets(pdf_path: str) -> int | None:
-    """Number of fillable widgets in a PDF, or None if unreadable."""
-    fields = _extract_pdf_fields(pdf_path)
-    return None if fields is None else len(fields)
-
 
 class TemplateService:
     def __init__(self):
@@ -119,10 +30,10 @@ class TemplateService:
         return list_templates(session)
 
     def resolve_pdf_path(self, path: str) -> Path:
-        return _resolve_project_file(path)
+        return paths._resolve_project_file(path)
 
     def save_uploaded_pdf(self, directory: str, filename: str, content: bytes) -> TemplateUploadResponse:
-        target_dir = _resolve_target_directory(directory)
+        target_dir = paths._resolve_target_directory(directory)
         target_dir.mkdir(parents=True, exist_ok=True)
 
         target_path = target_dir / filename
@@ -133,7 +44,7 @@ class TemplateService:
         with target_path.open("wb") as output_file:
             output_file.write(content)
 
-        relative_path = target_path.relative_to(PROJECT_ROOT).as_posix()
+        relative_path = target_path.relative_to(paths.PROJECT_ROOT).as_posix()
         extracted = _extract_pdf_fields(relative_path)
         return TemplateUploadResponse(
             filename=target_path.name,
@@ -157,8 +68,8 @@ class TemplateService:
         new_absolute = self.controller.prepare_fillable(resolved_pdf_path)
         new_path = Path(new_absolute)
         if not new_path.is_absolute():
-            new_path = (PROJECT_ROOT / new_path).resolve()
-        relative_path = new_path.relative_to(PROJECT_ROOT).as_posix()
+            new_path = (paths.PROJECT_ROOT / new_path).resolve()
+        relative_path = new_path.relative_to(paths.PROJECT_ROOT).as_posix()
 
         return MakeFillableResponse(
             pdf_path=relative_path,
@@ -173,7 +84,7 @@ class TemplateService:
         for sub in submissions:
             if sub.output_pdf_path:
                 try:
-                    resolved_out = _resolve_project_file(sub.output_pdf_path)
+                    resolved_out = paths._resolve_project_file(sub.output_pdf_path)
                     if resolved_out.exists() and resolved_out.is_file():
                         resolved_out.unlink()
                 except Exception:
@@ -186,7 +97,7 @@ class TemplateService:
 
         if template.pdf_path:
             try:
-                resolved_pdf = _resolve_project_file(template.pdf_path)
+                resolved_pdf = paths._resolve_project_file(template.pdf_path)
                 if resolved_pdf.exists() and resolved_pdf.is_file():
                     resolved_pdf.unlink()
             except Exception:

--- a/app/tasks/purge.py
+++ b/app/tasks/purge.py
@@ -9,15 +9,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from app.core.celery import celery_app
-from app.core.config import BASE_DIR, RETENTION_PERIOD_DAYS
+from app.core.config import RETENTION_PERIOD_DAYS
+from app.core.paths import PROJECT_ROOT
 from app.db.database import get_session
 from app.db.repositories import delete_form_submission
 from app.models import FormSubmission
 from sqlmodel import select
 
 logger = logging.getLogger(__name__)
-
-PROJECT_ROOT = BASE_DIR
 
 
 def _safe_delete_file(file_path: str) -> bool:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,7 @@ class TestTemplateEndpoints:
         # Point the upload directory inside tmp_path (which is inside the project
         # for the path-safety check — we monkeypatch the check).
         monkeypatch.setattr(
-            "app.services.template.PROJECT_ROOT",
+            "app.core.paths.PROJECT_ROOT",
             tmp_path,
         )
         resp = client.post(
@@ -387,7 +387,7 @@ class TestE2EPipeline:
 
     def test_full_flow(self, client, mock_controller, pdf_upload, tmp_path, monkeypatch, db):
         # -- Step 1: Upload a PDF --
-        monkeypatch.setattr("app.services.template.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("app.core.paths.PROJECT_ROOT", tmp_path)
         upload_resp = client.post(
             f"{API_PREFIX}/templates/upload",
             files=[pdf_upload],

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -69,7 +69,7 @@ class TestDeleteTemplate:
 
     def test_delete_template_deletes_pdf_file(self, client, tmp_path, monkeypatch):
         """Verify the template PDF file is removed from disk on delete."""
-        monkeypatch.setattr("app.services.template.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("app.core.paths.PROJECT_ROOT", tmp_path)
         pdf_file = tmp_path / "myform.pdf"
         pdf_file.write_bytes(b"%PDF-1.4 fake")
 
@@ -81,7 +81,7 @@ class TestDeleteTemplate:
 
     def test_delete_template_deletes_submission_output_pdfs(self, client, db, tmp_path, monkeypatch):
         """Output PDFs of related submissions should be wiped on template deletion."""
-        monkeypatch.setattr("app.services.template.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("app.core.paths.PROJECT_ROOT", tmp_path)
 
         out_pdf = tmp_path / "filled.pdf"
         out_pdf.write_bytes(b"%PDF-1.4 filled")
@@ -117,7 +117,7 @@ class TestDeleteSubmission:
         assert resp.status_code == 404
 
     def test_delete_submission_removes_output_pdf(self, client, db, tmp_path, monkeypatch):
-        monkeypatch.setattr("app.api.routes.forms.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("app.core.paths.PROJECT_ROOT", tmp_path)
         out_pdf = tmp_path / "filled_out.pdf"
         out_pdf.write_bytes(b"%PDF-1.4")
 
@@ -167,7 +167,7 @@ class TestPurgeSubmissions:
         assert resp.json()["purged_count"] == 0
 
     def test_purge_removes_output_pdf_file(self, client, db, tmp_path, monkeypatch):
-        monkeypatch.setattr("app.services.form.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("app.core.paths.PROJECT_ROOT", tmp_path)
         out_pdf = tmp_path / "old_filled.pdf"
         out_pdf.write_bytes(b"%PDF-1.4")
 


### PR DESCRIPTION
Closes #654.

Consolidates the helpers that got duplicated across files during the #640/#642 refactors
into two shared leaf modules:
- app/core/paths.py — PROJECT_ROOT, _resolve_project_file, _resolve_target_directory.
- app/core/pdf_utils.py — _pdf_text, _humanize, _count_pdf_widgets, _extract_pdf_fields,
  _FIELD_TYPE_BY_FT.

Both are dependency-free leaves (import only pathlib/pdfrw/fastapi, nothing from
app.services/app.api), which is what dissolves the circular import (template → controller →
file_manipulator → filler → template) that forced the duplication in the first place.
forms.py, form.py, template.py, filler.py, and purge.py now import from these instead of
holding their own copies.

Three things worth flagging (beyond a pure move):
- The three _resolve_project_file copies weren't identical — forms.py/form.py raised
  AppError, template.py raised HTTPException. The exception is swallowed at every observable
  call site, so I standardized on HTTPException (the only choice provably behavior-identical
  everywhere, including the one path where the type could theoretically surface).
- _count_pdf_widgets depends on _extract_pdf_fields, which needs PROJECT_ROOT — so those
  came along too (pdf_utils reaches PROJECT_ROOT via app.core.paths, an app.core→app.core
  ref, not reopening the cycle).
- purge.py had its own PROJECT_ROOT copy (a fourth site) — consolidated too;
  _safe_delete_file (different logic) left untouched.

Behavior-preserving — 155 tests pass with only monkeypatch-location changes (the 6
PROJECT_ROOT patches now target app.core.paths.PROJECT_ROOT via module-attribute access, so
one patch covers all callers). ruff check app/ clean. Each helper is now defined in exactly
one place.