### PR TITLE
Load the env file into the app and worker containers

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,15 @@ docker/
 
 See `.env.example` for the full list with descriptions.
 
+Both compose files load the env file into the app and worker containers with an
+`env_file` block, so a setting added to `.env.dev` or `.env.prod` reaches the
+running code without being listed a second time. The `environment` block below
+it still wins, and it is there for the handful of values a container needs
+different from the host, such as service names and data directories.
+
+`--env-file` on the compose command line is a separate thing. It only fills in
+`${}` placeholders inside the compose file and puts nothing into the container.
+
 ## Volumes
 
 `docker compose down` never removes volumes. Use `docker compose down -v` only to intentionally wipe all data.

--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -100,6 +100,11 @@ services:
       - fireform_uploads:/data/uploads
     ports:
       - "${APP_PORT:-8000}:8000"
+    # Everything in the env file reaches the container, so a new setting works
+    # without being listed twice. The block below still wins where a container
+    # needs a different value than the host (service names, data dirs).
+    env_file:
+      - ../.env.dev
     environment:
       - PYTHONUNBUFFERED=1
       - CUDA_VISIBLE_DEVICES=
@@ -136,6 +141,8 @@ services:
     volumes:
       - ../..:/app
       - fireform_uploads:/data/uploads
+    env_file:
+      - ../.env.dev
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONPATH=/app

--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -56,6 +56,11 @@ services:
       - fireform_uploads:/data/uploads
     ports:
       - "${APP_PORT}:8000"
+    # Everything in the env file reaches the container, so a new setting works
+    # without being listed twice. The block below still wins where a container
+    # needs a different value than the host.
+    env_file:
+      - ../.env.prod
     environment:
       - PYTHONUNBUFFERED=1
       - CUDA_VISIBLE_DEVICES=


### PR DESCRIPTION
# Load the env file into the app and worker containers

Settings in the env file never reached the running code. A new setting looked like it did nothing, and nothing pointed at why.

## Why

- Compose reads the env file through `--env-file`. That only fills in the `${}` placeholders inside the compose file itself.
- Nothing from it lands in the container. Every value had to be repeated by hand in the `environment` block.
- Miss that second line and the setting is silently absent. No error, no warning.

## What changed

- `docker/dev/compose.yml`: `env_file` on the app and worker services.
- `docker/prod/compose.yml`: same on the app service.
- `docker/README.md`: what `env_file` does, and how it differs from `--env-file`.

Part of #674
