### PR TITLE
Batch form generation API

### DIFF
--- a/app/api/routes/form_generation.py
+++ b/app/api/routes/form_generation.py
@@ -15,7 +15,7 @@ gets read as a form_id.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from fastapi.responses import FileResponse, JSONResponse
 from sqlmodel import Session
 
@@ -32,7 +32,6 @@ from app.api.schemas.form_generation import (
     SkippedForm,
 )
 from app.core.config import (
-    DATA_DIR,
     ESTIMATED_FORM_GENERATION_SECONDS,
     FORM_GENERATION_POLL_INTERVAL_SECONDS,
 )
@@ -40,8 +39,11 @@ from app.core.errors.base import AppError
 from app.db.repositories import get_form, list_forms_by_batch
 from app.services.form_generation import (
     FormGenerationService,
+    batch_state,
+    batch_zip,
     download_filename,
     form_version,
+    resolve_form_pdf,
 )
 
 router = APIRouter(prefix="/forms", tags=["forms"])
@@ -75,17 +77,7 @@ def get_batch_status(batch_id: UUID, db: Session = Depends(get_db)):
     completed = sum(1 for f in forms if f.status == FormStatus.completed)
     failed = sum(1 for f in forms if f.status == FormStatus.failed)
     total = len(forms)
-    done = completed + failed
-    if done < total:
-        status = "processing"
-    elif failed == total:
-        status = "failed"
-    else:
-        # Per design, a per-form failure doesn't fail the batch: the Job (and
-        # this status) reads "completed" as long as every form reached a
-        # terminal state and at least one succeeded — the forms list below
-        # still shows exactly which ones failed.
-        status = "completed"
+    status = batch_state(forms)
 
     return BatchStatus(
         batch_id=batch_id,
@@ -102,7 +94,44 @@ def get_batch_status(batch_id: UUID, db: Session = Depends(get_db)):
             )
             for f in forms
         ],
-        download_url=None,
+        # Only offered once there is something to bundle: a batch where every
+        # form failed has no PDFs behind the link.
+        download_url=(
+            f"/api/v1/forms/batch/{batch_id}/download" if status == "completed" else None
+        ),
+    )
+
+
+@router.get("/batch/{batch_id}/download")
+def download_batch_zip(batch_id: UUID, db: Session = Depends(get_db)):
+    forms = list_forms_by_batch(db, batch_id)
+    if not forms:
+        raise AppError(f"Batch {batch_id} not found", status_code=404, error_code="BATCH_NOT_FOUND")
+
+    status = batch_state(forms)
+    if status == "processing":
+        return JSONResponse(
+            status_code=202,
+            content={
+                "message": "Batch is still generating",
+                "status": status,
+                "retry_after_seconds": FORM_GENERATION_POLL_INTERVAL_SECONDS,
+            },
+        )
+
+    if status == "failed":
+        raise AppError(
+            f"Every form in batch {batch_id} failed to generate",
+            status_code=500,
+            error_code="FORM_GENERATION_FAILED",
+            detail={"reason": "No PDFs were produced for this batch"},
+        )
+
+    archive, filename = batch_zip(db, batch_id, forms)
+    return Response(
+        content=archive,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 
@@ -151,8 +180,8 @@ def download_form_pdf(form_id: UUID, db: Session = Depends(get_db)):
             },
         )
 
