### PR TITLE
[Pipeline C] Fix Form model, add migration and repo functions (#552, part 1)

### DIFF
--- a/alembic/versions/005_form_incident_template_batch.py
+++ b/alembic/versions/005_form_incident_template_batch.py
@@ -1,0 +1,59 @@
+"""forms: key by template, require incident, group by batch, drop extract_id
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-08-17
+
+Form generation (contract Layer 3, #552) keys a form by which template filled
+it and reaches the extraction through the incident rather than a direct link
+(incidents already FK the extraction, so extract_id was a redundant hop).
+Batching is a grouping key only — batch_id has no Batch table, batch status is
+derived on the fly from the Form rows that share an id.
+
+No route or repository writes a v1 Form row yet (form generation itself is
+still unimplemented), so the forms table is empty in every environment and
+the NOT NULL adds below are safe — there is no existing data to backfill.
+
+FK constraints are named explicitly, matching Postgres' own default
+`<table>_<column>_fkey` pattern, so downgrade can drop them by name. The same
+naming_convention is handed to batch_alter_table so SQLite's reflect-and-
+recreate path (needed for the incident_id nullable flip and the extract_id
+drop, neither of which SQLite can ALTER in place) assigns identical names.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '005'
+down_revision: Union[str, None] = '004'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+NAMING_CONVENTION = {"fk": "%(table_name)s_%(column_0_name)s_fkey"}
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('forms', naming_convention=NAMING_CONVENTION) as batch_op:
+        batch_op.add_column(sa.Column('template_id', sa.Uuid(), nullable=False))
+        batch_op.create_foreign_key(
+            'forms_template_id_fkey', 'form_templates', ['template_id'], ['template_id']
+        )
+        batch_op.add_column(sa.Column('batch_id', sa.Uuid(), nullable=True))
+        batch_op.drop_constraint('forms_extract_id_fkey', type_='foreignkey')
+        batch_op.drop_column('extract_id')
+        batch_op.alter_column('incident_id', existing_type=sa.Uuid(), nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('forms', naming_convention=NAMING_CONVENTION) as batch_op:
+        batch_op.alter_column('incident_id', existing_type=sa.Uuid(), nullable=True)
+        batch_op.add_column(sa.Column('extract_id', sa.Uuid(), nullable=False))
+        batch_op.create_foreign_key(
+            'forms_extract_id_fkey', 'extractions', ['extract_id'], ['extract_id']
+        )
+        batch_op.drop_constraint('forms_template_id_fkey', type_='foreignkey')
+        batch_op.drop_column('template_id')
+        batch_op.drop_column('batch_id')

--- a/app/db/repositories.py
+++ b/app/db/repositories.py
@@ -6,6 +6,7 @@ from app.models import (
     Template,
     FormSubmission,
     FormTemplate,
+    Form,
     Job,
     Input,
     Extraction,
@@ -112,6 +113,32 @@ def get_form_submission(session: Session, submission_id: int) -> FormSubmission 
 def delete_form_submission(session: Session, submission: FormSubmission) -> None:
     session.delete(submission)
     session.commit()
+
+
+# Forms (contract Layer 3 — v1 Form model, distinct from the legacy FormSubmission)
+def create_generated_form(session: Session, form: Form) -> Form:
+    session.add(form)
+    session.commit()
+    session.refresh(form)
+    return form
+
+
+def get_form(session: Session, form_id: UUID) -> Form | None:
+    return session.get(Form, form_id)
+
+
+def list_forms_by_batch(session: Session, batch_id: UUID) -> list[Form]:
+    statement = select(Form).where(Form.batch_id == batch_id).order_by(
+        Form.created_at, Form.form_id
+    )
+    return list(session.exec(statement))
+
+
+def update_form(session: Session, form: Form) -> Form:
+    session.add(form)
+    session.commit()
+    session.refresh(form)
+    return form
 
 
 # Inputs

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -160,8 +160,11 @@ class Form(SQLModel, table=True):
     status: FormStatus = Field(
         default=FormStatus.queued, sa_column=Column(AutoString, nullable=False)
     )
-    extract_id: UUID = Field(foreign_key="extractions.extract_id")
-    incident_id: UUID | None = Field(default=None, foreign_key="incidents.incident_id")
+    template_id: UUID = Field(foreign_key="form_templates.template_id")
+    incident_id: UUID = Field(foreign_key="incidents.incident_id")
+    # Grouping key for a batch generate request. No Batch table — batch status
+    # is derived on the fly from the Form rows sharing this id.
+    batch_id: UUID | None = None
     # Plain UUID, no FK constraint — pending contract Job model resolution (#544 decision A).
     job_id: UUID | None = None
     completed_at: datetime | None = None

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -253,8 +253,9 @@ def test_forms_columns(alembic_cfg, alembic_engine):
         "form_id",
         "form_type",
         "status",
-        "extract_id",
+        "template_id",
         "incident_id",
+        "batch_id",
         "job_id",
         "completed_at",
         "pdf_ready",
@@ -272,9 +273,10 @@ def test_forms_fk(alembic_cfg, alembic_engine):
 
     inspector = inspect(alembic_engine)
     fks = {fk["referred_table"]: fk for fk in inspector.get_foreign_keys("forms")}
-    # extract_id → extractions and incident_id → incidents; job_id has NO FK constraint
-    assert "extractions" in fks
-    assert fks["extractions"]["referred_columns"] == ["extract_id"]
+    # template_id → form_templates and incident_id → incidents; job_id and
+    # batch_id have NO FK constraint (batch_id is a grouping key, no Batch table)
+    assert "form_templates" in fks
+    assert fks["form_templates"]["referred_columns"] == ["template_id"]
     assert "incidents" in fks
     assert fks["incidents"]["referred_columns"] == ["incident_id"]
     assert len(fks) == 2
@@ -403,9 +405,13 @@ def test_template_uploads_no_fk(alembic_cfg, alembic_engine):
 
 
 def test_downgrade_004(alembic_cfg, alembic_engine):
-    """Downgrade by one step removes both 004 tables, leaving 003 intact."""
+    """Downgrade to 003 removes both 004 tables, leaving 003 intact.
+
+    Targets the "003" revision explicitly rather than "-1": 005 now sits on
+    top of head, so a relative one-step downgrade only undoes 005, not 004.
+    """
     command.upgrade(alembic_cfg, "head")
-    command.downgrade(alembic_cfg, "-1")
+    command.downgrade(alembic_cfg, "003")
 
     inspector = inspect(alembic_engine)
     tables = inspector.get_table_names()
@@ -414,3 +420,74 @@ def test_downgrade_004(alembic_cfg, alembic_engine):
     assert "inputs" in tables
     assert "forms" in tables
     assert "reports" in tables
+
+
+# ---------------------------------------------------------------------------
+# 005 — forms: template_id/incident_id/batch_id, drop extract_id
+# ---------------------------------------------------------------------------
+
+def test_forms_template_id_not_nullable(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"]: c for c in inspector.get_columns("forms")}
+    assert not columns["template_id"]["nullable"]
+
+
+def test_forms_incident_id_not_nullable(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"]: c for c in inspector.get_columns("forms")}
+    assert not columns["incident_id"]["nullable"]
+
+
+def test_forms_batch_id_nullable_no_fk(alembic_cfg, alembic_engine):
+    """batch_id is a plain grouping key — nullable, no FK (no Batch table)."""
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"]: c for c in inspector.get_columns("forms")}
+    assert columns["batch_id"]["nullable"]
+    referred_tables = {fk["referred_table"] for fk in inspector.get_foreign_keys("forms")}
+    assert "batches" not in referred_tables
+
+
+def test_forms_extract_id_removed(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("forms")}
+    assert "extract_id" not in columns
+
+
+def test_downgrade_005(alembic_cfg, alembic_engine):
+    """Downgrade by one step from head restores 004's forms shape."""
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "-1")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"]: c for c in inspector.get_columns("forms")}
+    assert "extract_id" in columns
+    assert "template_id" not in columns
+    assert "batch_id" not in columns
+    assert columns["incident_id"]["nullable"]
+
+    fks = {fk["referred_table"] for fk in inspector.get_foreign_keys("forms")}
+    assert "extractions" in fks
+    assert "form_templates" not in fks
+
+    # form_templates itself is untouched — only introduced by 004, not by 005
+    assert "form_templates" in inspector.get_table_names()
+
+
+def test_round_trip_005(alembic_cfg, alembic_engine):
+    command.upgrade(alembic_cfg, "head")
+    command.downgrade(alembic_cfg, "-1")
+    command.upgrade(alembic_cfg, "head")
+
+    inspector = inspect(alembic_engine)
+    columns = {c["name"] for c in inspector.get_columns("forms")}
+    assert "template_id" in columns
+    assert "batch_id" in columns
+    assert "extract_id" not in columns