-    path = (DATA_DIR / form.pdf_path).resolve()
-    if not path.is_relative_to(DATA_DIR) or not path.is_file():
+    path = resolve_form_pdf(form)
+    if path is None:
         raise AppError(f"Form {form_id} not found", status_code=404, error_code="FORM_NOT_FOUND")
 
     return FileResponse(

--- a/app/api/routes/form_generation.py
+++ b/app/api/routes/form_generation.py
@@ -38,7 +38,11 @@ from app.core.config import (
 )
 from app.core.errors.base import AppError
 from app.db.repositories import get_form, list_forms_by_batch
-from app.services.form_generation import FormGenerationService
+from app.services.form_generation import (
+    FormGenerationService,
+    download_filename,
+    form_version,
+)
 
 router = APIRouter(prefix="/forms", tags=["forms"])
 
@@ -151,7 +155,9 @@ def download_form_pdf(form_id: UUID, db: Session = Depends(get_db)):
     if not path.is_relative_to(DATA_DIR) or not path.is_file():
         raise AppError(f"Form {form_id} not found", status_code=404, error_code="FORM_NOT_FOUND")
 
-    return FileResponse(path, media_type="application/pdf", filename=path.name)
+    return FileResponse(
+        path, media_type="application/pdf", filename=download_filename(db, form)
+    )
 
 
 @router.get("/{form_id}/json", response_model=FormMappedJson)
@@ -160,15 +166,30 @@ def get_form_json(form_id: UUID, db: Session = Depends(get_db)):
     if not form:
         raise AppError(f"Form {form_id} not found", status_code=404, error_code="FORM_NOT_FOUND")
 
-    if not form.json_ready or form.json_data is None:
+    # Same three answers as /pdf, so a client polling both after one generate
+    # call reads them the same way: 500 once the fill failed, 202 while it is
+    # still running, the payload once it is there.
+    if form.status == FormStatus.failed:
         raise AppError(
-            f"Form {form_id} has no JSON output yet",
-            status_code=404,
-            error_code="FORM_JSON_NOT_READY",
+            f"Form {form_id} failed to generate",
+            status_code=500,
+            error_code="FORM_GENERATION_FAILED",
+            detail={"reason": "Form generation failed"},
+        )
+
+    if not form.json_ready or form.json_data is None:
+        return JSONResponse(
+            status_code=202,
+            content={
+                "message": "Form generation is still in progress",
+                "status": form.status,
+                "retry_after_seconds": FORM_GENERATION_POLL_INTERVAL_SECONDS,
+            },
         )
 
     return FormMappedJson(
         form_type=form.form_type,
+        form_version=form_version(db, form),
         form_id=form.form_id,
         template_id=form.template_id,
         incident_id=form.incident_id,

--- a/app/api/schemas/form_generation.py
+++ b/app/api/schemas/form_generation.py
@@ -30,12 +30,13 @@ class GenerateFormsOptions(BaseModel):
 class GenerateFormsRequest(BaseModel):
     """POST /forms/generate body.
 
-    template_ids is required in this build: omitting it (generate every
-    template the readiness matrix reports as ready) is #554, not built here.
+    Omitting template_ids generates every template the readiness matrix
+    reports as ready. An empty list is a different thing from an absent one
+    and is rejected: it reads as a selection screen that sent nothing.
     """
 
     incident_id: UUID
-    template_ids: list[UUID] = Field(min_length=1)
+    template_ids: list[UUID] | None = Field(default=None, min_length=1)
     options: GenerateFormsOptions | None = None
 
 
@@ -122,7 +123,7 @@ class BatchStatus(BaseModel):
     completed: int
     failed: int
     forms: list[BatchFormEntry] = Field(default_factory=list)
-    # Zip bundling of a batch's PDFs is #554; always null here.
+    # Set once the batch has finished with at least one PDF to bundle.
     download_url: str | None = None
 
 

--- a/app/api/schemas/form_generation.py
+++ b/app/api/schemas/form_generation.py
@@ -96,6 +96,9 @@ class FormMappedJson(BaseModel):
     """GET /forms/{form_id}/json response."""
 
     form_type: str
+    # The template's version, read at request time. Null when the template has
+    # since been deleted out of the registry.
+    form_version: str | None = None
     form_id: UUID
     template_id: UUID
     incident_id: UUID

--- a/app/services/form_generation.py
+++ b/app/services/form_generation.py
@@ -13,22 +13,27 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
 from uuid import UUID, uuid4
+from zipfile import ZIP_DEFLATED, ZipFile
 
 from sqlmodel import Session
 
-from app.api.schemas.enums import FormStatus
+from app.api.schemas.enums import FormStatus, TemplateStatus
 from app.api.schemas.form_generation import GenerateFormsOptions, GenerateFormsRequest
+from app.core.config import DATA_DIR
 from app.core.errors.base import AppError
 from app.db.repositories import (
     create_generated_form,
     create_job,
     get_form_template,
     get_incident,
+    list_form_templates,
     update_form,
     update_job,
 )
-from app.models import Form, Job
+from app.models import Form, FormTemplate, Job
 from app.services.extraction_readiness import gaps_for
 from app.services.form_templates import require_template
 from app.tasks.generate_forms import generate_forms_batch_task
@@ -68,6 +73,13 @@ def _slug(value: str) -> str:
     return _UNSAFE_IN_FILENAME.sub("-", value).strip("-")
 
 
+def _pdf_filename(form: Form, incident_number: str | None) -> str:
+    number = _slug(incident_number) if incident_number else ""
+    if not number:
+        return f"{form.form_id}.pdf"
+    return f"{_slug(form.form_type)}_{number}.pdf"
+
+
 def download_filename(session: Session, form: Form) -> str:
     """The name a downloaded PDF is saved under.
 
@@ -77,10 +89,7 @@ def download_filename(session: Session, form: Form) -> str:
     once the department has one, so the form id stands in when it is missing.
     """
     incident = get_incident(session, form.incident_id)
-    number = _slug(incident.incident_number) if incident and incident.incident_number else ""
-    if not number:
-        return f"{form.form_id}.pdf"
-    return f"{_slug(form.form_type)}_{number}.pdf"
+    return _pdf_filename(form, incident.incident_number if incident else None)
 
 
 def form_version(session: Session, form: Form) -> str | None:
@@ -94,7 +103,96 @@ def form_version(session: Session, form: Form) -> str | None:
     return template.version if template else None
 
 
+def batch_state(forms: list[Form]) -> str:
+    """processing, completed or failed, derived from the batch's Form rows.
+
+    There is no Batch table, so both the status endpoint and the zip download
+    read the batch's state from the same place. Per design a single failed form
+    does not fail the batch: it reads completed as long as every form reached a
+    terminal state and at least one succeeded, and the per-form list still shows
+    which ones failed.
+    """
+    total = len(forms)
+    completed = sum(1 for f in forms if f.status == FormStatus.completed)
+    failed = sum(1 for f in forms if f.status == FormStatus.failed)
+    if completed + failed < total:
+        return "processing"
+    return "failed" if failed == total else "completed"
+
+
+def resolve_form_pdf(form: Form) -> Path | None:
+    """The form's PDF on disk, or None if it is not there to serve.
+
+    pdf_path is stored relative to the data directory, so a value that climbs
+    out of it is refused rather than read. Single downloads turn a None into a
+    404; the batch zip just leaves that form out.
+    """
+    if not form.pdf_ready or not form.pdf_path:
+        return None
+    path = (DATA_DIR / form.pdf_path).resolve()
+    if not path.is_relative_to(DATA_DIR) or not path.is_file():
+        return None
+    return path
+
+
+def batch_pdfs(session: Session, forms: list[Form]) -> list[tuple[str, Path]]:
+    """Every finished PDF in the batch, as (name in the archive, path on disk).
+
+    Forms that failed, or whose file has gone missing under the data directory,
+    are left out rather than failing the whole download. One incident lookup
+    covers the batch because every form in it is filled from the same incident.
+    """
+    if not forms:
+        return []
+
+    incident = get_incident(session, forms[0].incident_id)
+    number = incident.incident_number if incident else None
+
+    entries: list[tuple[str, Path]] = []
+    for form in forms:
+        if form.status != FormStatus.completed:
+            continue
+        path = resolve_form_pdf(form)
+        if path is not None:
+            entries.append((_pdf_filename(form, number), path))
+    return entries
+
+
+def batch_zip(session: Session, batch_id: UUID, forms: list[Form]) -> tuple[bytes, str]:
+    """The batch's PDFs as one zip, with the name to serve it under.
+
+    Built in memory: a batch is one incident's report pack, so it is a handful
+    of PDFs rather than something worth spooling to disk.
+    """
+    entries = batch_pdfs(session, forms)
+    incident = get_incident(session, forms[0].incident_id) if forms else None
+    number = _slug(incident.incident_number) if incident and incident.incident_number else ""
+
+    buffer = BytesIO()
+    with ZipFile(buffer, "w", ZIP_DEFLATED) as archive:
+        for name, path in entries:
+            archive.write(path, arcname=name)
+
+    return buffer.getvalue(), f"fireform_batch_{number or batch_id}.zip"
+
+
 class FormGenerationService:
+    def _candidates(self, session: Session, request: GenerateFormsRequest) -> list[FormTemplate]:
+        """The templates this request is about, before readiness is considered.
+
+        An explicit selection is taken as given, including a legacy or draft
+        template the user deliberately picked. With no selection the candidates
+        are the active templates, the same set the readiness matrix offers on
+        the selection screen, so "generate everything ready" cannot pull in a
+        retired form nobody chose.
+
+        Every requested template is resolved before anything is written: a bad
+        template_id 404s cleanly instead of leaving a partial batch behind.
+        """
+        if request.template_ids is not None:
+            return [require_template(session, tid) for tid in request.template_ids]
+        return [t for t in list_form_templates(session) if t.status == TemplateStatus.active]
+
     def start_generation(self, session: Session, request: GenerateFormsRequest) -> GenerationResult:
         incident = get_incident(session, request.incident_id)
         if incident is None:
@@ -104,9 +202,7 @@ class FormGenerationService:
                 error_code="INCIDENT_NOT_FOUND",
             )
 
-        # Resolve every requested template before writing anything: a bad
-        # template_id 404s cleanly instead of leaving a partial batch behind.
-        templates = [require_template(session, tid) for tid in request.template_ids]
+        templates = self._candidates(session, request)
 
         options = request.options or GenerateFormsOptions()
         contract = incident.incident_contract or {}
@@ -139,10 +235,16 @@ class FormGenerationService:
             result.queued.append(create_generated_form(session, form))
 
         if not result.queued:
+            # Two ways to end up here, and the caller needs to tell them apart:
+            # a selection whose every template turned out to be blocked, or no
+            # selection at all with nothing in the registry ready to generate.
             raise AppError(
-                "No templates were selected and none are ready",
+                "None of the selected templates are ready"
+                if request.template_ids is not None
+                else "No templates were selected and none are ready",
                 status_code=422,
                 error_code="NO_FORMS_TO_GENERATE",
+                detail={"skipped": [s.reason for s in result.skipped]},
             )
 
         job = Job(celery_task_id="", job_type="batch_form_generation", status="queued")

--- a/app/services/form_generation.py
+++ b/app/services/form_generation.py
@@ -10,6 +10,7 @@ HTTP handler and calls straight into here.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
@@ -22,6 +23,7 @@ from app.core.errors.base import AppError
 from app.db.repositories import (
     create_generated_form,
     create_job,
+    get_form_template,
     get_incident,
     update_form,
     update_job,
@@ -30,6 +32,12 @@ from app.models import Form, Job
 from app.services.extraction_readiness import gaps_for
 from app.services.form_templates import require_template
 from app.tasks.generate_forms import generate_forms_batch_task
+
+# Anything outside this set is replaced in a download filename. Incident
+# numbers are free text typed by a responder, so they can carry slashes,
+# spaces or quotes, none of which belong in a Content-Disposition header.
+# Dots go too: the only one in the name should be the one before "pdf".
+_UNSAFE_IN_FILENAME = re.compile(r"[^A-Za-z0-9_-]+")
 
 
 @dataclass
@@ -54,6 +62,36 @@ def _skip_reason(gaps) -> str:
     way the contract's own example names a single field."""
     gap = gaps.missing_required[0]
     return f"Not ready: {gap.field_name} ({gap.source.value}) has no value"
+
+
+def _slug(value: str) -> str:
+    return _UNSAFE_IN_FILENAME.sub("-", value).strip("-")
+
+
+def download_filename(session: Session, form: Form) -> str:
+    """The name a downloaded PDF is saved under.
+
+    "{form_type}_{incident_number}.pdf", the same name the batch zip gives its
+    entries, so a form downloaded on its own and the same form pulled out of a
+    batch land as one file. Incident numbers are optional and are only assigned
+    once the department has one, so the form id stands in when it is missing.
+    """
+    incident = get_incident(session, form.incident_id)
+    number = _slug(incident.incident_number) if incident and incident.incident_number else ""
+    if not number:
+        return f"{form.form_id}.pdf"
+    return f"{_slug(form.form_type)}_{number}.pdf"
+
+
+def form_version(session: Session, form: Form) -> str | None:
+    """The version of the template the form was generated from.
+
+    Read live off the template rather than stamped on the form: templates are
+    versioned in place, so this reports the registry's current version, not the
+    one in force at fill time.
+    """
+    template = get_form_template(session, form.template_id)
+    return template.version if template else None
 
 
 class FormGenerationService:

--- a/contracts/path/forms.yaml
+++ b/contracts/path/forms.yaml
@@ -137,7 +137,9 @@ form_pdf:
     description: |
       Returns the filled PDF binary file for the specified form. If the form
       generation is still in progress, returns 202 Accepted with a retry_after
-      hint. The Content-Disposition header is set for browser download.
+      hint. The Content-Disposition header is set for browser download, naming
+      the file "{form_type}_{incident_number}.pdf", the same name the batch zip
+      uses for its entries. Incidents without a number fall back to the form id.
     tags:
       - forms
     parameters:
@@ -235,12 +237,40 @@ form_json:
                 alarm_time: "13:52"
                 acres_burned: 1247
                 cause: "natural"
+      "202":
+        description: Form generation still in progress
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+                retry_after_seconds:
+                  type: integer
+            example:
+              message: "Form generation is still in progress"
+              status: "processing"
+              retry_after_seconds: 5
       "404":
         description: Form not found
         content:
           application/json:
             schema:
               $ref: "../schemas/common.yaml#/ErrorResponse"
+      "500":
+        description: Form generation failed, so there is no JSON to return
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+            example:
+              error_code: "FORM_GENERATION_FAILED"
+              message: "Failed to generate form"
+              detail:
+                reason: "Template file corrupted or missing"
 
 batch_by_id:
   get:

--- a/contracts/path/forms.yaml
+++ b/contracts/path/forms.yaml
@@ -379,3 +379,14 @@ batch_download:
           application/json:
             schema:
               $ref: "../schemas/common.yaml#/ErrorResponse"
+      "500":
+        description: Every form in the batch failed, so there is nothing to bundle
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/ErrorResponse"
+            example:
+              error_code: "FORM_GENERATION_FAILED"
+              message: "Every form in the batch failed to generate"
+              detail:
+                reason: "No PDFs were produced for this batch"

--- a/contracts/schemas/form-record.yaml
+++ b/contracts/schemas/form-record.yaml
@@ -194,4 +194,5 @@ BatchStatus:
       type: string
       nullable: true
       description: Zip bundle of all completed PDFs, present once the batch
-        finishes (GET /api/v1/forms/batch/{batch_id}/download)
+        finishes with at least one PDF to bundle
+        (GET /api/v1/forms/batch/{batch_id}/download)

--- a/tests/test_v1_form_generation.py
+++ b/tests/test_v1_form_generation.py
@@ -8,8 +8,10 @@ against Form rows seeded directly.
 """
 
 from datetime import datetime, timezone
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
+from zipfile import ZipFile
 
 from app.api.schemas.enums import (
     ExtractionStatus,
@@ -17,6 +19,7 @@ from app.api.schemas.enums import (
     InputStatus,
     InputType,
     ReportStatus,
+    TemplateStatus,
 )
 from app.core.config import API_PREFIX
 from app.db.repositories import (
@@ -93,12 +96,13 @@ def _incident(db, contract=None, incident_number=None) -> Incident:
     )
 
 
-def _template(db, form_type="neris", fields=None) -> FormTemplate:
+def _template(db, form_type="neris", fields=None, status=TemplateStatus.active) -> FormTemplate:
     return create_form_template(
         db,
         FormTemplate(
             form_type=form_type,
             display_name=form_type.upper(),
+            status=status,
             fields=fields if fields is not None else [_field("incident_name")],
         ),
     )
@@ -316,6 +320,101 @@ class TestGenerateForms:
             )
         assert resp.status_code == 422
         assert resp.json()["error_code"] == "NO_FORMS_TO_GENERATE"
+        assert resp.json()["message"] == "None of the selected templates are ready"
+        assert resp.json()["detail"]["skipped"]
+
+
+# ---------------------------------------------------------------------------
+# POST /forms/generate with template_ids omitted
+# ---------------------------------------------------------------------------
+
+class TestGenerateEverythingReady:
+
+    def _generate_all(self, client, incident, **options):
+        body = {"incident_id": str(incident.incident_id)}
+        if options:
+            body["options"] = options
+        with NoCelery():
+            return client.post(f"{FORMS_URL}/generate", json=body)
+
+    def test_202_queues_every_ready_active_template(self, client, db):
+        incident = _incident(db)
+        _template(db, form_type="neris")
+        _template(db, form_type="nfirs_basic")
+
+        resp = self._generate_all(client, incident)
+
+        assert resp.status_code == 202
+        queued = {f["form_type"] for f in resp.json()["forms_queued"]}
+        assert queued == {"neris", "nfirs_basic"}
+
+    def test_legacy_and_draft_templates_are_not_candidates(self, client, db):
+        incident = _incident(db)
+        _template(db, form_type="neris")
+        _template(db, form_type="old_county", status=TemplateStatus.legacy)
+        _template(db, form_type="half_built", status=TemplateStatus.draft)
+
+        resp = self._generate_all(client, incident)
+
+        body = resp.json()
+        assert [f["form_type"] for f in body["forms_queued"]] == ["neris"]
+        assert body["forms_skipped"] == []
+
+    def test_a_legacy_template_still_generates_when_asked_for_by_id(self, client, db):
+        incident = _incident(db)
+        template = _template(db, form_type="old_county", status=TemplateStatus.legacy)
+
+        with NoCelery():
+            resp = client.post(
+                f"{FORMS_URL}/generate",
+                json={
+                    "incident_id": str(incident.incident_id),
+                    "template_ids": [str(template.template_id)],
+                },
+            )
+
+        assert resp.status_code == 202
+        assert len(resp.json()["forms_queued"]) == 1
+
+    def test_not_ready_template_is_skipped_with_a_reason(self, client, db):
+        incident = _incident(db)
+        _template(db, form_type="neris")
+        _template(
+            db,
+            form_type="state_texas",
+            fields=[_field("marshal_signature_name", source="manual", required=True)],
+        )
+
+        body = self._generate_all(client, incident).json()
+
+        assert [f["form_type"] for f in body["forms_queued"]] == ["neris"]
+        assert len(body["forms_skipped"]) == 1
+        assert body["forms_skipped"][0]["form_type"] == "state_texas"
+        assert "marshal_signature_name" in body["forms_skipped"][0]["reason"]
+
+    def test_force_partial_queues_the_not_ready_ones_too(self, client, db):
+        incident = _incident(db)
+        _template(db, form_type="neris")
+        _template(
+            db,
+            form_type="state_texas",
+            fields=[_field("marshal_signature_name", source="manual", required=True)],
+        )
+
+        body = self._generate_all(client, incident, force_partial=True).json()
+
+        assert {f["form_type"] for f in body["forms_queued"]} == {"neris", "state_texas"}
+        assert body["forms_skipped"] == []
+
+    def test_422_when_the_registry_has_nothing_ready(self, client, db):
+        incident = _incident(db)
+        _template(db, form_type="old_county", status=TemplateStatus.legacy)
+
+        resp = self._generate_all(client, incident)
+
+        assert resp.status_code == 422
+        assert resp.json()["error_code"] == "NO_FORMS_TO_GENERATE"
+        assert resp.json()["message"] == "No templates were selected and none are ready"
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +448,7 @@ class TestBatchStatus:
 
         resp = client.get(f"{FORMS_URL}/batch/{batch_id}")
         assert resp.json()["status"] == "completed"
+        assert resp.json()["download_url"] == f"/api/v1/forms/batch/{batch_id}/download"
 
     def test_completed_when_terminal_with_a_partial_failure(self, client, db):
         """One failed form doesn't fail the batch — matches the per-form isolation design."""
@@ -372,11 +472,144 @@ class TestBatchStatus:
 
         resp = client.get(f"{FORMS_URL}/batch/{batch_id}")
         assert resp.json()["status"] == "failed"
+        assert resp.json()["download_url"] is None
 
     def test_404_unknown_batch(self, client, db):
         resp = client.get(f"{FORMS_URL}/batch/{uuid4()}")
         assert resp.status_code == 404
         assert resp.json()["error_code"] == "BATCH_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# GET /forms/batch/{batch_id}/download
+# ---------------------------------------------------------------------------
+
+class TestBatchDownload:
+
+    def _pdf_form(self, db, tmp_path, pdf_bytes, incident, template, batch_id, name, **kwargs):
+        pdf_file = tmp_path / "forms" / "generated" / name
+        pdf_file.parent.mkdir(parents=True, exist_ok=True)
+        pdf_file.write_bytes(pdf_bytes)
+        return _form(
+            db, incident, template,
+            batch_id=batch_id,
+            status=FormStatus.completed,
+            pdf_ready=True,
+            pdf_path=f"forms/generated/{name}",
+            **kwargs,
+        )
+
+    def test_202_while_the_batch_is_still_generating(self, client, db):
+        incident = _incident(db)
+        template = _template(db)
+        batch_id = uuid4()
+        _form(db, incident, template, batch_id=batch_id, status=FormStatus.queued)
+
+        resp = client.get(f"{FORMS_URL}/batch/{batch_id}/download")
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "processing"
+        assert resp.json()["retry_after_seconds"] == 5
+
+    def test_500_when_every_form_failed(self, client, db):
+        incident = _incident(db)
+        template = _template(db)
+        batch_id = uuid4()
+        _form(db, incident, template, batch_id=batch_id, status=FormStatus.failed)
+
+        resp = client.get(f"{FORMS_URL}/batch/{batch_id}/download")
+        assert resp.status_code == 500
+        assert resp.json()["error_code"] == "FORM_GENERATION_FAILED"
+
+    def test_404_unknown_batch(self, client, db):
+        resp = client.get(f"{FORMS_URL}/batch/{uuid4()}/download")
+        assert resp.status_code == 404
+        assert resp.json()["error_code"] == "BATCH_NOT_FOUND"
+
+    def test_200_bundles_every_pdf_under_its_download_name(
+        self, client, db, monkeypatch, tmp_path, pdf_bytes
+    ):
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db, incident_number="FF-2024-CA-0157")
+        batch_id = uuid4()
+        self._pdf_form(
+            db, tmp_path, pdf_bytes, incident, _template(db, form_type="neris"), batch_id, "a.pdf"
+        )
+        self._pdf_form(
+            db, tmp_path, pdf_bytes, incident, _template(db, form_type="nfirs"), batch_id, "b.pdf"
+        )
+
+        resp = client.get(f"{FORMS_URL}/batch/{batch_id}/download")
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        assert 'filename="fireform_batch_FF-2024-CA-0157.zip"' in resp.headers[
+            "content-disposition"
+        ]
+        with ZipFile(BytesIO(resp.content)) as archive:
+            assert sorted(archive.namelist()) == [
+                "neris_FF-2024-CA-0157.pdf",
+                "nfirs_FF-2024-CA-0157.pdf",
+            ]
+            assert archive.read("neris_FF-2024-CA-0157.pdf") == pdf_bytes
+
+    def test_a_failed_form_is_left_out_of_the_zip(
+        self, client, db, monkeypatch, tmp_path, pdf_bytes
+    ):
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db, incident_number="FF-2024-CA-0157")
+        batch_id = uuid4()
+        self._pdf_form(
+            db, tmp_path, pdf_bytes, incident, _template(db, form_type="neris"), batch_id, "a.pdf"
+        )
+        _form(
+            db, incident, _template(db, form_type="nfirs"),
+            batch_id=batch_id, status=FormStatus.failed,
+        )
+
+        resp = client.get(f"{FORMS_URL}/batch/{batch_id}/download")
+
+        assert resp.status_code == 200
+        with ZipFile(BytesIO(resp.content)) as archive:
+            assert archive.namelist() == ["neris_FF-2024-CA-0157.pdf"]
+
+    def test_a_pdf_missing_off_disk_is_left_out_rather_than_failing(
+        self, client, db, monkeypatch, tmp_path, pdf_bytes
+    ):
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db, incident_number="FF-2024-CA-0157")
+        batch_id = uuid4()
+        self._pdf_form(
+            db, tmp_path, pdf_bytes, incident, _template(db, form_type="neris"), batch_id, "a.pdf"
+        )
+        _form(
+            db, incident, _template(db, form_type="nfirs"),
+            batch_id=batch_id,
+            status=FormStatus.completed,
+            pdf_ready=True,
+            pdf_path="forms/generated/gone.pdf",
+        )
+
+        resp = client.get(f"{FORMS_URL}/batch/{batch_id}/download")
+
+        assert resp.status_code == 200
+        with ZipFile(BytesIO(resp.content)) as archive:
+            assert archive.namelist() == ["neris_FF-2024-CA-0157.pdf"]
+
+    def test_zip_name_falls_back_to_the_batch_id_without_an_incident_number(
+        self, client, db, monkeypatch, tmp_path, pdf_bytes
+    ):
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db)
+        batch_id = uuid4()
+        form = self._pdf_form(
+            db, tmp_path, pdf_bytes, incident, _template(db), batch_id, "a.pdf"
+        )
+
+        resp = client.get(f"{FORMS_URL}/batch/{batch_id}/download")
+
+        assert f'filename="fireform_batch_{batch_id}.zip"' in resp.headers["content-disposition"]
+        with ZipFile(BytesIO(resp.content)) as archive:
+            assert archive.namelist() == [f"{form.form_id}.pdf"]
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +689,7 @@ class TestGetFormPdf:
         )
 
     def test_200_serves_the_pdf_file(self, client, db, monkeypatch, tmp_path, pdf_bytes):
-        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
         incident = _incident(db, incident_number="FF-2024-CA-0157")
         template = _template(db)
         form = self._completed_pdf_form(db, tmp_path, pdf_bytes, incident, template)
@@ -470,7 +703,7 @@ class TestGetFormPdf:
     def test_filename_falls_back_to_form_id_without_an_incident_number(
         self, client, db, monkeypatch, tmp_path, pdf_bytes
     ):
-        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
         incident = _incident(db)
         template = _template(db)
         form = self._completed_pdf_form(db, tmp_path, pdf_bytes, incident, template)
@@ -481,7 +714,7 @@ class TestGetFormPdf:
     def test_filename_strips_characters_an_incident_number_should_not_carry(
         self, client, db, monkeypatch, tmp_path, pdf_bytes
     ):
-        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
         incident = _incident(db, incident_number='../2024 "07"/0157')
         template = _template(db)
         form = self._completed_pdf_form(db, tmp_path, pdf_bytes, incident, template)
@@ -490,7 +723,7 @@ class TestGetFormPdf:
         assert 'filename="neris_2024-07-0157.pdf"' in resp.headers["content-disposition"]
 
     def test_404_path_escaping_data_dir_is_rejected(self, client, db, monkeypatch, tmp_path):
-        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        monkeypatch.setattr("app.services.form_generation.DATA_DIR", tmp_path)
         incident = _incident(db)
         template = _template(db)
         form = _form(

--- a/tests/test_v1_form_generation.py
+++ b/tests/test_v1_form_generation.py
@@ -61,7 +61,7 @@ def _field(name, source="schema", required=True, layout=None, **extra) -> dict:
     return field
 
 
-def _incident(db, contract=None) -> Incident:
+def _incident(db, contract=None, incident_number=None) -> Incident:
     now = datetime.now(timezone.utc)
     inp = create_input(
         db,
@@ -88,6 +88,7 @@ def _incident(db, contract=None) -> Incident:
             extract_id=extraction.extract_id,
             status=ReportStatus.draft,
             incident_contract=_CONTRACT if contract is None else contract,
+            incident_number=incident_number,
         ),
     )
 