--- a/tests/test_v1_models.py
+++ b/tests/test_v1_models.py
@@ -23,7 +23,7 @@ from app.api.schemas.enums import (
     PeriodType,
     ReportStatus,
 )
-from app.models import Extraction, Form, Incident, Input, Report
+from app.models import Extraction, Form, FormTemplate, Incident, Input, Report
 
 
 # ---------------------------------------------------------------------------
@@ -41,6 +41,26 @@ def _input(db: Session, **kwargs) -> Input:
 
 def _extraction(db: Session, input_id: UUID, **kwargs) -> "Extraction":
     row = Extraction(input_id=input_id, **kwargs)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _incident(db: Session, **kwargs) -> Incident:
+    inp = _input(db)
+    ext = _extraction(db, inp.input_id)
+    defaults = dict(extract_id=ext.extract_id)
+    row = Incident(**{**defaults, **kwargs})
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _form_template(db: Session, **kwargs) -> FormTemplate:
+    defaults = dict(form_type=f"test_form_{uuid4().hex[:8]}", display_name="Test Form", fields=[])
+    row = FormTemplate(**{**defaults, **kwargs})
     db.add(row)
     db.commit()
     db.refresh(row)
@@ -293,10 +313,11 @@ class TestIncidentModel:
 class TestFormModel:
 
     def _make(self, db, **kwargs):