@@ -443,26 +444,50 @@ class TestGetFormPdf:
         assert resp.status_code == 500
         assert resp.json()["error_code"] == "PDF_GENERATION_FAILED"
 
-    def test_200_serves_the_pdf_file(self, client, db, monkeypatch, tmp_path, pdf_bytes):
-        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
-        incident = _incident(db)
-        template = _template(db)
-
+    def _completed_pdf_form(self, db, tmp_path, pdf_bytes, incident, template):
         pdf_file = tmp_path / "forms" / "generated" / "x.pdf"
-        pdf_file.parent.mkdir(parents=True)
+        pdf_file.parent.mkdir(parents=True, exist_ok=True)
         pdf_file.write_bytes(pdf_bytes)
-
-        form = _form(
+        return _form(
             db, incident, template,
             status=FormStatus.completed,
             pdf_ready=True,
             pdf_path="forms/generated/x.pdf",
         )
 
+    def test_200_serves_the_pdf_file(self, client, db, monkeypatch, tmp_path, pdf_bytes):
+        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db, incident_number="FF-2024-CA-0157")
+        template = _template(db)
+        form = self._completed_pdf_form(db, tmp_path, pdf_bytes, incident, template)
+
         resp = client.get(f"{FORMS_URL}/{form.form_id}/pdf")
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"
         assert resp.content == pdf_bytes
+        assert 'filename="neris_FF-2024-CA-0157.pdf"' in resp.headers["content-disposition"]
+
+    def test_filename_falls_back_to_form_id_without_an_incident_number(
+        self, client, db, monkeypatch, tmp_path, pdf_bytes
+    ):
+        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db)
+        template = _template(db)
+        form = self._completed_pdf_form(db, tmp_path, pdf_bytes, incident, template)
+
+        resp = client.get(f"{FORMS_URL}/{form.form_id}/pdf")
+        assert f'filename="{form.form_id}.pdf"' in resp.headers["content-disposition"]
+
+    def test_filename_strips_characters_an_incident_number_should_not_carry(
+        self, client, db, monkeypatch, tmp_path, pdf_bytes
+    ):
+        monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
+        incident = _incident(db, incident_number='../2024 "07"/0157')
+        template = _template(db)
+        form = self._completed_pdf_form(db, tmp_path, pdf_bytes, incident, template)
+
+        resp = client.get(f"{FORMS_URL}/{form.form_id}/pdf")
+        assert 'filename="neris_2024-07-0157.pdf"' in resp.headers["content-disposition"]
 
     def test_404_path_escaping_data_dir_is_rejected(self, client, db, monkeypatch, tmp_path):
         monkeypatch.setattr("app.api.routes.form_generation.DATA_DIR", tmp_path)