-        inp = _input(db)
-        ext = _extraction(db, inp.input_id)
+        template = _form_template(db)
+        incident = _incident(db)
         defaults = dict(
-            extract_id=ext.extract_id,
+            template_id=template.template_id,
+            incident_id=incident.incident_id,
             form_type=FormType.nfirs_basic,
         )
         row = Form(**{**defaults, **kwargs})
@@ -311,7 +332,9 @@ class TestFormModel:
         assert row.status == FormStatus.queued
         assert row.pdf_ready is False
         assert row.json_ready is False
-        assert row.incident_id is None
+        assert isinstance(row.template_id, UUID)
+        assert isinstance(row.incident_id, UUID)
+        assert row.batch_id is None
         assert row.job_id is None
         assert row.completed_at is None
 
@@ -335,15 +358,11 @@ class TestFormModel:
         assert fetched.json_data["FDID"] == "CA99901"
 
     def test_incident_fk_links_correctly(self, db):
-        inp = _input(db)
-        ext = _extraction(db, inp.input_id)
-        incident = Incident(extract_id=ext.extract_id)
-        db.add(incident)
-        db.commit()
-        db.refresh(incident)
+        template = _form_template(db)
+        incident = _incident(db)
 
         form = Form(
-            extract_id=ext.extract_id,
+            template_id=template.template_id,
             form_type=FormType.neris,
             incident_id=incident.incident_id,
         )
@@ -351,6 +370,27 @@ class TestFormModel:
         db.commit()
         db.refresh(form)
         assert form.incident_id == incident.incident_id
+
+    def test_template_fk_links_correctly(self, db):
+        template = _form_template(db)
+        incident = _incident(db)
+
+        form = Form(
+            template_id=template.template_id,
+            form_type=FormType.neris,
+            incident_id=incident.incident_id,
+        )
+        db.add(form)
+        db.commit()
+        db.refresh(form)
+        assert form.template_id == template.template_id
+
+    def test_batch_id_roundtrip(self, db):
+        """batch_id is a plain UUID grouping key — no Batch table, no FK."""
+        batch_id = uuid4()
+        row = self._make(db, batch_id=batch_id)
+        fetched = db.get(Form, row.form_id)
+        assert fetched.batch_id == batch_id
 
     def test_job_id_stored_without_fk(self, db):
         """job_id is a plain UUID — can store any UUID without a FK constraint."""
@@ -360,10 +400,14 @@ class TestFormModel:
         assert fetched.job_id == arbitrary_uuid
 
     def test_all_form_types_accepted(self, db):
-        inp = _input(db)
-        ext = _extraction(db, inp.input_id)
+        template = _form_template(db)
+        incident = _incident(db)
         for ft in FormType:
-            form = Form(extract_id=ext.extract_id, form_type=ft)
+            form = Form(
+                template_id=template.template_id,
+                incident_id=incident.incident_id,
+                form_type=ft,
+            )
             db.add(form)
         db.commit()
         results = db.exec(select(Form)).all()


### PR DESCRIPTION
Part 1 of #552 (the data layer; the generate endpoint, fill task, and retrieval endpoints
follow in later PRs).

Fixes the v1 Form model to match the form-record.yaml contract and the agreed design (forms
link the incident, not the extract; keyed by template; batch is a grouping key, no Batch
table):
- Add template_id (FK to form_templates) — forms are keyed by template; FormRecord requires it.
- Add batch_id (nullable UUID, no FK) — batch is derived on the fly from Form rows sharing a
  batch_id, per the scope decision (no Batch table in #552; #554 can add one if it needs it).
- Make incident_id required; drop extract_id (the extraction is reachable through the
  incident, so forms don't link it directly).

Migration 005 (down_revision 004) uses batch_alter_table for SQLite/Postgres portability.
Verified on both: the full suite (454) passes on SQLite, and I ran upgrade → downgrade 004 →
upgrade → alembic check against a real Postgres 17 container — all clean, so the FK
drop/re-add works with the actual Postgres constraint names.

Repository functions for the v1 Form model: create_generated_form, get_form,
list_forms_by_batch, update_form (named to avoid colliding with the legacy create_form, which
targets the old FormSubmission and is untouched).

Note: the downgrade re-adds extract_id as NOT NULL, which assumes the forms table is empty -
true now (generation isn't implemented yet), but a rollback caveat once the fill task lands.

@marcvergees @vharkins1 @chetanr25 