@@ -500,15 +525,26 @@ class TestGetFormJson:
         body = resp.json()
         assert body["form_id"] == str(form.form_id)
         assert body["agency_fields"]["incident_name"] == "Bear Creek Wildfire"
+        assert body["form_version"] == template.version
 
-    def test_404_when_not_ready_yet(self, client, db):
+    def test_202_while_still_generating(self, client, db):
         incident = _incident(db)
         template = _template(db)
         form = _form(db, incident, template, status=FormStatus.queued)
 
         resp = client.get(f"{FORMS_URL}/{form.form_id}/json")
-        assert resp.status_code == 404
-        assert resp.json()["error_code"] == "FORM_JSON_NOT_READY"
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "queued"
+        assert resp.json()["retry_after_seconds"] == 5
+
+    def test_500_when_form_failed(self, client, db):
+        incident = _incident(db)
+        template = _template(db)
+        form = _form(db, incident, template, status=FormStatus.failed)
+
+        resp = client.get(f"{FORMS_URL}/{form.form_id}/json")
+        assert resp.status_code == 500
+        assert resp.json()["error_code"] == "FORM_GENERATION_FAILED"
 
     def test_404_unknown_form(self, client, db):
         resp = client.get(f"{FORMS_URL}/{uuid4()}/json")


### PR DESCRIPTION
# Batch form generation

Form generation could only run against a list of template ids the caller picked by hand, and a finished batch had no way to hand back its PDFs. This adds the rest of the batch flow from the contract.

## Why

- The readiness screen already works out which templates can be generated. Making the caller repeat that list back is work the API can do itself.
- A batch produces several PDFs for one incident. Downloading them one at a time is the only option today, and the status response advertises a `download_url` that was always null.
- When a whole batch failed there was nothing saying so at the download step.

## What changed

- `template_ids` is now optional on `POST /forms/generate`. Omit it and every active template the readiness matrix reports as ready is generated. An empty list is still rejected, since that means a selection screen sent nothing rather than the caller asking for everything.
- Legacy and draft templates are never picked up automatically. They still generate when asked for by id, because that is a deliberate choice by the user.
- `force_partial` keeps its meaning with no selection: not-ready templates generate with blanks instead of being skipped.
- `GET /forms/batch/{batch_id}/download` returns the batch's PDFs as one zip, named after the incident number. Entries use the same name a single download gets, so a form saved on its own and the same form taken out of the zip are one file.
- Forms that failed, or whose file has gone missing, are left out of the zip rather than failing the whole download. A batch where everything failed answers 500 instead of handing back an empty archive.
- `download_url` in the batch status is filled in once the batch has finished with at least one PDF behind it.
- The 422 when nothing can be generated now says which of the two cases happened, and carries the skip reasons. Before, a selection whose templates were all blocked reported that no templates were selected.
- The data directory check that keeps a stored path from escaping now lives in one place, shared by the single download and the zip.

## Contract

- Added the 500 to the batch download for a batch with no PDFs to bundle.
- `download_url` now says it appears once the batch finishes with at least one PDF, not simply once it finishes.

Closes #554
